### PR TITLE
Improve API credential security using session storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "late-meet",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "late-meet",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.45.0",
@@ -1217,7 +1217,6 @@
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1257,7 +1256,6 @@
       "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -1469,7 +1467,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2008,7 +2005,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3751,7 +3747,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3817,7 +3812,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/background.ts
+++ b/src/background.ts
@@ -197,7 +197,7 @@ function getTranscriptionPrompt() {
 async function transcribeChunk(base64Audio: string, mimeType = "audio/webm", prompt = "") {
   // Use ElevenLabs API key if available, fallback to OpenAI if not?
   // No, the requirement is to use ElevenLabs.
-  const elevenlabsKey = await chrome.storage.local
+  const elevenlabsKey = await chrome.storage.session
     .get("elevenlabs_api_key")
     .then((r) => r.elevenlabs_api_key);
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -136,7 +136,7 @@ async function broadcastStateUpdate() {
 }
 
 async function getApiKey() {
-  const result = await chrome.storage.local.get("openai_api_key");
+  const result = await chrome.storage.session.get("openai_api_key");
   return result.openai_api_key || null;
 }
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -10,7 +10,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let lastState: State | null = null;
 
   // ——— Check if API key is configured ———
-  const config = await chrome.storage.local.get(["openai_api_key", "elevenlabs_api_key"]);
+  const config = await chrome.storage.session.get(["openai_api_key", "elevenlabs_api_key"]);
 
   if (!config.openai_api_key && !config.elevenlabs_api_key) {
     setupView.style.display = "block";
@@ -32,7 +32,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // Since the popup only has one input currently, we'll save it as openai_api_key
     // Users can configure ElevenLabs in the options page.
-    await chrome.storage.local.set({ openai_api_key: apiKey });
+    await chrome.storage.session.set({ openai_api_key: apiKey });
 
     setupView.style.display = "none";
     mainView.style.display = "block";

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -9,7 +9,7 @@ const OPENAI_WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
  * Get the stored OpenAI API key
  */
 export async function getApiKey() {
-  const result = await chrome.storage.local.get("openai_api_key");
+  const result = await chrome.storage.session.get("openai_api_key");
   return result.openai_api_key || null;
 }
 


### PR DESCRIPTION
The PR improves the security of API credentials storage by migrating sensitive keys from chrome.storage.local tp chrome.storage.session.

Changes Made: 
1. Updated storage logic for:
    openai_api_key
    elevenlabs_api_key
2 Modified retrieval and save operations in:
    popup.ts
    background.ts
    api.js
3. Retained chrome.storage.local for non-sensitive persistent data such as:
    session history
    settings
    pending session

Security Improvement :
Using chrome.storage.session ensures that API credentials remain only in memory during the active browser session and are automatically cleared once the browser is fully closed.

Testing :
Verified API keys are stored in chrome.storage.session
Confirmed keys are not stored in chrome.storage.local
Tested extension functionality after migration
Confirmed session-only behavior after browser termination


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the storage mechanism for API keys throughout the extension to use browser session storage instead of persistent local storage. As a result, API keys will no longer be retained between browser sessions and must be re-entered after each browser restart.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->