### PR TITLE
feat: add real-time canvas audio waveform visualizer to dashboard

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -818,6 +818,16 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return;
       }
 
+      case "WAVEFORM_DATA": {
+        if (!message._relayed) {
+          chrome.runtime
+            .sendMessage({ type: "WAVEFORM_DATA", buckets: message.buckets, _relayed: true })
+            .catch(() => {});
+        }
+        sendResponse({ success: true });
+        return;
+      }
+
       case "OFFSCREEN_LOG": {
         // Relay log lines from the offscreen document into the SW console so
         // they are visible without opening the offscreen DevTools separately.

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -807,6 +807,35 @@ body::-webkit-scrollbar-thumb {
   border-color: #ff6b6b40;
 }
 
+/* ——— Audio Waveform Visualizer ——— */
+.waveform-canvas {
+  display: block;
+  width: 100%;
+  height: 48px;
+  border-radius: 6px;
+}
+
+.waveform-status-badge {
+  font-size: 9px;
+  font-weight: 700;
+  color: #525252;
+  background: #171717;
+  padding: 3px 8px;
+  border-radius: 4px;
+  letter-spacing: 0.5px;
+  border: 1px solid #262626;
+  transition:
+    color 0.3s ease,
+    background 0.3s ease,
+    border-color 0.3s ease;
+}
+
+.waveform-status-badge.active {
+  color: #000000;
+  background: #ffffff;
+  border-color: #ffffff;
+}
+
 /* ——— Live Transcript ——— */
 .transcript-info {
   font-size: 11px;

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -89,6 +89,33 @@
     <main class="dash-content">
       <!-- OVERVIEW TAB -->
       <section id="tab-overview" class="tab-panel active">
+        <!-- Audio Waveform Visualizer -->
+        <div class="dash-card waveform-card" id="waveform-card">
+          <div class="dash-card-head">
+            <span class="dash-card-icon">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                class="icon"
+              >
+                <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"></path>
+                <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+                <line x1="12" x2="12" y1="19" y2="22"></line>
+              </svg>
+            </span>
+            <span class="dash-card-title">Audio Input</span>
+            <span id="waveform-status" class="waveform-status-badge">IDLE</span>
+          </div>
+          <canvas id="waveform-canvas" class="waveform-canvas"></canvas>
+        </div>
+
         <!-- Live Summary -->
         <div class="dash-card glow-card">
           <div class="dash-card-head">

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,6 +1,65 @@
 import { State, Topic, TranscriptEntry, TimelineEvent, Decision, ActionItem } from "./types";
 
 document.addEventListener("DOMContentLoaded", async () => {
+  // ——— Waveform Visualizer ———
+  const WAVEFORM_N = 32;
+  const WAVEFORM_H = 48;
+  const WAVEFORM_SMOOTH = 0.55;
+
+  const waveformCanvas = document.getElementById("waveform-canvas") as HTMLCanvasElement | null;
+  const waveformStatusEl = document.getElementById("waveform-status");
+  let waveformCtx: CanvasRenderingContext2D | null = null;
+  let waveformCssW = 280;
+  let smoothed = new Array(WAVEFORM_N).fill(0);
+
+  function initWaveformCanvas() {
+    if (!waveformCanvas) return;
+    waveformCtx = waveformCanvas.getContext("2d");
+    const dpr = window.devicePixelRatio || 1;
+    waveformCssW = waveformCanvas.offsetWidth || 280;
+    waveformCanvas.width = Math.round(waveformCssW * dpr);
+    waveformCanvas.height = Math.round(WAVEFORM_H * dpr);
+    if (waveformCtx) waveformCtx.scale(dpr, dpr);
+    drawIdleWaveform();
+  }
+
+  function drawIdleWaveform() {
+    if (!waveformCtx) return;
+    const barGap = 2;
+    const barW = (waveformCssW - barGap * (WAVEFORM_N - 1)) / WAVEFORM_N;
+    const centerY = WAVEFORM_H / 2;
+    waveformCtx.clearRect(0, 0, waveformCssW, WAVEFORM_H);
+    for (let i = 0; i < WAVEFORM_N; i++) {
+      const x = i * (barW + barGap);
+      waveformCtx.fillStyle = "rgba(255,255,255,0.08)";
+      waveformCtx.beginPath();
+      waveformCtx.roundRect(x, centerY - 1, barW, 2, 1);
+      waveformCtx.fill();
+    }
+  }
+
+  function drawWaveform(buckets: number[]) {
+    if (!waveformCtx) return;
+    const barGap = 2;
+    const barW = (waveformCssW - barGap * (WAVEFORM_N - 1)) / WAVEFORM_N;
+    const centerY = WAVEFORM_H / 2;
+    waveformCtx.clearRect(0, 0, waveformCssW, WAVEFORM_H);
+    for (let i = 0; i < WAVEFORM_N; i++) {
+      smoothed[i] = smoothed[i] * WAVEFORM_SMOOTH + buckets[i] * (1 - WAVEFORM_SMOOTH);
+      const amp = smoothed[i];
+      const barH = Math.max(2, amp * WAVEFORM_H * 0.9);
+      const x = i * (barW + barGap);
+      const y = centerY - barH / 2;
+      const alpha = Math.min(1, 0.3 + amp * 2.4);
+      waveformCtx.fillStyle = `rgba(255,255,255,${alpha.toFixed(3)})`;
+      waveformCtx.beginPath();
+      waveformCtx.roundRect(x, y, barW, barH, barW / 2);
+      waveformCtx.fill();
+    }
+  }
+
+  initWaveformCanvas();
+
   // ——— Tab Switching ———
   const tabs = document.querySelectorAll(".dash-tab");
   const panels = document.querySelectorAll(".tab-panel");
@@ -33,12 +92,27 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (message.type === "STATE_UPDATE") {
       lastState = message.state;
       updateDashboard(message.state);
+      if (!message.state?.audioActive) {
+        smoothed = new Array(WAVEFORM_N).fill(0);
+        drawIdleWaveform();
+        if (waveformStatusEl) {
+          waveformStatusEl.textContent = "IDLE";
+          waveformStatusEl.classList.remove("active");
+        }
+      }
     }
     if (message.type === "SESSION_ENDED") {
       // Reload sessions if on that tab
       const sessionsTab = document.querySelector('[data-tab="sessions"]');
       if (sessionsTab?.classList.contains("active")) {
         loadSavedSessions();
+      }
+    }
+    if (message.type === "WAVEFORM_DATA" && Array.isArray(message.buckets)) {
+      drawWaveform(message.buckets);
+      if (waveformStatusEl && !waveformStatusEl.classList.contains("active")) {
+        waveformStatusEl.textContent = "LIVE";
+        waveformStatusEl.classList.add("active");
       }
     }
   });
@@ -54,6 +128,15 @@ document.addEventListener("DOMContentLoaded", async () => {
     try {
       audioBtn.disabled = true;
       audioBtn.textContent = "Starting...";
+
+      // Request mic permission from this user-facing page while the gesture is still live.
+      // Chrome grants the permission to the extension origin so the offscreen doc inherits it.
+      try {
+        const micStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+        micStream.getTracks().forEach((t) => t.stop());
+      } catch {
+        console.warn("[Dashboard] Mic permission not granted — waveform will use tab audio only");
+      }
 
       chrome.tabs.query({ url: "https://meet.google.com/*" }, (meetTabs) => {
         if (meetTabs.length === 0) {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -7,6 +7,7 @@ let mediaRecorder: MediaRecorder | null = null;
 let audioContext: AudioContext | null = null;
 let analyserNode: AnalyserNode | null = null;
 let vadTimer: ReturnType<typeof setInterval> | null = null;
+let waveformTimer: ReturnType<typeof setInterval> | null = null;
 let audioSources: MediaStreamAudioSourceNode[] = [];
 
 let pendingChunks: Blob[] = [];
@@ -14,6 +15,9 @@ let isStopping = false;
 let isDrainingQueue = false;
 
 const VAD_SAMPLE_MS = 250;
+const WAVEFORM_INTERVAL_MS = 50;
+const WAVEFORM_BUCKETS = 32;
+const WAVEFORM_GAIN = 6;
 const SILENCE_FLUSH_MS = 1500;
 const MAX_BUFFER_MS = 25000;
 const SILENCE_FLUSH_TICKS = Math.ceil(SILENCE_FLUSH_MS / VAD_SAMPLE_MS);
@@ -96,6 +100,26 @@ function getCurrentRms(): number {
   }
 
   return Math.sqrt(sumSquares / buffer.length);
+}
+
+function sampleAndSendWaveform() {
+  if (!analyserNode || !mediaRecorder || mediaRecorder.state !== "recording" || isStopping) return;
+
+  const buffer = new Uint8Array(analyserNode.fftSize);
+  analyserNode.getByteTimeDomainData(buffer);
+
+  const bucketSize = Math.floor(buffer.length / WAVEFORM_BUCKETS);
+  const buckets: number[] = [];
+
+  for (let i = 0; i < WAVEFORM_BUCKETS; i++) {
+    let sum = 0;
+    for (let j = 0; j < bucketSize; j++) {
+      sum += Math.abs((buffer[i * bucketSize + j] - 128) / 128);
+    }
+    buckets.push(Math.min(1, (sum / bucketSize) * WAVEFORM_GAIN));
+  }
+
+  chrome.runtime.sendMessage({ type: "WAVEFORM_DATA", buckets }).catch(() => {});
 }
 
 async function flushAudioChunk(force = false) {
@@ -199,6 +223,11 @@ async function cleanupResources() {
   mediaStream = null;
   microphoneStream = null;
   recorderStream = null;
+
+  if (waveformTimer) {
+    clearInterval(waveformTimer);
+    waveformTimer = null;
+  }
 
   if (audioContext) {
     try {
@@ -306,6 +335,10 @@ async function startCapture(
 
   audioContext = new AudioContext();
 
+  if (audioContext.state === "suspended") {
+    await audioContext.resume();
+  }
+
   const destination = audioContext.createMediaStreamDestination();
 
   analyserNode = audioContext.createAnalyser();
@@ -356,6 +389,8 @@ async function startCapture(
 
   // Continuous mode: no timeslice argument — we control flush timing via VAD.
   mediaRecorder.start();
+
+  waveformTimer = setInterval(sampleAndSendWaveform, WAVEFORM_INTERVAL_MS);
 
   voiceActivity = new VoiceActivityTracker({
     rmsThreshold: rmsThreshold,
@@ -418,6 +453,11 @@ async function stopCapture() {
     if (vadTimer) {
       clearInterval(vadTimer);
       vadTimer = null;
+    }
+
+    if (waveformTimer) {
+      clearInterval(waveformTimer);
+      waveformTimer = null;
     }
 
     if (mediaRecorder && mediaRecorder.state !== "inactive") {


### PR DESCRIPTION
Fixes #43

  ## What changed

  Adds a live audio waveform visualizer to the Overview tab of the dashboard panel,
  giving users a clear real-time signal that audio is actively being captured.

  ### `src/offscreen.ts`
  - Added a 50ms waveform sampling loop (separate from the 250ms VAD loop) that reads
    `getByteTimeDomainData()` from the existing `analyserNode`
  - Compresses 1024 raw samples into 32 amplitude buckets with a 6× gain factor
    (normal speech occupies only 5–15% of the raw scale; gain makes bars clearly visible)
  - Sends `WAVEFORM_DATA` to the background for relay; loop guards against `isStopping`
    and inactive recorder state so there is zero overhead at idle
  - Adds `audioContext.resume()` guard to handle Chrome's background-context autoplay
    suspension policy

  ### `src/background.ts`
  - Added `WAVEFORM_DATA` handler that relays the bucket payload to all extension pages
    via `chrome.runtime.sendMessage` (same pattern as `STATE_UPDATE`); a `_relayed` flag
    prevents the background from re-forwarding its own broadcast in a loop

  ### `src/dashboard.html`
  - Added an Audio Input card at the top of the Overview tab containing a `<canvas>`
    element and a status badge (`IDLE` / `LIVE`)

  ### `src/dashboard.ts`
  - Canvas is sized HiDPI-aware (`offsetWidth × devicePixelRatio`) with a matching
    `ctx.scale(dpr, dpr)` so all drawing uses CSS-pixel coordinates
  - `drawIdleWaveform()` renders 32 dim flat bars when no audio is flowing
  - `drawWaveform()` renders 32 symmetric bars with height and opacity driven by amplitude;
    exponential moving-average smoothing (`α = 0.55`) removes jitter between 50ms frames
  - Requests microphone permission via `getUserMedia` inside the "Start Audio" user-gesture
    handler so the offscreen document can inherit the grant (Chrome requires permission to
    be seeded from a visible extension page)
  - `WAVEFORM_DATA` messages flip the badge to `LIVE`; `STATE_UPDATE` with
    `audioActive = false` resets smoothed state, redraws the idle flat-line, and flips
    the badge back to `IDLE`

  ### `src/dashboard.css`
  - Added `.waveform-canvas` and `.waveform-status-badge` / `.waveform-status-badge.active`
    following the existing monochromatic design system (dim-grey idle → white-on-black live)

  ## How to test

  1. `npm run build` → reload extension at `chrome://extensions/`
  2. Open a Google Meet tab and open the Late-Meet side panel
  3. Click **Start Audio** — grant the microphone permission prompt that appears
  4. Speak: the Audio Input card at the top of Overview should show animated white bars
     that grow with voice and shrink during silence
  5. The status badge transitions `IDLE → LIVE` on first audio frame and back to
     `IDLE` when capture stops



Verification recording of the working code: (had to make the video fast and compressed because gh only lets video upload upto less 10mb or so) sorry for the bad recording but everything works, thank you for assigning

https://github.com/user-attachments/assets/378dd758-bbc4-4f11-aab1-ad9650a7c6a5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added audio waveform visualizer to the dashboard's Overview tab that displays real-time audio input levels in an "Audio Input" card.
* Waveform visualizer includes idle and live animation states based on microphone activity status.
* Integrated microphone permission handling into the audio capture workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/63?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->