### PR TITLE
fix: rollback audio startup state on failure

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -581,7 +581,9 @@ async function startAudioCapture(
 
   await ensureOffscreenDocument();
 
-  if (!state.isActive) {
+  const createdSession = !state.isActive;
+
+  if (createdSession) {
     resetState();
     state.isActive = true;
     state.startTime = Date.now();
@@ -630,6 +632,10 @@ async function startAudioCapture(
     await broadcastStateUpdate();
   } catch (err) {
     state.audioActive = false;
+    if (createdSession) {
+      resetState();
+      await broadcastStateUpdate();
+    }
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
Fixes stale meeting state when audio capture startup fails after the background worker has already marked a meeting as active.

Fixes #52

## Changes
- Track whether startAudioCapture created a new session for the current startup attempt.
- On startup failure, reset newly-created meeting state and broadcast the idle state.
- Preserve existing active sessions by only rolling back state created by the failed startup attempt.

## Steps to Test
1. Run npm run lint
2. Run npm run build
3. Start audio capture and simulate OFFSCREEN_START_CAPTURE returning { success: false }.
4. Confirm popup/dashboard state returns to idle instead of showing Meeting active.

## Screenshots
Not applicable; backend/service-worker state consistency fix.

## Notes for Reviewer
Plain node --test cannot run the existing TypeScript test files in this repo without a TypeScript loader; validation used the configured npm scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery when audio capture fails to start by properly cleaning up session state and ensuring resources are released.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->