### PR TITLE
fix: remove broken requestData block causing TS18047 null error

### DIFF
--- a/src/audioProcessing.ts
+++ b/src/audioProcessing.ts
@@ -35,8 +35,5 @@ export function audioFileExtensionForMimeType(mimeType: string) {
 }
 
 export function isChunkViable(blob: Blob, minBytes = 15000): boolean {
-  if (!blob || blob.size < minBytes) {
-    return false;
-  }
-  return true;
+  return !!blob && blob.size >= minBytes;
 }

--- a/src/audioProcessing.ts
+++ b/src/audioProcessing.ts
@@ -37,3 +37,4 @@ export function audioFileExtensionForMimeType(mimeType: string) {
 export function isChunkViable(blob: Blob, minBytes = 15000): boolean {
   return !!blob && blob.size >= minBytes;
 }
+

--- a/src/audioProcessing.ts
+++ b/src/audioProcessing.ts
@@ -37,4 +37,3 @@ export function audioFileExtensionForMimeType(mimeType: string) {
 export function isChunkViable(blob: Blob, minBytes = 15000): boolean {
   return !!blob && blob.size >= minBytes;
 }
-

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -96,6 +96,12 @@ async function flushAudioChunk() {
     }
 
     await drainPendingChunks();
+
+  try {
+      mediaRecorder.requestData();
+    } catch (err) {
+      console.error('[LateMeet][offscreen] requestData failed:', err);
+    }
   } finally {
     isFlushInProgress = false;
   }

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -194,7 +194,9 @@ async function startCapture(streamId: string, _tabId: number, includeMicrophone 
   if (mediaRecorder && mediaRecorder.state === 'recording') {
     console.log(
       '[LateMeet][offscreen] Capture already running. Mic active:',
-      Boolean(microphoneStream)
+      Boolean(microphoneStream),
+      '| MIME:',
+      mediaRecorder.mimeType || 'default'
     );
     return {
       microphoneActive: Boolean(microphoneStream)

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -105,8 +105,9 @@ async function postChunk(blob: Blob) {
   console.log('[LateMeet][offscreen] postChunk called, blob size:', blob?.size || 0);
   if (!isChunkViable(blob)) { console.warn('[LateMeet][offscreen] Chunk too small, skipping:', blob?.size ?? 0, 'bytes'); return; }
 
-  const audioBase64 = await blobToBase64(blob);
-  const mimeType = mediaRecorder?.mimeType || 'audio/webm';
+  const currentRecorder = mediaRecorder;
+const audioBase64 = await blobToBase64(blob);
+const mimeType = currentRecorder?.mimeType || 'audio/webm';
 
   if (!mimeType) {
   console.warn('[LateMeet][offscreen] Missing MIME type');

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -94,7 +94,6 @@ async function flushAudioChunk() {
     if (!voiceActivity.consumeShouldFlush()) {
       return;
     }
-
     await drainPendingChunks();
 
   try {
@@ -200,9 +199,7 @@ async function startCapture(streamId: string, _tabId: number, includeMicrophone 
   if (mediaRecorder && mediaRecorder.state === 'recording') {
     console.log(
       '[LateMeet][offscreen] Capture already running. Mic active:',
-      Boolean(microphoneStream),
-      '| MIME:',
-      mediaRecorder.mimeType || 'default'
+      Boolean(microphoneStream)
     );
     return {
       microphoneActive: Boolean(microphoneStream)


### PR DESCRIPTION
fixed error TS18047: 'mediaRecorder' is possibly 'null' error.

Please add appropriate labels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio chunk flushing and processing pipeline efficiency
  * Enhanced media recorder reference handling during chunk operations

* **Refactor**
  * Simplified audio chunk viability validation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->