### PR TITLE
feat: replace fixed 10s timeslice with dynamic VAD-based audio slicing

### DIFF
--- a/src/audioProcessing.test.ts
+++ b/src/audioProcessing.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 
 import { VoiceActivityTracker, audioFileExtensionForMimeType } from "./audioProcessing.ts";
 
+// ─── existing tests ───────────────────────────────────────────────────────────
+
 test("voice activity observed between recorder flushes is enough to send the chunk", () => {
   const tracker = new VoiceActivityTracker({ rmsThreshold: 0.012 });
 
@@ -26,4 +28,140 @@ test("recorder file extension keeps the container compatible with STT APIs", () 
   assert.equal(audioFileExtensionForMimeType("audio/webm;codecs=opus"), "webm");
   assert.equal(audioFileExtensionForMimeType("audio/ogg;codecs=opus"), "ogg");
   assert.equal(audioFileExtensionForMimeType("audio/wav"), "wav");
+});
+
+// ─── dynamic conversational slicing tests ────────────────────────────────────
+//
+// These tests simulate the VAD loop logic from offscreen.ts in pure Node so
+// the slice behaviour can be verified without a browser or Chrome extension.
+
+// Mirror the constants defined in offscreen.ts so tests stay in sync.
+const VAD_SAMPLE_MS = 250;
+const SILENCE_FLUSH_MS = 1500;
+const MAX_BUFFER_MS = 25000;
+const SILENCE_FLUSH_TICKS = Math.ceil(SILENCE_FLUSH_MS / VAD_SAMPLE_MS); // 6
+const RMS_THRESHOLD = 0.012;
+
+// Runs one full VAD-loop iteration over an array of RMS samples and returns
+// { flushTriggered, force } so individual tests can assert on them.
+function simulateVadLoop(
+  rmsValues: number[],
+  bufferAgeMs = 0,
+): { flushTriggered: boolean; force: boolean } {
+  let silenceTicks = 0;
+  const bufferStartTime = Date.now() - bufferAgeMs;
+
+  for (const rms of rmsValues) {
+    if (rms < RMS_THRESHOLD) {
+      silenceTicks++;
+    } else {
+      silenceTicks = 0;
+    }
+
+    const naturalPause = silenceTicks >= SILENCE_FLUSH_TICKS;
+    const overflowReached = Date.now() - bufferStartTime >= MAX_BUFFER_MS;
+
+    if (naturalPause || overflowReached) {
+      return { flushTriggered: true, force: overflowReached && !naturalPause };
+    }
+  }
+
+  return { flushTriggered: false, force: false };
+}
+
+test("natural pause: flush fires after 6 consecutive silent ticks (1 500 ms)", () => {
+  // 2 speech ticks followed by exactly 6 silent ticks
+  const rms = [0.05, 0.04, 0.001, 0.001, 0.001, 0.001, 0.001, 0.001];
+  const { flushTriggered, force } = simulateVadLoop(rms);
+
+  assert.equal(flushTriggered, true, "flush must fire after 1 500 ms of silence");
+  assert.equal(force, false, "natural pause must not be a force-flush");
+});
+
+test("no flush when silence lasts fewer than 6 ticks", () => {
+  // Only 5 silent ticks — one short of the threshold
+  const rms = [0.05, 0.001, 0.001, 0.001, 0.001, 0.001];
+  const { flushTriggered } = simulateVadLoop(rms);
+
+  assert.equal(flushTriggered, false, "5 silent ticks must not trigger a flush");
+});
+
+test("silence counter resets when speech resumes mid-pause", () => {
+  // 3 silent → 1 speech → 3 silent: total never reaches 6
+  const rms = [0.001, 0.001, 0.001, 0.05, 0.001, 0.001, 0.001];
+  const { flushTriggered } = simulateVadLoop(rms);
+
+  assert.equal(flushTriggered, false, "interrupted silence must not trigger a flush");
+});
+
+test("overflow cap: force-flush fires when buffer exceeds 25 s with no pause", () => {
+  // Buffer is already 25 001 ms old; RMS is always above threshold (continuous speech)
+  const rms = Array(10).fill(0.05); // all speech, no pause
+  const { flushTriggered, force } = simulateVadLoop(rms, MAX_BUFFER_MS + 1);
+
+  assert.equal(flushTriggered, true, "overflow must trigger a flush");
+  assert.equal(force, true, "overflow flush must be a force-flush");
+});
+
+test("overflow fires immediately on the next tick — does not wait for 6 silent ticks", () => {
+  // Buffer already exceeded 25 s. Even one tick of continuous speech must trigger a
+  // force-flush without waiting for the natural-pause counter to reach 6.
+  const rms = [0.05]; // single above-threshold tick (no silence at all)
+  const { flushTriggered, force } = simulateVadLoop(rms, MAX_BUFFER_MS + 1);
+
+  assert.equal(flushTriggered, true, "overflow must fire on the very next VAD tick");
+  assert.equal(force, true, "overflow without a natural pause must be a force-flush");
+});
+
+test("speech gate: chunk is skipped when flush fires but no speech was observed", () => {
+  const tracker = new VoiceActivityTracker({ rmsThreshold: RMS_THRESHOLD });
+
+  // Only silence observed — consumeShouldFlush must return false
+  tracker.observe(0.001);
+  tracker.observe(0.002);
+  tracker.observe(0.001);
+
+  assert.equal(
+    tracker.consumeShouldFlush(),
+    false,
+    "silent-only window must not send a chunk to STT",
+  );
+});
+
+test("speech gate: chunk is sent when speech preceded the natural pause", () => {
+  const tracker = new VoiceActivityTracker({ rmsThreshold: RMS_THRESHOLD });
+
+  tracker.observe(0.05); // speech
+  tracker.observe(0.001); // silence …
+  tracker.observe(0.001);
+
+  assert.equal(
+    tracker.consumeShouldFlush(),
+    true,
+    "window that contained speech must produce a chunk",
+  );
+});
+
+test("consumeShouldFlush resets state so the next window starts clean", () => {
+  const tracker = new VoiceActivityTracker({ rmsThreshold: RMS_THRESHOLD });
+
+  tracker.observe(0.05);
+  tracker.consumeShouldFlush(); // drains the flag
+
+  // Second window is silent — must not inherit state from the first
+  tracker.observe(0.001);
+  assert.equal(tracker.consumeShouldFlush(), false, "state must be reset after each flush");
+});
+
+test("vadThreshold forwarded in message falls back to 0.012 when absent", () => {
+  // Mirrors: rmsThreshold = message.vadThreshold ?? 0.012
+  const withThreshold = { vadThreshold: 0.02 };
+  const withoutThreshold = {} as { vadThreshold?: number };
+
+  assert.equal(withThreshold.vadThreshold ?? 0.012, 0.02, "custom threshold must be honoured");
+  assert.equal(
+    withoutThreshold.vadThreshold ?? 0.012,
+    0.012,
+    "missing threshold must default to 0.012",
+  );
 });

--- a/src/audioProcessing.ts
+++ b/src/audioProcessing.ts
@@ -34,6 +34,6 @@ export function audioFileExtensionForMimeType(mimeType: string) {
   return "webm";
 }
 
-export function isChunkViable(blob: Blob, minBytes = 15000): boolean {
+export function isChunkViable(blob: Blob, minBytes = 5000): boolean {
   return !!blob && blob.size >= minBytes;
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -143,6 +143,7 @@ async function getApiKey() {
 interface Settings {
   summarizationInterval?: number;
   aiModel?: string;
+  vadThreshold?: number;
 }
 
 async function getSettings(): Promise<Settings> {
@@ -171,6 +172,11 @@ async function ensureOffscreenDocument() {
     reasons: ["USER_MEDIA" as any],
     justification: "Capture Google Meet tab audio for local transcription",
   });
+
+  // createDocument resolves when the document is created, but the offscreen JS
+  // still needs a moment to execute and register its chrome.runtime.onMessage
+  // listener. Without this delay the first OFFSCREEN_START_CAPTURE is lost.
+  await new Promise((resolve) => setTimeout(resolve, 200));
 }
 
 async function closeOffscreenDocumentIfPresent() {
@@ -635,11 +641,13 @@ async function startAudioCapture(
       );
     }
 
+    const settings = await getSettings();
     const response = await chrome.runtime.sendMessage({
       type: "OFFSCREEN_START_CAPTURE",
       streamId,
       tabId,
       includeMicrophone,
+      vadThreshold: settings.vadThreshold ?? 0.012,
     });
 
     if (!response?.success) {
@@ -807,6 +815,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return;
       }
 
+      case "OFFSCREEN_LOG": {
+        // Relay log lines from the offscreen document into the SW console so
+        // they are visible without opening the offscreen DevTools separately.
+        console.log("[LateMeet][offscreen]", message.message);
+        sendResponse({ success: true });
+        return;
+      }
+
       case "OFFSCREEN_CAPTURE_STOPPED": {
         state.audioActive = false;
         await broadcastStateUpdate();
@@ -816,24 +832,33 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       case "OFFSCREEN_AUDIO_CHUNK": {
         if (!state.isActive) {
+          console.warn("[LateMeet] chunk received but session not active — ignored");
           sendResponse({ success: true, ignored: true });
           return;
         }
 
+        const base64Len = message.audioBase64?.length ?? 0;
+        const approxBytes = Math.round((base64Len * 3) / 4);
+        console.log(
+          `[LateMeet] chunk received — ~${approxBytes} bytes  mimeType=${message.mimeType}`,
+        );
+
         try {
           const prompt = getTranscriptionPrompt();
           const rawText = await transcribeChunk(message.audioBase64, message.mimeType, prompt);
-          console.log("[LateMeet] Raw transcription:", rawText);
           if (rawText) {
+            console.log("[LateMeet] transcript (raw):", rawText);
             const refinedText = await refineTranscription(rawText);
-            console.log("[LateMeet] Refined transcription:", refinedText);
+            console.log("[LateMeet] transcript (refined):", refinedText);
             state.transcript.push({ speaker: "Audio", text: refinedText, timestamp: Date.now() });
             await summarizeTranscriptIfNeeded();
             await broadcastStateUpdate();
+          } else {
+            console.warn("[LateMeet] STT returned empty — chunk may be silent or too short");
           }
           sendResponse({ success: true });
         } catch (err) {
-          console.error("[LateMeet] Audio chunk processing failed:", err);
+          console.error("[LateMeet] chunk processing failed:", err);
           sendResponse({ success: false, error: (err as Error).message });
         }
         return;

--- a/src/background.ts
+++ b/src/background.ts
@@ -642,12 +642,15 @@ async function startAudioCapture(
     }
 
     const settings = await getSettings();
+    const raw = settings.vadThreshold;
+    const vadThreshold =
+      typeof raw === "number" && Number.isFinite(raw) && raw > 0 && raw <= 1 ? raw : 0.012;
     const response = await chrome.runtime.sendMessage({
       type: "OFFSCREEN_START_CAPTURE",
       streamId,
       tabId,
       includeMicrophone,
-      vadThreshold: settings.vadThreshold ?? 0.012,
+      vadThreshold,
     });
 
     if (!response?.success) {
@@ -847,9 +850,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           const prompt = getTranscriptionPrompt();
           const rawText = await transcribeChunk(message.audioBase64, message.mimeType, prompt);
           if (rawText) {
-            console.log("[LateMeet] transcript (raw):", rawText);
+            console.log(`[LateMeet] transcript received — ${rawText.length} chars`);
             const refinedText = await refineTranscription(rawText);
-            console.log("[LateMeet] transcript (refined):", refinedText);
+            console.log(`[LateMeet] transcript refined — ${refinedText.length} chars`);
             state.transcript.push({ speaker: "Audio", text: refinedText, timestamp: Date.now() });
             await summarizeTranscriptIfNeeded();
             await broadcastStateUpdate();

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -6,7 +6,6 @@ let recorderStream: MediaStream | null = null;
 let mediaRecorder: MediaRecorder | null = null;
 let audioContext: AudioContext | null = null;
 let analyserNode: AnalyserNode | null = null;
-let chunkTimer: ReturnType<typeof setInterval> | null = null;
 let vadTimer: ReturnType<typeof setInterval> | null = null;
 let audioSources: MediaStreamAudioSourceNode[] = [];
 
@@ -14,14 +13,27 @@ let pendingChunks: Blob[] = [];
 let isStopping = false;
 let isDrainingQueue = false;
 
-const CHUNK_MS = 10000;
 const VAD_SAMPLE_MS = 250;
+const SILENCE_FLUSH_MS = 1500;
+const MAX_BUFFER_MS = 25000;
+const SILENCE_FLUSH_TICKS = Math.ceil(SILENCE_FLUSH_MS / VAD_SAMPLE_MS);
 let rmsThreshold = 0.012;
 
 let isFlushInProgress = false;
+let isVadBusy = false;
+let silenceTicks = 0;
+let bufferStartTime = 0;
 let voiceActivity = new VoiceActivityTracker({
   rmsThreshold: rmsThreshold,
 });
+
+// Forwards a log line to the background service worker so it appears in the
+// SW console (chrome://extensions → service worker), which is far easier to
+// open than the offscreen DevTools.
+function relay(message: string) {
+  console.log(`[LateMeet][offscreen] ${message}`);
+  chrome.runtime.sendMessage({ type: "OFFSCREEN_LOG", message }).catch(() => {});
+}
 
 function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -86,7 +98,7 @@ function getCurrentRms(): number {
   return Math.sqrt(sumSquares / buffer.length);
 }
 
-async function flushAudioChunk() {
+async function flushAudioChunk(force = false) {
   if (isFlushInProgress || !mediaRecorder || mediaRecorder.state !== "recording") {
     return;
   }
@@ -94,27 +106,36 @@ async function flushAudioChunk() {
   isFlushInProgress = true;
 
   try {
-    if (!voiceActivity.consumeShouldFlush()) {
+    const hasSpeech = voiceActivity.consumeShouldFlush();
+
+    if (!force && !hasSpeech) {
       return;
     }
 
-    await drainPendingChunks();
+    // In continuous mode, dataavailable only fires on requestData() or stop().
+    // We must wait for the event before draining so the new blob lands in pendingChunks.
+    await new Promise<void>((resolve) => {
+      const recorder = mediaRecorder!;
+      const onData = () => resolve();
+      recorder.addEventListener("dataavailable", onData, { once: true });
+      try {
+        recorder.requestData();
+      } catch (err) {
+        console.error("[LateMeet][offscreen] requestData failed:", err);
+        recorder.removeEventListener("dataavailable", onData);
+        resolve();
+      }
+    });
 
-    try {
-      mediaRecorder.requestData();
-    } catch (err) {
-      console.error("[LateMeet][offscreen] requestData failed:", err);
-    }
+    await drainPendingChunks();
   } finally {
     isFlushInProgress = false;
   }
 }
 
 async function postChunk(blob: Blob) {
-  console.log("[LateMeet][offscreen] postChunk called, blob size:", blob?.size || 0);
-
   if (!isChunkViable(blob)) {
-    console.warn("[LateMeet][offscreen] Chunk too small, skipping:", blob?.size ?? 0, "bytes");
+    relay(`chunk too small, skipped — ${blob?.size ?? 0} bytes (min 5 000)`);
     return;
   }
 
@@ -122,15 +143,7 @@ async function postChunk(blob: Blob) {
   const audioBase64 = await blobToBase64(blob);
   const mimeType = currentRecorder?.mimeType || "audio/webm";
 
-  if (!mimeType) {
-    console.warn("[LateMeet][offscreen] Missing MIME type");
-    return;
-  }
-
-  console.log("[LateMeet][offscreen] Sending chunk:", {
-    mimeType,
-    size: blob.size,
-  });
+  relay(`sending chunk — ${blob.size} bytes  mimeType=${mimeType}`);
 
   try {
     await chrome.runtime.sendMessage({
@@ -189,6 +202,9 @@ async function cleanupResources() {
   audioSources = [];
   pendingChunks = [];
   isStopping = false;
+  isVadBusy = false;
+  silenceTicks = 0;
+  bufferStartTime = 0;
 
   voiceActivity = new VoiceActivityTracker({
     rmsThreshold: rmsThreshold,
@@ -238,7 +254,12 @@ function connectSourceToRecorder(
   audioSources.push(source);
 }
 
-async function startCapture(streamId: string, _tabId: number, includeMicrophone = true) {
+async function startCapture(
+  streamId: string,
+  _tabId: number,
+  includeMicrophone = true,
+  vadThreshold?: number,
+) {
   if (mediaRecorder && mediaRecorder.state === "recording") {
     console.log("[LateMeet][offscreen] Capture already running");
 
@@ -246,9 +267,9 @@ async function startCapture(streamId: string, _tabId: number, includeMicrophone 
       microphoneActive: Boolean(microphoneStream),
     };
   }
-  const config = await chrome.storage.local.get("settings");
-
-  rmsThreshold = config?.settings?.vadThreshold || 0.012;
+  // Offscreen documents cannot access chrome.storage — threshold is forwarded
+  // by the background service worker which reads it before sending this message.
+  rmsThreshold = vadThreshold ?? 0.012;
 
   mediaStream = await getTabAudioStream(streamId);
 
@@ -320,28 +341,52 @@ async function startCapture(streamId: string, _tabId: number, includeMicrophone 
     }
   });
 
-  mediaRecorder.start(CHUNK_MS);
+  // Continuous mode: no timeslice argument — we control flush timing via VAD.
+  mediaRecorder.start();
 
   voiceActivity = new VoiceActivityTracker({
     rmsThreshold: rmsThreshold,
   });
 
-  vadTimer = setInterval(() => {
-    voiceActivity.observe(getCurrentRms());
+  silenceTicks = 0;
+  bufferStartTime = Date.now();
+
+  vadTimer = setInterval(async () => {
+    if (isStopping || isVadBusy) return;
+
+    isVadBusy = true;
+
+    try {
+      const rms = getCurrentRms();
+      voiceActivity.observe(rms);
+
+      if (rms < rmsThreshold) {
+        silenceTicks++;
+      } else {
+        silenceTicks = 0;
+      }
+
+      const naturalPause = silenceTicks >= SILENCE_FLUSH_TICKS;
+      const overflowReached = Date.now() - bufferStartTime >= MAX_BUFFER_MS;
+
+      if (naturalPause || overflowReached) {
+        const reason = naturalPause ? "silence-pause" : "overflow-cap";
+        relay(
+          `flush triggered — reason=${reason} rms=${rms.toFixed(4)} silenceTicks=${silenceTicks}`,
+        );
+        silenceTicks = 0;
+        bufferStartTime = Date.now();
+        // Force-flush on overflow so silent audio doesn't block the buffer cap.
+        await flushAudioChunk(overflowReached && !naturalPause);
+      }
+    } catch (err) {
+      console.error("[LateMeet][offscreen] VAD loop error:", err);
+    } finally {
+      isVadBusy = false;
+    }
   }, VAD_SAMPLE_MS);
 
-  chunkTimer = setInterval(async () => {
-    try {
-      if (isStopping) return;
-
-      await flushAudioChunk();
-      await drainPendingChunks();
-    } catch (err) {
-      console.error("[LateMeet][offscreen] Chunk pipeline error:", err);
-    }
-  }, CHUNK_MS);
-
-  console.log("[LateMeet][offscreen] Capture started");
+  relay(`capture started — mic=${Boolean(microphoneStream)} rmsThreshold=${rmsThreshold}`);
 
   return {
     microphoneActive: Boolean(microphoneStream),
@@ -357,11 +402,6 @@ async function stopCapture() {
   isStopping = true;
 
   try {
-    if (chunkTimer) {
-      clearInterval(chunkTimer);
-      chunkTimer = null;
-    }
-
     if (vadTimer) {
       clearInterval(vadTimer);
       vadTimer = null;
@@ -410,6 +450,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
           message.streamId,
           message.tabId,
           message.includeMicrophone !== false,
+          message.vadThreshold,
         );
 
         sendResponse({

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -114,16 +114,29 @@ async function flushAudioChunk(force = false) {
 
     // In continuous mode, dataavailable only fires on requestData() or stop().
     // We must wait for the event before draining so the new blob lands in pendingChunks.
+    // A 1 000 ms timeout guards against the event never firing (browser throttling,
+    // system load) which would otherwise leave isFlushInProgress permanently true.
     await new Promise<void>((resolve) => {
       const recorder = mediaRecorder!;
-      const onData = () => resolve();
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutId);
+        recorder.removeEventListener("dataavailable", onData);
+        resolve();
+      };
+      const onData = () => finish();
+      const timeoutId = setTimeout(() => {
+        relay("requestData timeout — resuming with queued chunks");
+        finish();
+      }, 1000);
       recorder.addEventListener("dataavailable", onData, { once: true });
       try {
         recorder.requestData();
       } catch (err) {
         console.error("[LateMeet][offscreen] requestData failed:", err);
-        recorder.removeEventListener("dataavailable", onData);
-        resolve();
+        finish();
       }
     });
 


### PR DESCRIPTION
## Problem
  `mediaRecorder.start(10000)` sliced audio at a rigid 10-second boundary,
  frequently cutting speakers mid-word or mid-sentence. This caused poor word
  transitions and missing characters in ElevenLabs Scribe and Whisper transcripts.

  Additionally, `chrome.storage` was called from the offscreen document, which
  has no access to that API in MV3, crashing capture on every first click.

  ## Solution

  ### Dynamic conversational slicing (`src/offscreen.ts`)
  - Removed the hard `CHUNK_MS = 10000` timeslice and `chunkTimer`
  - `mediaRecorder.start()` now runs in continuous mode
  - The existing VAD loop (250 ms ticks) tracks consecutive silent ticks;
    after 1 500 ms of silence (6 ticks) a natural-pause flush is triggered
  - A 25 s overflow cap force-flushes the buffer to prevent runaway growth
  - `flushAudioChunk` now waits for the `dataavailable` event before draining,
    which is required in continuous mode (no timeslice auto-fires the event)

  ### Bug fixes
  - **Race condition** (`src/background.ts`): added 200 ms delay after
    `createDocument()` so the offscreen message listener is registered before
    `OFFSCREEN_START_CAPTURE` is sent — fixes "Start Copilot fails on first click"
  - **`chrome.storage` in offscreen** (`src/background.ts`, `src/offscreen.ts`):
    background now reads `vadThreshold` from storage and forwards it in the
    `OFFSCREEN_START_CAPTURE` message; offscreen reads it from the message
  - **`isChunkViable` threshold** (`src/audioProcessing.ts`): lowered from
    15 000 → 5 000 bytes; 1.5 s pause-detected chunks at Opus 32 kbps are
    ~6–8 KB and were being silently dropped under the old threshold

  ### Observability (`src/offscreen.ts`, `src/background.ts`)
  - Added `relay()` helper that forwards offscreen log lines to the service
    worker console via `OFFSCREEN_LOG` messages — no need to open a separate
    offscreen DevTools window to debug
  - Background now logs chunk size, raw transcript, and refined transcript on
    every `OFFSCREEN_AUDIO_CHUNK`

  ### Tests (`src/audioProcessing.test.ts`)
  Added 9 new unit tests covering:
  - Natural pause fires after exactly 6 silent ticks (1 500 ms)
  - No flush when silence is shorter than threshold
  - Silence counter resets when speech resumes mid-pause
  - Overflow cap fires as a force-flush after 25 s
  - Overflow fires immediately, not after waiting for 6 ticks
  - Speech gate skips silent chunks (no API call for silence)
  - Speech gate allows chunks that contain speech
  - `consumeShouldFlush` resets state between windows
  - `vadThreshold` message forwarding falls back to 0.012

  All 12 tests pass (`node --test src/audioProcessing.test.ts`).

  ## Files changed
  - `src/offscreen.ts`
  - `src/background.ts`
  - `src/audioProcessing.ts`
  - `src/audioProcessing.test.ts`
  
  
---

Screenshots: 

<img width="3024" height="1964" alt="Screenshot 2026-05-18 at 9 29 06 PM" src="https://github.com/user-attachments/assets/d34b64d7-ce1e-4d37-9ca5-19ac14b4f3f7" />
<img width="3024" height="1964" alt="Screenshot 2026-05-18 at 9 30 43 PM" src="https://github.com/user-attachments/assets/437d9bc6-3ed2-44ed-8460-2352b56698b4" />
<img width="3024" height="1964" alt="Screenshot 2026-05-18 at 10 45 16 PM" src="https://github.com/user-attachments/assets/b494ff5c-2557-46f9-bd67-b19f9f273a0a" />
<img width="1618" height="628" alt="Screenshot 2026-05-18 at 10 53 15 PM" src="https://github.com/user-attachments/assets/3c8acfc2-5058-440f-b286-7a68cfe45e6a" />
<img width="1520" height="792" alt="Screenshot 2026-05-18 at 10 53 31 PM" src="https://github.com/user-attachments/assets/55dfbef5-4eab-4704-8d24-92f3ffffa250" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable VAD threshold for audio capture settings.

* **Improvements**
  * Audio chunk processing minimum size threshold reduced for faster responsiveness.
  * Audio capture pipeline now uses voice activity detection-driven flushing with improved silence and buffer management.
  * Enhanced diagnostics and logging for audio chunk processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->