### PR TITLE
fix: allow users to clear API keys from settings

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -190,8 +190,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       settings: newSettings,
     };
 
-    if (openaiKey) saveData.openai_api_key = openaiKey;
-    if (elevenlabsKey) saveData.elevenlabs_api_key = elevenlabsKey;
+    saveData.openai_api_key = openaiKey || "";
+    saveData.elevenlabs_api_key = elevenlabsKey || "";
 
     await chrome.storage.local.set(saveData);
 


### PR DESCRIPTION
Fixed an issue where users were unable to delete their OpenAI and ElevenLabs API keys from the options page because empty string values were silently ignored during the save operation.

@shouri123 Please review this PR!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API key storage handling to ensure API credentials are consistently persisted in settings, even when empty.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->