### PR TITLE
fix: prevent meeting timer from freezing during rapid updates

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -153,7 +153,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let timerInterval: number | NodeJS.Timeout | null = null;
 
   function startTimer(startTime: number) {
-    if (timerInterval) clearInterval(timerInterval as any);
+    if (timerInterval) return;
     timerInterval = setInterval(() => {
       const elapsed = Math.round((Date.now() - startTime) / 1000);
       const timerEl = document.getElementById("dash-timer");

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -259,7 +259,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let durationInterval: number | NodeJS.Timeout | null = null;
 
   function startDurationTimer(startTime: number) {
-    if (durationInterval) clearInterval(durationInterval as any);
+    if (durationInterval) return;
 
     durationInterval = setInterval(() => {
       const elapsed = Math.round((Date.now() - startTime) / 1000);


### PR DESCRIPTION
Fixes the bug where rapid STATE_UPDATE messages would continually reset the setInterval, freezing the clock. @shouri123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timer handling to prevent unnecessary restarting of operations already in progress, enhancing reliability and efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->