### PR TITLE
fix: respect saved feature toggles

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -464,15 +464,24 @@ Return a JSON object with these exact keys:
   if (topicDetectionEnabled) {
     state.topics = Array.isArray(parsed.topics) ? parsed.topics : state.topics;
     state.currentTopic = parsed.currentTopic || state.currentTopic;
+  } else {
+    state.topics = [];
+    state.currentTopic = "";
   }
   if (decisionDetectionEnabled) {
     state.decisions = Array.isArray(parsed.decisions) ? parsed.decisions : state.decisions;
+  } else {
+    state.decisions = [];
   }
   if (actionExtractionEnabled) {
     state.actionItems = Array.isArray(parsed.actionItems) ? parsed.actionItems : state.actionItems;
+  } else {
+    state.actionItems = [];
   }
   if (sentimentAnalysisEnabled) {
     state.sentiment = parsed.sentiment || state.sentiment;
+  } else {
+    state.sentiment = "neutral";
   }
   state.keyInsights = Array.isArray(parsed.keyInsights) ? parsed.keyInsights : state.keyInsights;
   state.questionsRaised = Array.isArray(parsed.questionsRaised)

--- a/src/background.ts
+++ b/src/background.ts
@@ -147,11 +147,20 @@ interface Settings {
   summarizationInterval?: number;
   aiModel?: string;
   vadThreshold?: number;
+  lateJoinerBriefing?: boolean;
+  topicDetection?: boolean;
+  decisionDetection?: boolean;
+  actionExtraction?: boolean;
+  sentimentAnalysis?: boolean;
 }
 
 async function getSettings(): Promise<Settings> {
   const result = await chrome.storage.local.get("settings");
   return result.settings || {};
+}
+
+function isFeatureEnabled(settings: Settings, key: keyof Settings): boolean {
+  return settings[key] !== false;
 }
 
 function sanitizePromptText(value: string | null) {
@@ -375,14 +384,35 @@ async function summarizeTranscriptIfNeeded() {
     .join("\n");
   if (!transcriptWindow.trim()) return;
 
+  const topicDetectionEnabled = isFeatureEnabled(settings, "topicDetection");
+  const decisionDetectionEnabled = isFeatureEnabled(settings, "decisionDetection");
+  const actionExtractionEnabled = isFeatureEnabled(settings, "actionExtraction");
+  const sentimentAnalysisEnabled = isFeatureEnabled(settings, "sentimentAnalysis");
+  const outputFields = [
+    '"summary": "Updated meeting summary..."',
+    ...(topicDetectionEnabled
+      ? [
+          '"topics": [{"name": "Topic", "status": "active|completed"}]',
+          '"currentTopic": "Identifying the current main topic"',
+        ]
+      : []),
+    ...(decisionDetectionEnabled ? ['"decisions": ["Decision 1", ...]'] : []),
+    ...(actionExtractionEnabled ? ['"actionItems": ["Action 1", ...]'] : []),
+    ...(sentimentAnalysisEnabled ? ['"sentiment": "positive|neutral|negative|mixed"'] : []),
+    '"keyInsights": ["Insight 1", ...]',
+    '"questionsRaised": ["Question 1", ...]',
+  ];
+
   const systemPrompt = `You are a World-Class Meeting Intelligence Engine. 
 Your goal is to extract high-fidelity insights from meeting transcripts.
 
 OUTPUT GUIDELINES:
 - Provide a concise yet professional summary (business grade).
-- Identify distinct topics and their statuses (active/completed).
-- Precisely capture decisions and action items (with assignees if mentioned).
-- Detect the prevailing sentiment and emotional dynamics.
+- Extract only the fields requested by the user prompt.
+${topicDetectionEnabled ? "- Identify distinct topics and their statuses (active/completed)." : ""}
+${decisionDetectionEnabled ? "- Precisely capture decisions if mentioned." : ""}
+${actionExtractionEnabled ? "- Precisely capture action items with assignees if mentioned." : ""}
+${sentimentAnalysisEnabled ? "- Detect the prevailing sentiment and emotional dynamics." : ""}
 - Extract "Key Insights" that go beyond a simple summary (strategic value).
 - Track specific questions raised that remain unanswered.
 
@@ -399,14 +429,7 @@ ${transcriptWindow}
 
 Return a JSON object with these exact keys:
 {
-  "summary": "Updated meeting summary...",
-  "topics": [{"name": "Topic", "status": "active|completed"}],
-  "decisions": ["Decision 1", ...],
-  "actionItems": ["Action 1", ...],
-  "currentTopic": "Identifying the current main topic",
-  "sentiment": "positive|neutral|negative|mixed",
-  "keyInsights": ["Insight 1", ...],
-  "questionsRaised": ["Question 1", ...]
+  ${outputFields.join(",\n  ")}
 }`;
 
   const response = await fetch(OPENAI_CHAT_URL, {
@@ -438,11 +461,19 @@ Return a JSON object with these exact keys:
 
   const parsed = JSON.parse(content);
   state.summary = parsed.summary || state.summary;
-  state.topics = Array.isArray(parsed.topics) ? parsed.topics : state.topics;
-  state.decisions = Array.isArray(parsed.decisions) ? parsed.decisions : state.decisions;
-  state.actionItems = Array.isArray(parsed.actionItems) ? parsed.actionItems : state.actionItems;
-  state.currentTopic = parsed.currentTopic || state.currentTopic;
-  state.sentiment = parsed.sentiment || state.sentiment;
+  if (topicDetectionEnabled) {
+    state.topics = Array.isArray(parsed.topics) ? parsed.topics : state.topics;
+    state.currentTopic = parsed.currentTopic || state.currentTopic;
+  }
+  if (decisionDetectionEnabled) {
+    state.decisions = Array.isArray(parsed.decisions) ? parsed.decisions : state.decisions;
+  }
+  if (actionExtractionEnabled) {
+    state.actionItems = Array.isArray(parsed.actionItems) ? parsed.actionItems : state.actionItems;
+  }
+  if (sentimentAnalysisEnabled) {
+    state.sentiment = parsed.sentiment || state.sentiment;
+  }
   state.keyInsights = Array.isArray(parsed.keyInsights) ? parsed.keyInsights : state.keyInsights;
   state.questionsRaised = Array.isArray(parsed.questionsRaised)
     ? parsed.questionsRaised
@@ -546,6 +577,9 @@ async function sendChatToTab(tabId: number, text: string) {
 
 async function maybeWelcomeJoiners(tabId: number | undefined, joiners: string[]) {
   if (!joiners.length || getDuration() <= MIN_MEETING_DURATION_FOR_WELCOME || !tabId) return;
+
+  const settings = await getSettings();
+  if (!isFeatureEnabled(settings, "lateJoinerBriefing")) return;
 
   const normalizedSelf = normalizeParticipantName(selfParticipantName);
 


### PR DESCRIPTION
 ## Description

  This PR fixes the backend handling for saved feature toggles from the Options page.

  Previously, settings like `lateJoinerBriefing`, `topicDetection`, `decisionDetection`, `actionExtraction`, and
  `sentimentAnalysis` were saved correctly, but the background service worker did not enforce them. Because of
  that, disabled AI features could still run during a meeting.

  This change makes the background worker read those toggles and respect them:
  - Skips late joiner briefing generation when disabled.
  - Only asks the AI model for enabled summarization fields.
  - Avoids updating disabled feature state such as topics, decisions, action items, or sentiment.

  Fixes #61

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update
  - [ ] 🎨 UI/UX improvement
  - [ ] ♻️ Code refactoring (no functional changes)
  - [ ] 🧪 Tests

  ## How Has This Been Tested?

  - [x] Built the extension with `npm run build`
  - [ ] Loaded the extension in Chrome and tested manually
  - [ ] Tested on a live Google Meet call
  - [ ] Verified no console errors
  - [ ] Tested with ElevenLabs API key
  - [ ] Tested with OpenAI API key

  Note: `npm run lint` could not be completed locally because the rebased upstream version expects `eslint`, but
  the local install currently does not include the required executable in `node_modules`.

  ## Screenshots (if applicable)

  Not applicable. This is a backend/service-worker behavior fix with no UI changes.

  ## Checklist

  - [ ] I have **starred the repository** ⭐ (helps us grow and show your support!).
  - [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
  - [x] I have performed a self-review of my code
  - [x] I have commented my code where necessary
  - [ ] My code follows the formatting of this project (run `npm run format`)
  - [ ] ESLint checks pass locally without any errors (run `npm run lint`)
  - [ ] TypeScript type checks pass locally (run `npm run type-check`)
  - [x] My changes generate no new warnings or errors
  - [x] I have updated the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable toggles for AI-powered transcript analysis features: topic detection, decision identification, action extraction, and sentiment analysis.
  * Late-joiner welcome messages can now be enabled or disabled via settings.

* **Refactor**
  * Optimized transcript summarization to dynamically adapt based on enabled features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->