### PR TITLE
fix: ignore Meet tile controls in participant detection

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1,3 +1,5 @@
+import { collectParticipantNames, type ParticipantNameCandidate } from './participantDetection';
+
 (() => {
   const COPILOT_PREFIX = '[LateMeet]';
 
@@ -21,7 +23,7 @@
     participantNodes: [
       '[data-participant-id] [data-self-name]',
       '[data-participant-id] [role="heading"]',
-      '[data-participant-id] [aria-label]',
+      '[data-participant-id][aria-label^="Participant:"]',
       '[data-self-name]', // The tile for the local user
       'div[jsname="NfX98"]', // Common class for names on video tiles
       '[aria-label^="Participant:"]' // Tile aria-labels
@@ -29,8 +31,6 @@
     showEveryoneBtn: '[aria-label*="Show everyone"]'
   };
   
-  const MAX_PARTICIPANT_NAME_LEN = 120;
-
   function queryFirst(selectors: string[], root: Document | HTMLElement = document): HTMLElement | null {
     for (const selector of selectors) {
       const el = root.querySelector(selector);
@@ -167,29 +167,26 @@
   }
 
   function collectParticipants(): string[] {
-    const names = new Set(['You']);
+    const candidates: ParticipantNameCandidate[] = [];
 
     for (const selector of SELECTORS.participantNodes) {
       document.querySelectorAll(selector).forEach(node => {
-        const label = node.getAttribute('aria-label');
-        const cleanLabel = label ? label.replace(/^Participant:\s*/, '') : null;
-        const text = (cleanLabel || getTextValue(node as HTMLElement)).trim();
-        
-        if (text && text.length < MAX_PARTICIPANT_NAME_LEN && !text.includes('…')) {
-          if (!['Meeting host', 'You', 'Presentation', 'Muted', 'Audio on'].includes(text)) {
-            names.add(text);
-          }
-        }
+        const element = node as HTMLElement;
+        candidates.push({
+          ariaLabel: element.getAttribute('aria-label'),
+          selfName: element.getAttribute('data-self-name'),
+          text: getTextValue(element)
+        });
       });
     }
 
     const selfNode = document.querySelector('[data-self-name]');
     if (selfNode) {
       const selfName = selfNode.getAttribute('data-self-name');
-      if (selfName) names.add(selfName);
+      if (selfName) candidates.push({ selfName });
     }
 
-    return [...names].filter(n => n.length > 0);
+    return collectParticipantNames(candidates);
   }
 
   let participantPollTimer: number | NodeJS.Timeout | null = null;

--- a/src/participantDetection.test.ts
+++ b/src/participantDetection.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { collectParticipantNames, participantNameFromCandidate } from './participantDetection.ts';
+
+test('participant aria labels are converted into participant names', () => {
+  assert.equal(
+    participantNameFromCandidate({ ariaLabel: 'Participant: Ada Lovelace' }),
+    'Ada Lovelace'
+  );
+  assert.equal(
+    participantNameFromCandidate({
+      ariaLabel: 'Participant: Ada Lovelace',
+      text: 'Mute More options Pin'
+    }),
+    'Ada Lovelace'
+  );
+});
+
+test('tile control aria labels are not treated as participant names', () => {
+  assert.equal(participantNameFromCandidate({ ariaLabel: 'Mute' }), null);
+  assert.equal(participantNameFromCandidate({ ariaLabel: 'More options' }), null);
+  assert.equal(participantNameFromCandidate({ ariaLabel: 'Camera off' }), null);
+  assert.equal(participantNameFromCandidate({ ariaLabel: 'Pin' }), null);
+});
+
+test('participant collection ignores duplicate and control candidates', () => {
+  assert.deepEqual(
+    collectParticipantNames([
+      { ariaLabel: 'Participant: You' },
+      { text: 'Grace Hopper' },
+      { ariaLabel: 'Mute' },
+      { ariaLabel: 'More options' },
+      { ariaLabel: 'Participant: Grace Hopper' },
+      { selfName: 'Katherine Johnson' }
+    ]),
+    ['Grace Hopper', 'Katherine Johnson']
+  );
+});
+
+test('participant collection uses You only as a fallback', () => {
+  assert.deepEqual(
+    collectParticipantNames([{ selfName: 'Ada Lovelace' }]),
+    ['Ada Lovelace']
+  );
+  assert.deepEqual(collectParticipantNames([]), ['You']);
+});

--- a/src/participantDetection.ts
+++ b/src/participantDetection.ts
@@ -1,0 +1,60 @@
+export const MAX_PARTICIPANT_NAME_LEN = 120;
+
+const EXCLUDED_PARTICIPANT_LABELS = new Set([
+  'Audio on',
+  'Camera off',
+  'Camera on',
+  'Meeting host',
+  'More options',
+  'Mute',
+  'Muted',
+  'Pin',
+  'Presentation',
+  'Unmute',
+  'Unpin',
+  'You'
+]);
+
+export interface ParticipantNameCandidate {
+  ariaLabel?: string | null;
+  selfName?: string | null;
+  text?: string | null;
+}
+
+function cleanText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+export function participantNameFromCandidate(candidate: ParticipantNameCandidate): string | null {
+  const selfName = cleanText(candidate.selfName || '');
+  const text = cleanText(candidate.text || '');
+  const ariaLabel = cleanText(candidate.ariaLabel || '');
+
+  const participantAriaName = ariaLabel.startsWith('Participant:')
+    ? ariaLabel.replace(/^Participant:\s*/, '')
+    : '';
+  const rawName = selfName || participantAriaName || text;
+  const name = cleanText(rawName);
+
+  if (!name || name.length >= MAX_PARTICIPANT_NAME_LEN || name.includes('…')) {
+    return null;
+  }
+
+  if (EXCLUDED_PARTICIPANT_LABELS.has(name)) {
+    return null;
+  }
+
+  return name;
+}
+
+export function collectParticipantNames(candidates: ParticipantNameCandidate[]): string[] {
+  const names = new Set<string>();
+
+  for (const candidate of candidates) {
+    const name = participantNameFromCandidate(candidate);
+    if (name) names.add(name);
+  }
+
+  const participantNames = [...names].filter(name => name.length > 0);
+  return participantNames.length > 0 ? participantNames : ['You'];
+}


### PR DESCRIPTION
 ## Description

  Fixes #12

  This PR fixes the phantom participant count issue in Google Meet. The participant scanner was picking up nested
  tile controls like Mute, Camera off, Pin, and More options because the selector was too broad. I tightened the
  selector and added a small participant-name filter so only real participant names are counted.

  I also added regression tests for the reported control labels to prevent this from coming back.

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update
  - [ ] 🎨 UI/UX improvement
  - [ ] ♻️ Code refactoring (no functional changes)
  - [x] 🧪 Tests

  ## How Has This Been Tested?

  - [x] Built the extension with npm run build
  - [ ] Loaded the extension in Chrome and tested manually
  - [ ] Tested on a live Google Meet call
  - [ ] Verified no console errors
  - [ ] Tested with ElevenLabs API key
  - [ ] Tested with OpenAI API key

  Additional test run:

  - node --test src/*.test.ts

  ## Screenshots (if applicable)

  No UI changes.

  ## Checklist

  - [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
  - [x] I have performed a self-review of my code
  - [x] I have commented my code where necessary
  - [x] My changes generate no new warnings or errors
  - [ ] I have updated the documentation if needed

  Documentation was not updated because this is an internal bug fix with no user-facing behavior or setup
  changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of participant name detection by filtering out UI control labels that were incorrectly appearing as participant names.
  * Enhanced deduplication and handling of edge cases in participant name normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/14)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->