### PR TITLE
feat: add dual-channel exporter with dropdown and toast notifications

### DIFF
--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -906,3 +906,84 @@ body::-webkit-scrollbar-thumb {
   line-height: 1.5;
   word-break: break-word;
 }
+
+/* Export wrapper */
+.export-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+/* Export dropdown */
+.export-dropdown {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 6px;
+  min-width: 200px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+}
+
+.export-dropdown[hidden] {
+  display: none;
+}
+
+.export-option {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: #fafafa;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+}
+
+.export-option:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* Toast notification */
+.export-toast {
+  position: fixed;
+  bottom: 64px;
+  left: 50%;
+  transform: translateX(-50%) translateY(20px);
+  background: #1a1a1a;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  padding: 10px 18px;
+  color: #fafafa;
+  font-size: 13px;
+  font-family: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+  z-index: 200;
+  white-space: nowrap;
+}
+
+.export-toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.export-toast.success {
+  border-color: rgba(34, 197, 94, 0.4);
+  color: #86efac;
+}
+
+.export-toast.error {
+  border-color: rgba(239, 68, 68, 0.4);
+  color: #fca5a5;
+}

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -17,6 +17,7 @@
       }
     </style>
   </head>
+
   <body>
     <!-- Header -->
     <header class="dash-header">
@@ -545,26 +546,97 @@
 
     <!-- Footer -->
     <footer class="dash-footer">
-      <button id="export-btn" class="export-btn">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          class="icon"
-          style="margin-right: 6px"
-        >
-          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-          <polyline points="7 10 12 15 17 10"></polyline>
-          <line x1="12" x2="12" y1="15" y2="3"></line>
-        </svg>
-        Export Summary
-      </button>
+      <div class="export-wrapper" id="export-wrapper">
+        <button id="export-btn" class="export-btn" aria-haspopup="true" aria-expanded="false">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="icon"
+            style="margin-right: 6px"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="7 10 12 15 17 10"></polyline>
+            <line x1="12" x2="12" y1="15" y2="3"></line>
+          </svg>
+          Export Summary
+        </button>
+
+        <div class="export-dropdown" id="export-dropdown" role="menu" hidden>
+          <button class="export-option" id="export-md-btn" role="menuitem">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="icon"
+              style="margin-right: 8px"
+            >
+              <path
+                d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"
+              ></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+            </svg>
+            Download .md File
+          </button>
+          <button class="export-option" id="export-json-btn" role="menuitem">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="icon"
+              style="margin-right: 8px"
+            >
+              <path
+                d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"
+              ></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+              <line x1="16" x2="8" y1="13" y2="13"></line>
+            </svg>
+            Download .json Backup
+          </button>
+          <button class="export-option" id="export-clipboard-btn" role="menuitem">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="icon"
+              style="margin-right: 8px"
+            >
+              <rect width="8" height="4" x="8" y="2" rx="1" ry="1"></rect>
+              <path
+                d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"
+              ></path>
+            </svg>
+            Copy to Clipboard
+          </button>
+        </div>
+      </div>
+
+      <div class="export-toast" id="export-toast" role="status" aria-live="polite"></div>
     </footer>
 
     <script type="module" src="dashboard.ts"></script>

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -486,56 +486,122 @@ document.addEventListener("DOMContentLoaded", async () => {
     container.scrollTop = container.scrollHeight;
   }
 
-  // ——— Export ———
-  document.getElementById("export-btn")?.addEventListener("click", async () => {
+  // ——— Export Helpers ———
+  function generateMarkdown(state: State): string {
+    let markdown = `# Meeting Summary\n\n`;
+    markdown += `**Date:** ${new Date().toLocaleDateString()}\n`;
+    markdown += `**Duration:** ${formatDuration(state.duration || 0)}\n`;
+    markdown += `**Participants:** ${state.participants?.join(", ") || "N/A"}\n\n`;
+    markdown += `## Summary\n${state.summary || "N/A"}\n\n`;
+    if (state.topics?.length) {
+      markdown += `## Topics\n`;
+      state.topics.forEach((t: Topic) => (markdown += `- ${t.name} (${t.status})\n`));
+      markdown += "\n";
+    }
+    if (state.decisions?.length) {
+      markdown += `## Decisions\n`;
+      state.decisions.forEach(
+        (d: Decision) => (markdown += `- ${d.text}${d.by ? ` — ${d.by}` : ""}\n`),
+      );
+      markdown += "\n";
+    }
+    if (state.actionItems?.length) {
+      markdown += `## Action Items\n`;
+      state.actionItems.forEach((a: ActionItem) => {
+        markdown += `- [ ] ${a.task}`;
+        if (a.owner) markdown += ` → ${a.owner}`;
+        if (a.deadline) markdown += ` (due: ${a.deadline})`;
+        markdown += "\n";
+      });
+    }
+    return markdown;
+  }
+
+  function showToast(message: string, type: "success" | "error" = "success"): void {
+    const toast = document.getElementById("export-toast") as HTMLDivElement;
+    if (!toast) return;
+    toast.textContent = message;
+    toast.className = `export-toast ${type} show`;
+    setTimeout(() => {
+      toast.className = "export-toast";
+    }, 3000);
+  }
+
+  function downloadFile(content: string, filename: string, mimeType: string): void {
+    const blob = new Blob([content], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }
+
+  // ——— Export Dropdown ———
+  const exportBtn = document.getElementById("export-btn") as HTMLButtonElement;
+  const exportDropdown = document.getElementById("export-dropdown") as HTMLDivElement;
+
+  exportBtn?.addEventListener("click", () => {
+    const isHidden = exportDropdown.hasAttribute("hidden");
+    if (isHidden) {
+      exportDropdown.removeAttribute("hidden");
+      exportBtn.setAttribute("aria-expanded", "true");
+    } else {
+      exportDropdown.setAttribute("hidden", "");
+      exportBtn.setAttribute("aria-expanded", "false");
+    }
+  });
+
+  document.addEventListener("click", (e: MouseEvent) => {
+    const wrapper = document.getElementById("export-wrapper");
+    if (wrapper && !wrapper.contains(e.target as Node)) {
+      exportDropdown?.setAttribute("hidden", "");
+      exportBtn?.setAttribute("aria-expanded", "false");
+    }
+  });
+
+  document.getElementById("export-md-btn")?.addEventListener("click", async () => {
+    const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
+    if (!state) return;
+    const markdown = generateMarkdown(state);
+    const filename = `meeting-summary-${new Date().toISOString().slice(0, 10)}.md`;
+    downloadFile(markdown, filename, "text/markdown");
+    exportDropdown?.setAttribute("hidden", "");
+    exportBtn?.setAttribute("aria-expanded", "false");
+    showToast("Downloaded as .md file", "success");
+  });
+
+  document.getElementById("export-json-btn")?.addEventListener("click", async () => {
+    const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
+    if (!state) return;
+    const sessionData = {
+      exportedAt: new Date().toISOString(),
+      summary: state.summary || "",
+      participants: state.participants || [],
+      topics: state.topics || [],
+      decisions: state.decisions || [],
+      actionItems: state.actionItems || [],
+      transcript: state.transcript || [],
+      timeline: state.timeline || [],
+    };
+    const filename = `meeting-backup-${new Date().toISOString().slice(0, 10)}.json`;
+    downloadFile(JSON.stringify(sessionData, null, 2), filename, "application/json");
+    exportDropdown?.setAttribute("hidden", "");
+    exportBtn?.setAttribute("aria-expanded", "false");
+    showToast("Downloaded as .json backup", "success");
+  });
+
+  document.getElementById("export-clipboard-btn")?.addEventListener("click", async () => {
     try {
       const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
       if (!state) return;
-
-      let markdown = `# Meeting Summary\n\n`;
-      markdown += `**Date:** ${new Date().toLocaleDateString()}\n`;
-      markdown += `**Duration:** ${formatDuration(state.duration || 0)}\n`;
-      markdown += `**Participants:** ${state.participants?.join(", ") || "N/A"}\n\n`;
-      markdown += `## Summary\n${state.summary || "N/A"}\n\n`;
-
-      if (state.topics?.length) {
-        markdown += `## Topics\n`;
-        state.topics.forEach((t: Topic) => (markdown += `- ${t.name} (${t.status})\n`));
-        markdown += "\n";
-      }
-
-      if (state.decisions?.length) {
-        markdown += `## Decisions\n`;
-        state.decisions.forEach(
-          (d: Decision) => (markdown += `- ${d.text}${d.by ? ` — ${d.by}` : ""}\n`),
-        );
-        markdown += "\n";
-      }
-
-      if (state.actionItems?.length) {
-        markdown += `## Action Items\n`;
-        state.actionItems.forEach((a: ActionItem) => {
-          markdown += `- [ ] ${a.task}`;
-          if (a.owner) markdown += ` → ${a.owner}`;
-          if (a.deadline) markdown += ` (due: ${a.deadline})`;
-          markdown += "\n";
-        });
-      }
-
-      // Copy to clipboard
+      const markdown = generateMarkdown(state);
       await navigator.clipboard.writeText(markdown);
-
-      const btn = document.getElementById("export-btn") as HTMLButtonElement | null;
-      if (btn) {
-        const originalContent = btn.innerHTML;
-        btn.innerHTML =
-          '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:6px"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg> Copied to clipboard!';
-        setTimeout(() => {
-          btn.innerHTML = originalContent;
-        }, 2000);
-      }
-    } catch (err) {
-      console.error("Export failed:", err);
+      exportDropdown?.setAttribute("hidden", "");
+      exportBtn?.setAttribute("aria-expanded", "false");
+      showToast("Copied to clipboard", "success");
+    } catch {
+      showToast("Failed to copy to clipboard", "error");
     }
   });
 
@@ -670,7 +736,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     navigator.clipboard.writeText(md).then(() => {
-      alert("Session exported to clipboard as Markdown!");
+      showToast("Session exported to clipboard", "success");
     });
   }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -517,13 +517,17 @@ document.addEventListener("DOMContentLoaded", async () => {
     return markdown;
   }
 
+  let exportToastTimer: number | null = null;
+
   function showToast(message: string, type: "success" | "error" = "success"): void {
     const toast = document.getElementById("export-toast") as HTMLDivElement;
     if (!toast) return;
+    if (exportToastTimer) window.clearTimeout(exportToastTimer);
     toast.textContent = message;
     toast.className = `export-toast ${type} show`;
-    setTimeout(() => {
+    exportToastTimer = window.setTimeout(() => {
       toast.className = "export-toast";
+      exportToastTimer = null;
     }, 3000);
   }
 
@@ -534,7 +538,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     anchor.href = url;
     anchor.download = filename;
     anchor.click();
-    URL.revokeObjectURL(url);
+    window.setTimeout(() => {
+      URL.revokeObjectURL(url);
+    }, 0);
   }
 
   // ——— Export Dropdown ———
@@ -561,16 +567,20 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   document.getElementById("export-md-btn")?.addEventListener("click", async () => {
-    const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
-    if (!state) return;
-    const markdown = generateMarkdown(state);
-    const filename = `meeting-summary-${new Date().toISOString().slice(0, 10)}.md`;
-    downloadFile(markdown, filename, "text/markdown");
-    exportDropdown?.setAttribute("hidden", "");
-    exportBtn?.setAttribute("aria-expanded", "false");
-    showToast("Downloaded as .md file", "success");
+    try {
+      const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
+      if (!state) throw new Error("No meeting data available");
+      const markdown = generateMarkdown(state);
+      const filename = `meeting-summary-${new Date().toISOString().slice(0, 10)}.md`;
+      downloadFile(markdown, filename, "text/markdown");
+      showToast("Downloaded as .md file", "success");
+    } catch (err) {
+      showToast("Failed to export: " + (err instanceof Error ? err.message : String(err)), "error");
+    } finally {
+      exportDropdown?.setAttribute("hidden", "");
+      exportBtn?.setAttribute("aria-expanded", "false");
+    }
   });
-
   document.getElementById("export-json-btn")?.addEventListener("click", async () => {
     const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
     if (!state) return;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -581,24 +581,30 @@ document.addEventListener("DOMContentLoaded", async () => {
       exportBtn?.setAttribute("aria-expanded", "false");
     }
   });
+
   document.getElementById("export-json-btn")?.addEventListener("click", async () => {
-    const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
-    if (!state) return;
-    const sessionData = {
-      exportedAt: new Date().toISOString(),
-      summary: state.summary || "",
-      participants: state.participants || [],
-      topics: state.topics || [],
-      decisions: state.decisions || [],
-      actionItems: state.actionItems || [],
-      transcript: state.transcript || [],
-      timeline: state.timeline || [],
-    };
-    const filename = `meeting-backup-${new Date().toISOString().slice(0, 10)}.json`;
-    downloadFile(JSON.stringify(sessionData, null, 2), filename, "application/json");
-    exportDropdown?.setAttribute("hidden", "");
-    exportBtn?.setAttribute("aria-expanded", "false");
-    showToast("Downloaded as .json backup", "success");
+    try {
+      const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
+      if (!state) throw new Error("No meeting data available");
+      const sessionData = {
+        exportedAt: new Date().toISOString(),
+        summary: state.summary || "",
+        participants: state.participants || [],
+        topics: state.topics || [],
+        decisions: state.decisions || [],
+        actionItems: state.actionItems || [],
+        transcript: state.transcript || [],
+        timeline: state.timeline || [],
+      };
+      const filename = `meeting-backup-${new Date().toISOString().slice(0, 10)}.json`;
+      downloadFile(JSON.stringify(sessionData, null, 2), filename, "application/json");
+      showToast("Downloaded as .json backup", "success");
+    } catch (err) {
+      showToast("Failed to export: " + (err instanceof Error ? err.message : String(err)), "error");
+    } finally {
+      exportDropdown?.setAttribute("hidden", "");
+      exportBtn?.setAttribute("aria-expanded", "false");
+    }
   });
 
   document.getElementById("export-clipboard-btn")?.addEventListener("click", async () => {
@@ -607,11 +613,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (!state) return;
       const markdown = generateMarkdown(state);
       await navigator.clipboard.writeText(markdown);
-      exportDropdown?.setAttribute("hidden", "");
-      exportBtn?.setAttribute("aria-expanded", "false");
       showToast("Copied to clipboard", "success");
     } catch {
       showToast("Failed to copy to clipboard", "error");
+    } finally {
+      exportDropdown?.setAttribute("hidden", "");
+      exportBtn?.setAttribute("aria-expanded", "false");
     }
   });
 
@@ -745,9 +752,17 @@ document.addEventListener("DOMContentLoaded", async () => {
       });
     }
 
-    navigator.clipboard.writeText(md).then(() => {
-      showToast("Session exported to clipboard", "success");
-    });
+    navigator.clipboard
+      .writeText(md)
+      .then(() => {
+        showToast("Session exported to clipboard", "success");
+      })
+      .catch((err) => {
+        showToast(
+          "Failed to export session: " + (err instanceof Error ? err.message : String(err)),
+          "error",
+        );
+      });
   }
 
   // Load sessions on tab switch


### PR DESCRIPTION
## Description
Upgraded the Export button in the meeting dashboard with a dropdown panel offering three export options, and replaced disruptive browser alert() popups with smooth DOM toast notifications.

Fixes #38

## Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 UI/UX improvement

## How Has This Been Tested?
- [x] Built the extension with `npm run build`
- [x] Verified no console errors

## Screenshots
Changes affect the Export button in the dashboard footer — now shows a dropdown with 3 options instead of immediately copying to clipboard.

## Checklist
- [x] I have starred the repository ⭐
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export redesigned into a dropdown offering Markdown download, JSON backup, and copy-to-clipboard.
  * Improved status feedback with toast notifications for success and error outcomes.
  * Dropdown closes on outside click and provides expanded/collapsed accessibility attributes.

* **Style**
  * New styles for the export UI, dropdown options, and animated toast variants (success/error).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->