### PR TITLE
feat: Add Markdown download button for saved sessions

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -822,7 +822,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   }
 
-  function exportSessionMarkdown(session: State) {
+  function generateSessionMarkdown(session: State): string {
     let md = `# Meeting Summary\n\n`;
     md += `**Date:** ${new Date((session as any).savedAt || session.startTime).toLocaleString()}\n`;
     md += `**Duration:** ${formatDuration(session.duration || 0)}\n`;
@@ -851,6 +851,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         md += "\n";
       });
     }
+    return md;
+  }
+
+  function exportSessionMarkdown(session: State) {
+    const md = generateSessionMarkdown(session);
 
     navigator.clipboard
       .writeText(md)
@@ -864,35 +869,9 @@ document.addEventListener("DOMContentLoaded", async () => {
         );
       });
   }
-  function downloadSessionMarkdown(session: State) {
-    let md = `# Meeting Summary\n\n`;
-    md += `**Date:** ${new Date((session as any).savedAt || session.startTime).toLocaleString()}\n`;
-    md += `**Duration:** ${formatDuration(session.duration || 0)}\n`;
-    md += `**Meeting ID:** ${session.meetingId || "N/A"}\n`;
-    md += `**Participants:** ${session.participants?.join(", ") || "N/A"}\n\n`;
-    md += `## Summary\n${session.summary || "N/A"}\n\n`;
 
-    if (session.topics?.length) {
-      md += `## Topics\n`;
-      session.topics.forEach((t: Topic) => (md += `- ${t.name} (${t.status})\n`));
-      md += "\n";
-    }
-    if (session.decisions?.length) {
-      md += `## Decisions\n`;
-      session.decisions.forEach(
-        (d: Decision) => (md += `- ${d.text}${d.by ? ` — ${d.by}` : ""}\n`),
-      );
-      md += "\n";
-    }
-    if (session.actionItems?.length) {
-      md += `## Action Items\n`;
-      session.actionItems.forEach((a: ActionItem) => {
-        md += `- [ ] ${a.task}`;
-        if (a.owner) md += ` → ${a.owner}`;
-        if (a.deadline) md += ` (due: ${a.deadline})`;
-        md += "\n";
-      });
-    }
+  function downloadSessionMarkdown(session: State) {
+    const md = generateSessionMarkdown(session);
 
     const filename = `meeting-summary-${new Date((session as any).savedAt || session.startTime).toISOString().slice(0, 10)}.md`;
     downloadFile(md, filename, "text/markdown");

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -774,6 +774,10 @@ document.addEventListener("DOMContentLoaded", async () => {
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" x2="12" y1="15" y2="3"></line></svg>
                 Export
               </button>
+              <button class="session-export-btn session-download-btn" data-session-id="${s.id}" title="Download as Markdown File">
+                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" x2="12" y1="15" y2="3"></line></svg>
+                Download
+              </button>
               <button class="session-delete-btn" data-session-id="${s.id}" title="Delete session">
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
                 Delete
@@ -785,11 +789,21 @@ document.addEventListener("DOMContentLoaded", async () => {
         .join("");
 
       // Wire up export buttons
-      container.querySelectorAll<HTMLButtonElement>(".session-export-btn").forEach((btn) => {
+      container
+        .querySelectorAll<HTMLButtonElement>(".session-export-btn:not(.session-download-btn)")
+        .forEach((btn) => {
+          btn.addEventListener("click", () => {
+            const sessionId = btn.dataset.sessionId;
+            const session = sessions.find((s: State) => (s as any).id === sessionId);
+            if (session) exportSessionMarkdown(session);
+          });
+        });
+
+      container.querySelectorAll<HTMLButtonElement>(".session-download-btn").forEach((btn) => {
         btn.addEventListener("click", () => {
           const sessionId = btn.dataset.sessionId;
           const session = sessions.find((s: State) => (s as any).id === sessionId);
-          if (session) exportSessionMarkdown(session);
+          if (session) downloadSessionMarkdown(session);
         });
       });
 
@@ -849,6 +863,40 @@ document.addEventListener("DOMContentLoaded", async () => {
           "error",
         );
       });
+  }
+  function downloadSessionMarkdown(session: State) {
+    let md = `# Meeting Summary\n\n`;
+    md += `**Date:** ${new Date((session as any).savedAt || session.startTime).toLocaleString()}\n`;
+    md += `**Duration:** ${formatDuration(session.duration || 0)}\n`;
+    md += `**Meeting ID:** ${session.meetingId || "N/A"}\n`;
+    md += `**Participants:** ${session.participants?.join(", ") || "N/A"}\n\n`;
+    md += `## Summary\n${session.summary || "N/A"}\n\n`;
+
+    if (session.topics?.length) {
+      md += `## Topics\n`;
+      session.topics.forEach((t: Topic) => (md += `- ${t.name} (${t.status})\n`));
+      md += "\n";
+    }
+    if (session.decisions?.length) {
+      md += `## Decisions\n`;
+      session.decisions.forEach(
+        (d: Decision) => (md += `- ${d.text}${d.by ? ` — ${d.by}` : ""}\n`),
+      );
+      md += "\n";
+    }
+    if (session.actionItems?.length) {
+      md += `## Action Items\n`;
+      session.actionItems.forEach((a: ActionItem) => {
+        md += `- [ ] ${a.task}`;
+        if (a.owner) md += ` → ${a.owner}`;
+        if (a.deadline) md += ` (due: ${a.deadline})`;
+        md += "\n";
+      });
+    }
+
+    const filename = `meeting-summary-${new Date((session as any).savedAt || session.startTime).toISOString().slice(0, 10)}.md`;
+    downloadFile(md, filename, "text/markdown");
+    showToast("Downloaded as .md file", "success");
   }
 
   // Load sessions on tab switch


### PR DESCRIPTION
## Description

This PR introduces a dedicated "Download" button next to each past session in the "Saved Sessions" history tab. It allows users to download their archived meeting summaries directly as formatted Markdown (`.md`) files with one click, while cleanly retaining the existing clipboard copy option.

### Changes made

* **New Download Button:** Added a dedicated `session-download-btn` next to the `session-export-btn` inside the dynamic Saved Sessions item template in `src/dashboard.ts`.
* **Zero-CSS Class Sharing:** Reused the existing `.session-export-btn` styling to style the new download button natively and beautifully with zero changes to `dashboard.css`.
*  **File Download Handler:** Added the `downloadSessionMarkdown` helper function in `src/dashboard.ts` to trigger a standard Markdown file 
* **Event Selector Isolation:** Updated the event listener selector in `dashboard.ts` to `.session-export-btn:not(.session-download-btn)` to prevent click events from double-triggering the clipboard copy action on the download button.

Fixes #55 

---

## Type of Change

* [x] ✨ New feature (non-breaking change which adds functionality)

---

## How Has This Been Tested?

* [x] Built the extension using `npm run build`
* [x] Loaded the static extension package in Chrome and tested manually
* [x] Injected mock session data into `chrome.storage.local` to verify dynamic listing render
* [x] Verified file downloads compile all metadata accurately with matching date timestamps
* [x] Confirmed zero console errors or style glitches

@shouri123 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now download session data as markdown files directly from the dashboard, while the existing copy-to-clipboard export functionality remains available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/72?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->