### PR TITLE
fix: reset floating button state when dashboard closes

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -324,7 +324,7 @@ initTheme();
     }
 
     if (message?.type === "STATE_UPDATE") {
-      const btn = document.getElementById("late-meet-floating-btn");
+      const btn = document.getElementById("late-meet-floating-btn") as HTMLButtonElement | null;
       if (btn && message.state.isActive) {
         btn.style.display = "none";
       } else if (btn && !message.state.isActive) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -325,9 +325,10 @@ initTheme();
 
     if (message?.type === "STATE_UPDATE") {
       const btn = document.getElementById("late-meet-floating-btn") as HTMLButtonElement | null;
-      if (btn && message.state.isActive) {
+      const isActive = message.state?.isActive;
+      if (btn && isActive) {
         btn.style.display = "none";
-      } else if (btn && !message.state.isActive) {
+      } else if (btn && !isActive) {
         btn.style.display = "flex";
         btn.disabled = false;
         const textSpan = btn.querySelector(".late-meet-btn-text");

--- a/src/content.ts
+++ b/src/content.ts
@@ -329,6 +329,9 @@ initTheme();
         btn.style.display = "none";
       } else if (btn && !message.state.isActive) {
         btn.style.display = "flex";
+        btn.disabled = false;
+        const textSpan = btn.querySelector(".late-meet-btn-text");
+        if (textSpan) textSpan.textContent = "Start Copilot";
       }
       sendResponse({ success: true });
       return false;


### PR DESCRIPTION
Fixed a UI state bug where the injected floating 'Start Copilot' button would remain permanently disabled with the text 'Opening Copilot...' if the user closed the side panel and the button reappeared.

@shouri123 Please review this PR!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Copilot floating button failed to properly enable and display the correct label when becoming inactive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->