### PR TITLE
docs: add Chrome 116+ version requirement to Installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ The extension is built natively on Manifest V3 using **TypeScript and Vite 5** f
 **🚨 IMPORTANT DISTINCTION 🚨**  
 * **For Regular Users:** You only need the compiled `dist/` folder. This is the actual, ready-to-use extension.  
 * **For Developers:** The `src/` folder contains the raw TypeScript/source code. You must compile it first using the steps below.
-
+> ⚠️ **Prerequisites:** Google Chrome version **116 or higher** is required.  
+> This extension uses `chrome.tabCapture`, Offscreen Documents API, and Manifest V3 — all of which require Chrome 116+. Users on older versions may experience silent failures.
 1. **Clone the repository:**
    ```bash
    git clone https://github.com/shouri123/Late-Meet.git

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The extension is built natively on Manifest V3 using **TypeScript and Vite 5** f
 * **For Developers:** The `src/` folder contains the raw TypeScript/source code. You must compile it first using the steps below.
 > ⚠️ **Prerequisites:** Google Chrome version **116 or higher** is required.  
 > ⚠️ **Prerequisites:** Google Chrome version **116 or higher** is required.  
+> ⚠️ **Prerequisites:** Google Chrome version **116 or higher** is required.  
 > This extension is tested and supported on Chrome 116+. The underlying APIs (`chrome.tabCapture`, Offscreen Documents, Manifest V3) have lower individual minimums, but this project standardizes on Chrome 116+.
 1. **Clone the repository:**
    ```bash

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The extension is built natively on Manifest V3 using **TypeScript and Vite 5** f
 * **For Regular Users:** You only need the compiled `dist/` folder. This is the actual, ready-to-use extension.  
 * **For Developers:** The `src/` folder contains the raw TypeScript/source code. You must compile it first using the steps below.
 > ⚠️ **Prerequisites:** Google Chrome version **116 or higher** is required.  
-> This extension uses `chrome.tabCapture`, Offscreen Documents API, and Manifest V3 — all of which require Chrome 116+. Users on older versions may experience silent failures.
+> ⚠️ **Prerequisites:** Google Chrome version **116 or higher** is required.  
+> This extension is tested and supported on Chrome 116+. The underlying APIs (`chrome.tabCapture`, Offscreen Documents, Manifest V3) have lower individual minimums, but this project standardizes on Chrome 116+.
 1. **Clone the repository:**
    ```bash
    git clone https://github.com/shouri123/Late-Meet.git


### PR DESCRIPTION
Fixes #9
     
     Added a prerequisites note in the Installation & Setup section 
     mentioning that Chrome 116+ is required for chrome.tabCapture, 
     Offscreen Documents API, and Manifest V3 to work properly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation section with a new prerequisites notice clarifying that Google Chrome version 116+ is required. Extension features may fail silently on older Chrome versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/13)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->