### PR TITLE
feat: Add loading states and duplicate submission prevention during meeting creation #74

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -625,21 +625,60 @@ async function savePendingSession() {
   await chrome.storage.local.set({ pendingSession: session });
 }
 
-async function persistSession() {
-  const { pendingSession, savedSessions } = await chrome.storage.local.get([
-    "pendingSession",
-    "savedSessions",
-  ]);
-  if (!pendingSession) return;
+let isProcessingSession = false;
 
-  const sessions = Array.isArray(savedSessions) ? savedSessions : [];
-  sessions.unshift(pendingSession);
-  await chrome.storage.local.set({ savedSessions: sessions, pendingSession: null });
+async function persistSession() {
+  if (isProcessingSession) {
+    console.log("[LateMeet] Already processing session, ignoring duplicate save request.");
+    return;
+  }
+  isProcessingSession = true;
+  try {
+    const { pendingSession, savedSessions } = await chrome.storage.local.get([
+      "pendingSession",
+      "savedSessions",
+    ]);
+    if (!pendingSession) {
+      console.log("[LateMeet] No pending session found to save.");
+      return;
+    }
+
+    const sessions = Array.isArray(savedSessions) ? savedSessions : [];
+
+    // Check if the session ID already exists in savedSessions to prevent duplicate entries
+    const sessionExists = sessions.some((s: any) => s.id === pendingSession.id);
+    if (sessionExists) {
+      console.log("[LateMeet] Session already persisted, ignoring duplicate save.");
+      return;
+    }
+
+    sessions.unshift(pendingSession);
+    await chrome.storage.local.set({ savedSessions: sessions, pendingSession: null });
+    console.log("[LateMeet] Session successfully saved:", pendingSession.id);
+  } catch (err) {
+    console.error("[LateMeet] Error persisting session:", err);
+  } finally {
+    isProcessingSession = false;
+  }
 }
 
 async function discardPendingSession() {
-  await chrome.storage.local.set({ pendingSession: null });
+  if (isProcessingSession) {
+    console.log("[LateMeet] Already processing session, ignoring duplicate discard request.");
+    return;
+  }
+  isProcessingSession = true;
+  try {
+    await chrome.storage.local.set({ pendingSession: null });
+    console.log("[LateMeet] Pending session discarded.");
+  } catch (err) {
+    console.error("[LateMeet] Error discarding session:", err);
+  } finally {
+    isProcessingSession = false;
+  }
 }
+
+let isStartingAudio = false;
 
 async function startAudioCapture(
   tabId: number,
@@ -649,22 +688,31 @@ async function startAudioCapture(
   includeMicrophone = true,
 ) {
   if (!tabId) throw new Error("Missing target tab id");
-
-  await ensureOffscreenDocument();
+  if (state.audioActive) {
+    console.log("[LateMeet] Audio already active, skipping start request.");
+    return;
+  }
+  if (isStartingAudio) {
+    console.log("[LateMeet] Audio start already in progress, skipping start request.");
+    return;
+  }
+  isStartingAudio = true;
 
   const createdSession = !state.isActive;
 
-  if (createdSession) {
-    resetState();
-    state.isActive = true;
-    state.startTime = Date.now();
-    state.meetingId = meetingId || "unknown";
-    state.meetingUrl = meetingUrl || null;
-    state.targetTabId = tabId;
-    addTimeline(`Meeting started (${state.meetingId})`);
-  }
-
   try {
+    await ensureOffscreenDocument();
+
+    if (createdSession) {
+      resetState();
+      state.isActive = true;
+      state.startTime = Date.now();
+      state.meetingId = meetingId || "unknown";
+      state.meetingUrl = meetingUrl || null;
+      state.targetTabId = tabId;
+      addTimeline(`Meeting started (${state.meetingId})`);
+    }
+
     let streamId = providedStreamId;
 
     if (!streamId) {
@@ -718,6 +766,8 @@ async function startAudioCapture(
       await broadcastStateUpdate();
     }
     throw err;
+  } finally {
+    isStartingAudio = false;
   }
 }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -648,7 +648,8 @@ async function persistSession() {
     // Check if the session ID already exists in savedSessions to prevent duplicate entries
     const sessionExists = sessions.some((s: any) => s.id === pendingSession.id);
     if (sessionExists) {
-      console.log("[LateMeet] Session already persisted, ignoring duplicate save.");
+      await chrome.storage.local.set({ pendingSession: null });
+      console.log("[LateMeet] Session already persisted, cleared pending session.");
       return;
     }
 

--- a/src/popup.css
+++ b/src/popup.css
@@ -800,3 +800,14 @@ body::-webkit-scrollbar-thumb {
   color: var(--text-main);
   border-color: var(--border-sub);
 }
+
+.session-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  filter: grayscale(0.5);
+}
+
+.session-btn.loading {
+  cursor: wait;
+  pointer-events: none;
+}

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -207,6 +207,18 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ——— Session Save/Discard Modal ———
   function showSessionModal() {
+    const saveBtn = document.getElementById("save-session-btn") as HTMLButtonElement | null;
+    const discardBtn = document.getElementById("discard-session-btn") as HTMLButtonElement | null;
+    if (saveBtn) {
+      saveBtn.disabled = false;
+      saveBtn.textContent = "Save Session";
+      saveBtn.classList.remove("loading");
+    }
+    if (discardBtn) {
+      discardBtn.disabled = false;
+      discardBtn.textContent = "Discard";
+      discardBtn.classList.remove("loading");
+    }
     sessionModal.style.display = "flex";
     requestAnimationFrame(() => sessionModal.classList.add("visible"));
   }
@@ -218,14 +230,58 @@ document.addEventListener("DOMContentLoaded", async () => {
     }, 300);
   }
 
-  document.getElementById("save-session-btn")?.addEventListener("click", async () => {
-    await chrome.runtime.sendMessage({ type: "SAVE_SESSION" });
-    hideSessionModal();
+  document.getElementById("save-session-btn")?.addEventListener("click", async (e) => {
+    const btn = e.currentTarget as HTMLButtonElement;
+    const discardBtn = document.getElementById("discard-session-btn") as HTMLButtonElement | null;
+    const originalText = btn.textContent || "Save Session";
+
+    btn.disabled = true;
+    btn.textContent = "Saving...";
+    btn.classList.add("loading");
+    if (discardBtn) {
+      discardBtn.disabled = true;
+    }
+
+    try {
+      await chrome.runtime.sendMessage({ type: "SAVE_SESSION" });
+      hideSessionModal();
+    } catch (err) {
+      console.error("[LateMeet] Failed to save session:", err);
+      // Restore states on error
+      btn.disabled = false;
+      btn.textContent = originalText;
+      btn.classList.remove("loading");
+      if (discardBtn) {
+        discardBtn.disabled = false;
+      }
+    }
   });
 
-  document.getElementById("discard-session-btn")?.addEventListener("click", async () => {
-    await chrome.runtime.sendMessage({ type: "DISCARD_SESSION" });
-    hideSessionModal();
+  document.getElementById("discard-session-btn")?.addEventListener("click", async (e) => {
+    const btn = e.currentTarget as HTMLButtonElement;
+    const saveBtn = document.getElementById("save-session-btn") as HTMLButtonElement | null;
+    const originalText = btn.textContent || "Discard";
+
+    btn.disabled = true;
+    btn.textContent = "Discarding...";
+    btn.classList.add("loading");
+    if (saveBtn) {
+      saveBtn.disabled = true;
+    }
+
+    try {
+      await chrome.runtime.sendMessage({ type: "DISCARD_SESSION" });
+      hideSessionModal();
+    } catch (err) {
+      console.error("[LateMeet] Failed to discard session:", err);
+      // Restore states on error
+      btn.disabled = false;
+      btn.textContent = originalText;
+      btn.classList.remove("loading");
+      if (saveBtn) {
+        saveBtn.disabled = false;
+      }
+    }
   });
 
   // ——— Check for pending session on load ———


### PR DESCRIPTION
Solved #74: Added loading states and duplicate submission prevention for meeting creation (persisting sessions) in both the background service worker and frontend popup UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session save/discard flows show loading states and manage button states to prevent duplicate actions.

* **Bug Fixes**
  * Prevented duplicate session storage and concurrent save/discard operations.
  * Stopped repeated audio capture/start attempts by guarding against concurrent starts.

* **Style**
  * Improved button styles for disabled and loading states (cursor, opacity, and visual feedback).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->