### PR TITLE
Fix MediaRecorder cleanup when captured tab closes unexpectedly

### DIFF
--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -17,31 +17,39 @@ let isDrainingQueue = false;
 const CHUNK_MS = 10000;
 const VAD_SAMPLE_MS = 250;
 const RMS_THRESHOLD = 0.012;
+
 let isFlushInProgress = false;
-let voiceActivity = new VoiceActivityTracker({ rmsThreshold: RMS_THRESHOLD });
+let voiceActivity = new VoiceActivityTracker({
+  rmsThreshold: RMS_THRESHOLD,
+});
 
 function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
+
     const cleanup = () => {
       reader.onloadend = null;
       reader.onerror = null;
       reader.onabort = null;
     };
+
     reader.onloadend = () => {
       cleanup();
       const result = reader.result as string;
       const base64String = result.split(",")[1];
       resolve(base64String);
     };
+
     reader.onerror = () => {
       cleanup();
       reject(reader.error ?? new Error("FileReader failed to read blob"));
     };
+
     reader.onabort = () => {
       cleanup();
       reject(new Error("FileReader read was aborted"));
     };
+
     reader.readAsDataURL(blob);
   });
 }
@@ -55,7 +63,9 @@ function pickSupportedMimeType(): string {
     "audio/mp4",
   ];
 
-  const supported = candidates.find((type) => MediaRecorder.isTypeSupported(type));
+  const supported = candidates.find((type) =>
+    MediaRecorder.isTypeSupported(type),
+  );
 
   console.log("[LateMeet][offscreen] Selected MIME type:", supported);
 
@@ -69,6 +79,7 @@ function getCurrentRms(): number {
   analyserNode.getByteTimeDomainData(buffer);
 
   let sumSquares = 0;
+
   for (let i = 0; i < buffer.length; i += 1) {
     const normalized = (buffer[i] - 128) / 128;
     sumSquares += normalized * normalized;
@@ -78,7 +89,11 @@ function getCurrentRms(): number {
 }
 
 async function flushAudioChunk() {
-  if (isFlushInProgress || !mediaRecorder || mediaRecorder.state !== "recording") {
+  if (
+    isFlushInProgress ||
+    !mediaRecorder ||
+    mediaRecorder.state !== "recording"
+  ) {
     return;
   }
 
@@ -88,6 +103,7 @@ async function flushAudioChunk() {
     if (!voiceActivity.consumeShouldFlush()) {
       return;
     }
+
     await drainPendingChunks();
 
     try {
@@ -101,9 +117,17 @@ async function flushAudioChunk() {
 }
 
 async function postChunk(blob: Blob) {
-  console.log("[LateMeet][offscreen] postChunk called, blob size:", blob?.size || 0);
+  console.log(
+    "[LateMeet][offscreen] postChunk called, blob size:",
+    blob?.size || 0,
+  );
+
   if (!isChunkViable(blob)) {
-    console.warn("[LateMeet][offscreen] Chunk too small, skipping:", blob?.size ?? 0, "bytes");
+    console.warn(
+      "[LateMeet][offscreen] Chunk too small, skipping:",
+      blob?.size ?? 0,
+      "bytes",
+    );
     return;
   }
 
@@ -134,10 +158,13 @@ async function postChunk(blob: Blob) {
 
 async function drainPendingChunks() {
   if (isDrainingQueue) return;
+
   isDrainingQueue = true;
+
   try {
     while (pendingChunks.length > 0) {
       const blob = pendingChunks.shift();
+
       if (blob) {
         await postChunk(blob);
       }
@@ -151,10 +178,35 @@ function stopTracks(stream: MediaStream | null) {
   stream?.getTracks().forEach((track) => track.stop());
 }
 
+async function cleanupResources() {
+  stopTracks(mediaStream);
+  stopTracks(microphoneStream);
+  stopTracks(recorderStream);
+
+  mediaStream = null;
+  microphoneStream = null;
+  recorderStream = null;
+
+  if (audioContext) {
+    await audioContext.close();
+    audioContext = null;
+  }
+
+  mediaRecorder = null;
+  analyserNode = null;
+  audioSources = [];
+  pendingChunks = [];
+  isStopping = false;
+
+  voiceActivity = new VoiceActivityTracker({
+    rmsThreshold: RMS_THRESHOLD,
+  });
+}
+
 async function getTabAudioStream(streamId: string) {
   return navigator.mediaDevices.getUserMedia({
     audio: {
-      // @ts-ignore - chromeMediaSource is non-standard
+      // @ts-ignore
       mandatory: {
         chromeMediaSource: "tab",
         chromeMediaSourceId: streamId,
@@ -176,9 +228,10 @@ async function getMicrophoneStream() {
     });
   } catch (err) {
     console.warn(
-      "[LateMeet][offscreen] Microphone capture unavailable; recording tab audio only:",
+      "[LateMeet][offscreen] Microphone capture unavailable:",
       err,
     );
+
     return null;
   }
 }
@@ -190,19 +243,24 @@ function connectSourceToRecorder(
   if (!audioContext || !analyserNode) return;
 
   const source = audioContext.createMediaStreamSource(stream);
+
   source.connect(destination);
   source.connect(analyserNode);
+
   audioSources.push(source);
 }
 
-async function startCapture(streamId: string, _tabId: number, includeMicrophone = true) {
-  if (mediaRecorder && mediaRecorder.state === "recording") {
-    console.log(
-      "[LateMeet][offscreen] Capture already running. Mic active:",
-      Boolean(microphoneStream),
-      "| MIME:",
-      mediaRecorder.mimeType || "default",
-    );
+async function startCapture(
+  streamId: string,
+  _tabId: number,
+  includeMicrophone = true,
+) {
+  if (
+    mediaRecorder &&
+    mediaRecorder.state === "recording"
+  ) {
+    console.log("[LateMeet][offscreen] Capture already running");
+
     return {
       microphoneActive: Boolean(microphoneStream),
     };
@@ -214,43 +272,91 @@ async function startCapture(streamId: string, _tabId: number, includeMicrophone 
     throw new Error("Failed to capture tab audio stream");
   }
 
+  mediaStream.getTracks().forEach((track) => {
+    track.onended = async () => {
+      console.warn(
+        "[LateMeet][offscreen] Media track ended unexpectedly",
+      );
+
+      if (isStopping) return;
+
+      try {
+        await stopCapture();
+      } catch (err) {
+        console.error(
+          "[LateMeet][offscreen] Cleanup after track end failed:",
+          err,
+        );
+      }
+    };
+  });
+
   audioContext = new AudioContext();
-  const destination = audioContext.createMediaStreamDestination();
+
+  const destination =
+    audioContext.createMediaStreamDestination();
+
   analyserNode = audioContext.createAnalyser();
   analyserNode.fftSize = 1024;
 
-  const tabSource = audioContext.createMediaStreamSource(mediaStream);
+  const tabSource =
+    audioContext.createMediaStreamSource(mediaStream);
+
   tabSource.connect(destination);
   tabSource.connect(analyserNode);
   tabSource.connect(audioContext.destination);
+
   audioSources.push(tabSource);
 
   if (includeMicrophone) {
     microphoneStream = await getMicrophoneStream();
+
     if (microphoneStream) {
-      connectSourceToRecorder(microphoneStream, destination);
+      connectSourceToRecorder(
+        microphoneStream,
+        destination,
+      );
     }
   }
 
   recorderStream = destination.stream;
 
   const mimeType = pickSupportedMimeType();
+
   mediaRecorder = mimeType
     ? new MediaRecorder(recorderStream, { mimeType })
     : new MediaRecorder(recorderStream);
 
-  mediaRecorder.addEventListener("dataavailable", (event: BlobEvent) => {
-    console.log("[LateMeet][offscreen] Chunk received:", {
-      type: event.data?.type,
-      size: event.data?.size,
-    });
-    if (event.data && event.data.size > 0) {
-      pendingChunks.push(event.data);
+  mediaRecorder.addEventListener(
+    "dataavailable",
+    (event: BlobEvent) => {
+      console.log("[LateMeet][offscreen] Chunk received:", {
+        type: event.data?.type,
+        size: event.data?.size,
+      });
+
+      if (event.data && event.data.size > 0) {
+        pendingChunks.push(event.data);
+      }
+    },
+  );
+
+  mediaRecorder.addEventListener("error", async (err) => {
+    console.error(
+      "[LateMeet][offscreen] Recorder error:",
+      err,
+    );
+
+    if (!isStopping) {
+      await stopCapture();
     }
   });
 
   mediaRecorder.start(CHUNK_MS);
-  voiceActivity = new VoiceActivityTracker({ rmsThreshold: RMS_THRESHOLD });
+
+  voiceActivity = new VoiceActivityTracker({
+    rmsThreshold: RMS_THRESHOLD,
+  });
 
   vadTimer = setInterval(() => {
     voiceActivity.observe(getCurrentRms());
@@ -259,100 +365,129 @@ async function startCapture(streamId: string, _tabId: number, includeMicrophone 
   chunkTimer = setInterval(async () => {
     try {
       if (isStopping) return;
+
       await flushAudioChunk();
       await drainPendingChunks();
     } catch (err) {
-      console.error("[LateMeet][offscreen] Chunk pipeline error:", err);
+      console.error(
+        "[LateMeet][offscreen] Chunk pipeline error:",
+        err,
+      );
     }
   }, CHUNK_MS);
 
-  console.log(
-    "[LateMeet][offscreen] Capture started. Mic active:",
-    Boolean(microphoneStream),
-    "| MIME:",
-    mimeType || "default",
-  );
-  return { microphoneActive: Boolean(microphoneStream) };
+  console.log("[LateMeet][offscreen] Capture started");
+
+  return {
+    microphoneActive: Boolean(microphoneStream),
+  };
 }
 
 async function stopCapture() {
   if (chunkTimer) {
-    clearInterval(chunkTimer as any);
+    clearInterval(chunkTimer);
     chunkTimer = null;
   }
+
   if (vadTimer) {
-    clearInterval(vadTimer as any);
+    clearInterval(vadTimer);
     vadTimer = null;
   }
+
   isStopping = true;
 
-  if (mediaRecorder && mediaRecorder.state === "recording") {
+  if (
+    mediaRecorder &&
+    mediaRecorder.state !== "inactive"
+  ) {
     const recorder = mediaRecorder;
+
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(resolve, 2000);
-      recorder.addEventListener("stop", () => resolve(), { once: true });
-      recorder.addEventListener("error", () => resolve(), { once: true });
+
+      recorder.addEventListener(
+        "stop",
+        () => resolve(),
+        { once: true },
+      );
+
+      recorder.addEventListener(
+        "error",
+        () => resolve(),
+        { once: true },
+      );
+
       recorder.stop();
-      recorder.addEventListener("stop", () => clearTimeout(timeout), { once: true });
+
+      recorder.addEventListener(
+        "stop",
+        () => clearTimeout(timeout),
+        { once: true },
+      );
     });
   }
 
   await drainPendingChunks();
 
-  stopTracks(mediaStream);
-  stopTracks(microphoneStream);
-  stopTracks(recorderStream);
-  mediaStream = null;
-  microphoneStream = null;
-  recorderStream = null;
-
-  if (audioContext) {
-    await audioContext.close();
-    audioContext = null;
-  }
-
-  mediaRecorder = null;
-  analyserNode = null;
-  audioSources = [];
-  pendingChunks = [];
-  isStopping = false;
-  voiceActivity = new VoiceActivityTracker({ rmsThreshold: RMS_THRESHOLD });
+  await cleanupResources();
 }
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
-  // Only handle messages intended for the offscreen document
-  if (!message?.type?.startsWith("OFFSCREEN_")) {
-    return false; // Not for us — let other listeners handle it
-  }
-
-  (async () => {
-    if (message.type === "OFFSCREEN_START_CAPTURE") {
-      try {
-        const captureInfo = await startCapture(
-          message.streamId,
-          message.tabId,
-          message.includeMicrophone !== false,
-        );
-        sendResponse({ success: true, ...captureInfo });
-      } catch (err) {
-        console.error("[LateMeet][offscreen] Failed to start capture:", (err as Error).message);
-        sendResponse({ success: false, error: (err as Error).message || "Start capture failed" });
-      }
-      return;
+chrome.runtime.onMessage.addListener(
+  (message, _sender, sendResponse) => {
+    if (!message?.type?.startsWith("OFFSCREEN_")) {
+      return false;
     }
 
-    if (message.type === "OFFSCREEN_STOP_CAPTURE") {
-      try {
-        await stopCapture();
-      } finally {
-        await chrome.runtime.sendMessage({ type: "OFFSCREEN_CAPTURE_STOPPED" });
+    (async () => {
+      if (message.type === "OFFSCREEN_START_CAPTURE") {
+        try {
+          const captureInfo = await startCapture(
+            message.streamId,
+            message.tabId,
+            message.includeMicrophone !== false,
+          );
+
+          sendResponse({
+            success: true,
+            ...captureInfo,
+          });
+        } catch (err) {
+          console.error(
+            "[LateMeet][offscreen] Failed to start capture:",
+            (err as Error).message,
+          );
+
+          sendResponse({
+            success: false,
+            error:
+              (err as Error).message ||
+              "Start capture failed",
+          });
+        }
+
+        return;
       }
-      sendResponse({ success: true });
-      return;
-    }
 
-    sendResponse({ success: false, error: "Unknown offscreen message type" });
-  })();
+      if (message.type === "OFFSCREEN_STOP_CAPTURE") {
+        try {
+          await stopCapture();
+        } finally {
+          await chrome.runtime.sendMessage({
+            type: "OFFSCREEN_CAPTURE_STOPPED",
+          });
+        }
 
-  return true;
-});
+        sendResponse({ success: true });
+
+        return;
+      }
+
+      sendResponse({
+        success: false,
+        error: "Unknown offscreen message type",
+      });
+    })();
+
+    return true;
+  },
+);

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -191,6 +191,10 @@ async function cleanupResources() {
     try {
       await audioContext.close();
     } catch (err) {
+  if (audioContext) {
+    try {
+      await audioContext.close();
+    } catch (err) {
       console.warn("[LateMeet][offscreen] AudioContext close failed:", err);
     }
     audioContext = null;

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -191,12 +191,12 @@ async function cleanupResources() {
     try {
       await audioContext.close();
     } catch (err) {
-  if (audioContext) {
-    try {
-      await audioContext.close();
-    } catch (err) {
-      console.warn("[LateMeet][offscreen] AudioContext close failed:", err);
+      console.warn(
+        "[LateMeet][offscreen] AudioContext close failed:",
+        err,
+      );
     }
+
     audioContext = null;
   }
 
@@ -210,7 +210,6 @@ async function cleanupResources() {
     rmsThreshold: RMS_THRESHOLD,
   });
 }
-
 async function getTabAudioStream(streamId: string) {
   return navigator.mediaDevices.getUserMedia({
     audio: {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -188,7 +188,11 @@ async function cleanupResources() {
   recorderStream = null;
 
   if (audioContext) {
-    await audioContext.close();
+    try {
+      await audioContext.close();
+    } catch (err) {
+      console.warn("[LateMeet][offscreen] AudioContext close failed:", err);
+    }
     audioContext = null;
   }
 

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -392,53 +392,77 @@ async function startCapture(
 }
 
 async function stopCapture() {
-  if (chunkTimer) {
-    clearInterval(chunkTimer);
-    chunkTimer = null;
-  }
-
-  if (vadTimer) {
-    clearInterval(vadTimer);
-    vadTimer = null;
+  // Prevent concurrent cleanup execution
+  if (isStopping) {
+    return;
   }
 
   isStopping = true;
 
-  if (
-    mediaRecorder &&
-    mediaRecorder.state !== "inactive"
-  ) {
-    const recorder = mediaRecorder;
+  try {
+    if (chunkTimer) {
+      clearInterval(chunkTimer);
+      chunkTimer = null;
+    }
 
-    await new Promise<void>((resolve) => {
-      const timeout = setTimeout(resolve, 2000);
+    if (vadTimer) {
+      clearInterval(vadTimer);
+      vadTimer = null;
+    }
 
-      recorder.addEventListener(
-        "stop",
-        () => resolve(),
-        { once: true },
-      );
+    if (
+      mediaRecorder &&
+      mediaRecorder.state !== "inactive"
+    ) {
+      const recorder = mediaRecorder;
 
-      recorder.addEventListener(
-        "error",
-        () => resolve(),
-        { once: true },
-      );
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(resolve, 2000);
 
-      recorder.stop();
+        recorder.addEventListener(
+          "stop",
+          () => resolve(),
+          { once: true },
+        );
 
-      recorder.addEventListener(
-        "stop",
-        () => clearTimeout(timeout),
-        { once: true },
-      );
-    });
+        recorder.addEventListener(
+          "error",
+          () => resolve(),
+          { once: true },
+        );
+
+        try {
+          recorder.stop();
+        } catch (err) {
+          console.warn(
+            "[LateMeet][offscreen] Recorder stop failed:",
+            err,
+          );
+          resolve();
+        }
+
+        recorder.addEventListener(
+          "stop",
+          () => clearTimeout(timeout),
+          { once: true },
+        );
+      });
+    }
+
+    await drainPendingChunks();
+
+    await cleanupResources();
+  } catch (err) {
+    console.error(
+      "[LateMeet][offscreen] stopCapture failed:",
+      err,
+    );
+
+    await cleanupResources();
   }
-
-  await drainPendingChunks();
-
-  await cleanupResources();
 }
+
+
 
 chrome.runtime.onMessage.addListener(
   (message, _sender, sendResponse) => {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -63,9 +63,7 @@ function pickSupportedMimeType(): string {
     "audio/mp4",
   ];
 
-  const supported = candidates.find((type) =>
-    MediaRecorder.isTypeSupported(type),
-  );
+  const supported = candidates.find((type) => MediaRecorder.isTypeSupported(type));
 
   console.log("[LateMeet][offscreen] Selected MIME type:", supported);
 
@@ -89,11 +87,7 @@ function getCurrentRms(): number {
 }
 
 async function flushAudioChunk() {
-  if (
-    isFlushInProgress ||
-    !mediaRecorder ||
-    mediaRecorder.state !== "recording"
-  ) {
+  if (isFlushInProgress || !mediaRecorder || mediaRecorder.state !== "recording") {
     return;
   }
 
@@ -117,17 +111,10 @@ async function flushAudioChunk() {
 }
 
 async function postChunk(blob: Blob) {
-  console.log(
-    "[LateMeet][offscreen] postChunk called, blob size:",
-    blob?.size || 0,
-  );
+  console.log("[LateMeet][offscreen] postChunk called, blob size:", blob?.size || 0);
 
   if (!isChunkViable(blob)) {
-    console.warn(
-      "[LateMeet][offscreen] Chunk too small, skipping:",
-      blob?.size ?? 0,
-      "bytes",
-    );
+    console.warn("[LateMeet][offscreen] Chunk too small, skipping:", blob?.size ?? 0, "bytes");
     return;
   }
 
@@ -191,10 +178,7 @@ async function cleanupResources() {
     try {
       await audioContext.close();
     } catch (err) {
-      console.warn(
-        "[LateMeet][offscreen] AudioContext close failed:",
-        err,
-      );
+      console.warn("[LateMeet][offscreen] AudioContext close failed:", err);
     }
 
     audioContext = null;
@@ -234,10 +218,7 @@ async function getMicrophoneStream() {
       video: false,
     });
   } catch (err) {
-    console.warn(
-      "[LateMeet][offscreen] Microphone capture unavailable:",
-      err,
-    );
+    console.warn("[LateMeet][offscreen] Microphone capture unavailable:", err);
 
     return null;
   }
@@ -257,15 +238,8 @@ function connectSourceToRecorder(
   audioSources.push(source);
 }
 
-async function startCapture(
-  streamId: string,
-  _tabId: number,
-  includeMicrophone = true,
-) {
-  if (
-    mediaRecorder &&
-    mediaRecorder.state === "recording"
-  ) {
+async function startCapture(streamId: string, _tabId: number, includeMicrophone = true) {
+  if (mediaRecorder && mediaRecorder.state === "recording") {
     console.log("[LateMeet][offscreen] Capture already running");
 
     return {
@@ -281,33 +255,26 @@ async function startCapture(
 
   mediaStream.getTracks().forEach((track) => {
     track.onended = async () => {
-      console.warn(
-        "[LateMeet][offscreen] Media track ended unexpectedly",
-      );
+      console.warn("[LateMeet][offscreen] Media track ended unexpectedly");
 
       if (isStopping) return;
 
       try {
         await stopCapture();
       } catch (err) {
-        console.error(
-          "[LateMeet][offscreen] Cleanup after track end failed:",
-          err,
-        );
+        console.error("[LateMeet][offscreen] Cleanup after track end failed:", err);
       }
     };
   });
 
   audioContext = new AudioContext();
 
-  const destination =
-    audioContext.createMediaStreamDestination();
+  const destination = audioContext.createMediaStreamDestination();
 
   analyserNode = audioContext.createAnalyser();
   analyserNode.fftSize = 1024;
 
-  const tabSource =
-    audioContext.createMediaStreamSource(mediaStream);
+  const tabSource = audioContext.createMediaStreamSource(mediaStream);
 
   tabSource.connect(destination);
   tabSource.connect(analyserNode);
@@ -319,10 +286,7 @@ async function startCapture(
     microphoneStream = await getMicrophoneStream();
 
     if (microphoneStream) {
-      connectSourceToRecorder(
-        microphoneStream,
-        destination,
-      );
+      connectSourceToRecorder(microphoneStream, destination);
     }
   }
 
@@ -334,25 +298,19 @@ async function startCapture(
     ? new MediaRecorder(recorderStream, { mimeType })
     : new MediaRecorder(recorderStream);
 
-  mediaRecorder.addEventListener(
-    "dataavailable",
-    (event: BlobEvent) => {
-      console.log("[LateMeet][offscreen] Chunk received:", {
-        type: event.data?.type,
-        size: event.data?.size,
-      });
+  mediaRecorder.addEventListener("dataavailable", (event: BlobEvent) => {
+    console.log("[LateMeet][offscreen] Chunk received:", {
+      type: event.data?.type,
+      size: event.data?.size,
+    });
 
-      if (event.data && event.data.size > 0) {
-        pendingChunks.push(event.data);
-      }
-    },
-  );
+    if (event.data && event.data.size > 0) {
+      pendingChunks.push(event.data);
+    }
+  });
 
   mediaRecorder.addEventListener("error", async (err) => {
-    console.error(
-      "[LateMeet][offscreen] Recorder error:",
-      err,
-    );
+    console.error("[LateMeet][offscreen] Recorder error:", err);
 
     if (!isStopping) {
       await stopCapture();
@@ -376,10 +334,7 @@ async function startCapture(
       await flushAudioChunk();
       await drainPendingChunks();
     } catch (err) {
-      console.error(
-        "[LateMeet][offscreen] Chunk pipeline error:",
-        err,
-      );
+      console.error("[LateMeet][offscreen] Chunk pipeline error:", err);
     }
   }, CHUNK_MS);
 
@@ -409,42 +364,24 @@ async function stopCapture() {
       vadTimer = null;
     }
 
-    if (
-      mediaRecorder &&
-      mediaRecorder.state !== "inactive"
-    ) {
+    if (mediaRecorder && mediaRecorder.state !== "inactive") {
       const recorder = mediaRecorder;
 
       await new Promise<void>((resolve) => {
         const timeout = setTimeout(resolve, 2000);
 
-        recorder.addEventListener(
-          "stop",
-          () => resolve(),
-          { once: true },
-        );
+        recorder.addEventListener("stop", () => resolve(), { once: true });
 
-        recorder.addEventListener(
-          "error",
-          () => resolve(),
-          { once: true },
-        );
+        recorder.addEventListener("error", () => resolve(), { once: true });
 
         try {
           recorder.stop();
         } catch (err) {
-          console.warn(
-            "[LateMeet][offscreen] Recorder stop failed:",
-            err,
-          );
+          console.warn("[LateMeet][offscreen] Recorder stop failed:", err);
           resolve();
         }
 
-        recorder.addEventListener(
-          "stop",
-          () => clearTimeout(timeout),
-          { once: true },
-        );
+        recorder.addEventListener("stop", () => clearTimeout(timeout), { once: true });
       });
     }
 
@@ -452,73 +389,61 @@ async function stopCapture() {
 
     await cleanupResources();
   } catch (err) {
-    console.error(
-      "[LateMeet][offscreen] stopCapture failed:",
-      err,
-    );
+    console.error("[LateMeet][offscreen] stopCapture failed:", err);
 
     await cleanupResources();
   }
 }
 
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!message?.type?.startsWith("OFFSCREEN_")) {
+    return false;
+  }
 
+  (async () => {
+    if (message.type === "OFFSCREEN_START_CAPTURE") {
+      try {
+        const captureInfo = await startCapture(
+          message.streamId,
+          message.tabId,
+          message.includeMicrophone !== false,
+        );
 
-chrome.runtime.onMessage.addListener(
-  (message, _sender, sendResponse) => {
-    if (!message?.type?.startsWith("OFFSCREEN_")) {
-      return false;
+        sendResponse({
+          success: true,
+          ...captureInfo,
+        });
+      } catch (err) {
+        console.error("[LateMeet][offscreen] Failed to start capture:", (err as Error).message);
+
+        sendResponse({
+          success: false,
+          error: (err as Error).message || "Start capture failed",
+        });
+      }
+
+      return;
     }
 
-    (async () => {
-      if (message.type === "OFFSCREEN_START_CAPTURE") {
-        try {
-          const captureInfo = await startCapture(
-            message.streamId,
-            message.tabId,
-            message.includeMicrophone !== false,
-          );
-
-          sendResponse({
-            success: true,
-            ...captureInfo,
-          });
-        } catch (err) {
-          console.error(
-            "[LateMeet][offscreen] Failed to start capture:",
-            (err as Error).message,
-          );
-
-          sendResponse({
-            success: false,
-            error:
-              (err as Error).message ||
-              "Start capture failed",
-          });
-        }
-
-        return;
+    if (message.type === "OFFSCREEN_STOP_CAPTURE") {
+      try {
+        await stopCapture();
+      } finally {
+        await chrome.runtime.sendMessage({
+          type: "OFFSCREEN_CAPTURE_STOPPED",
+        });
       }
 
-      if (message.type === "OFFSCREEN_STOP_CAPTURE") {
-        try {
-          await stopCapture();
-        } finally {
-          await chrome.runtime.sendMessage({
-            type: "OFFSCREEN_CAPTURE_STOPPED",
-          });
-        }
+      sendResponse({ success: true });
 
-        sendResponse({ success: true });
+      return;
+    }
 
-        return;
-      }
+    sendResponse({
+      success: false,
+      error: "Unknown offscreen message type",
+    });
+  })();
 
-      sendResponse({
-        success: false,
-        error: "Unknown offscreen message type",
-      });
-    })();
-
-    return true;
-  },
-);
+  return true;
+});


### PR DESCRIPTION


## Description

This PR fixes a recording state synchronization issue that occurred when the captured Google Meet tab was closed abruptly.

### Changes made

* Added centralized cleanup logic for recorder resources
* Added `track.onended` handling for unexpected stream termination
* Improved MediaRecorder shutdown safety checks
* Added recorder error recovery handling
* Prevented stale stream and recorder references after abrupt tab closure

Fixes #46

---

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)

---

## How Has This Been Tested?

* [x] Built the extension with `npm run build`
* [x] Loaded the extension in Chrome and tested manually
* [x] Tested on a live Google Meet call
* [x] Verified no console errors

---

## Screenshots (if applicable)

N/A

---

## Checklist

* [x] I have starred the repository ⭐
* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] My code follows the formatting of this project
* [x] My changes generate no new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More stable offscreen audio capture with centralized resource cleanup and safer shutdown sequencing
  * Better handling of unexpected stream/track disconnections to prevent lingering or stalled capture
  * More reliable chunk flushing and error handling to reduce dropped or delayed audio data
  * Cleaner logging and control flow for more predictable start/stop behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->