### PR TITLE
feat: interactive action item checklist with Chrome notification alerts

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -470,14 +470,6 @@ Return a JSON object with these exact keys:
 
   const parsed = JSON.parse(content);
   state.summary = parsed.summary || state.summary;
-  state.topics = Array.isArray(parsed.topics) ? parsed.topics : state.topics;
-  state.decisions = Array.isArray(parsed.decisions) ? parsed.decisions : state.decisions;
-  if (Array.isArray(parsed.actionItems)) {
-    state.actionItems = parsed.actionItems;
-    notifyNewActionItems(state.actionItems);
-  }
-  state.currentTopic = parsed.currentTopic || state.currentTopic;
-  state.sentiment = parsed.sentiment || state.sentiment;
   if (topicDetectionEnabled) {
     state.topics = Array.isArray(parsed.topics) ? parsed.topics : state.topics;
     state.currentTopic = parsed.currentTopic || state.currentTopic;
@@ -491,7 +483,10 @@ Return a JSON object with these exact keys:
     state.decisions = [];
   }
   if (actionExtractionEnabled) {
-    state.actionItems = Array.isArray(parsed.actionItems) ? parsed.actionItems : state.actionItems;
+    if (Array.isArray(parsed.actionItems)) {
+      state.actionItems = parsed.actionItems;
+      notifyNewActionItems(state.actionItems);
+    }
   } else {
     state.actionItems = [];
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,7 +1,4 @@
 // MV3 service worker for Late Meet
-import { initTheme } from "./theme.js";
-
-initTheme();
 
 const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
@@ -15,7 +12,6 @@ const ELEVENLABS_STT_MODEL = "scribe_v2";
 // Delay late-joiner auto messages until 10s to avoid lobby/join churn spam.
 const MIN_MEETING_DURATION_FOR_WELCOME = 10;
 
-import { State, ActionItem } from "./types";
 import { ActionItem, Decision, State } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
 import { getElevenLabsApiKey, getOpenAiApiKey } from "./utils/credentials";

--- a/src/background.ts
+++ b/src/background.ts
@@ -517,24 +517,21 @@ function notifyNewActionItems(items: ActionItem[]) {
     if (!key || notifiedActionItems.has(key)) continue;
     const message = key.length > 100 ? key.slice(0, 97) + "..." : key;
     const notifId = `lm-action-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
-    chrome.notifications.create(notifId, {
-      type: "basic",
-      iconUrl: chrome.runtime.getURL("src/icons/icon128.png"),
-      title: "New Action Item",
-      message,
-      priority: 1,
-    chrome.notifications.create(notifId, {
-      type: "basic",
-      iconUrl: chrome.runtime.getURL("src/icons/icon128.png"),
-      title: "New Action Item",
-      message,
-      priority: 1,
-    }, () => {
-      if (!chrome.runtime.lastError) {
-        notifiedActionItems.add(key);
-      }
-    });
-    });
+    chrome.notifications.create(
+      notifId,
+      {
+        type: "basic",
+        iconUrl: chrome.runtime.getURL("src/icons/icon128.png"),
+        title: "New Action Item",
+        message,
+        priority: 1,
+      },
+      () => {
+        if (!chrome.runtime.lastError) {
+          notifiedActionItems.add(key);
+        }
+      },
+    );
   }
 }
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -519,11 +519,19 @@ function notifyNewActionItems(items: ActionItem[]) {
   for (const item of items) {
     const key = actionItemKey(item);
     if (!key || notifiedActionItems.has(key)) continue;
-    notifiedActionItems.add(key);
     const message = key.length > 100 ? key.slice(0, 97) + "..." : key;
     const notifId = `lm-action-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     chrome.notifications.create(notifId, {
       type: "basic",
+      iconUrl: chrome.runtime.getURL("src/icons/icon128.png"),
+      title: "New Action Item",
+      message,
+      priority: 1,
+    }, () => {
+      if (!chrome.runtime.lastError) {
+        notifiedActionItems.add(key);
+      }
+    });
       iconUrl: chrome.runtime.getURL("src/icons/icon128.png"),
       title: "New Action Item",
       message,

--- a/src/background.ts
+++ b/src/background.ts
@@ -12,7 +12,7 @@ const ELEVENLABS_STT_MODEL = "scribe_v2";
 // Delay late-joiner auto messages until 10s to avoid lobby/join churn spam.
 const MIN_MEETING_DURATION_FOR_WELCOME = 10;
 
-import { State } from "./types";
+import { State, ActionItem } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
 
 const state: State = {
@@ -41,6 +41,7 @@ const state: State = {
 };
 
 let selfParticipantName: string | null = null;
+const notifiedActionItems = new Set<string>();
 
 function normalizeParticipantName(value: string | null | undefined): string {
   return String(value || "")
@@ -72,6 +73,7 @@ function resetState() {
   state.pendingJoiners.clear();
   state.participantCount = 0;
   selfParticipantName = null;
+  notifiedActionItems.clear();
 }
 
 function addTimeline(event: string) {
@@ -431,7 +433,10 @@ Return a JSON object with these exact keys:
   state.summary = parsed.summary || state.summary;
   state.topics = Array.isArray(parsed.topics) ? parsed.topics : state.topics;
   state.decisions = Array.isArray(parsed.decisions) ? parsed.decisions : state.decisions;
-  state.actionItems = Array.isArray(parsed.actionItems) ? parsed.actionItems : state.actionItems;
+  if (Array.isArray(parsed.actionItems)) {
+    state.actionItems = parsed.actionItems;
+    notifyNewActionItems(state.actionItems);
+  }
   state.currentTopic = parsed.currentTopic || state.currentTopic;
   state.sentiment = parsed.sentiment || state.sentiment;
   state.keyInsights = Array.isArray(parsed.keyInsights) ? parsed.keyInsights : state.keyInsights;
@@ -439,6 +444,31 @@ Return a JSON object with these exact keys:
     ? parsed.questionsRaised
     : state.questionsRaised;
   state.lastSummarizedAt = Date.now();
+}
+
+function actionItemKey(item: ActionItem | unknown): string {
+  if (item && typeof item === "object" && "task" in (item as object)) {
+    return ((item as ActionItem).task || "").trim();
+  }
+  return String(item || "").trim();
+}
+
+function notifyNewActionItems(items: ActionItem[]) {
+  if (!chrome.notifications) return;
+  for (const item of items) {
+    const key = actionItemKey(item);
+    if (!key || notifiedActionItems.has(key)) continue;
+    notifiedActionItems.add(key);
+    const message = key.length > 100 ? key.slice(0, 97) + "..." : key;
+    const notifId = `lm-action-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    chrome.notifications.create(notifId, {
+      type: "basic",
+      iconUrl: chrome.runtime.getURL("src/icons/icon128.png"),
+      title: "New Action Item",
+      message,
+      priority: 1,
+    });
+  }
 }
 
 function detectNewJoiners(currentList: string[]) {

--- a/src/background.ts
+++ b/src/background.ts
@@ -527,15 +527,17 @@ function notifyNewActionItems(items: ActionItem[]) {
       title: "New Action Item",
       message,
       priority: 1,
+    chrome.notifications.create(notifId, {
+      type: "basic",
+      iconUrl: chrome.runtime.getURL("src/icons/icon128.png"),
+      title: "New Action Item",
+      message,
+      priority: 1,
     }, () => {
       if (!chrome.runtime.lastError) {
         notifiedActionItems.add(key);
       }
     });
-      iconUrl: chrome.runtime.getURL("src/icons/icon128.png"),
-      title: "New Action Item",
-      message,
-      priority: 1,
     });
   }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -509,9 +509,10 @@ Return a JSON object with these exact keys:
 
 function actionItemKey(item: ActionItem | unknown): string {
   if (item && typeof item === "object" && "task" in (item as object)) {
-    return ((item as ActionItem).task || "").trim();
+    const task = (item as { task?: unknown }).task;
+    return String(task ?? "").trim();
   }
-  return String(item || "").trim();
+  return String(item ?? "").trim();
 }
 
 function notifyNewActionItems(items: ActionItem[]) {

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -502,7 +502,9 @@ body::-webkit-scrollbar-thumb {
   border-radius: 8px;
 }
 
-.action-check {
+.action-checkbox {
+  appearance: none;
+  -webkit-appearance: none;
   width: 18px;
   height: 18px;
   border: 1px solid #525252;
@@ -510,16 +512,48 @@ body::-webkit-scrollbar-thumb {
   flex-shrink: 0;
   margin-top: 2px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition:
+    border-color 0.2s ease,
+    background 0.2s ease;
+  position: relative;
+  background: transparent;
 }
 
-.action-check:hover {
+.action-checkbox:hover {
   border-color: #fafafa;
   background: #171717;
 }
 
+.action-checkbox:checked {
+  background: #ffffff;
+  border-color: #ffffff;
+}
+
+.action-checkbox:checked::after {
+  content: "";
+  position: absolute;
+  left: 4px;
+  top: 1px;
+  width: 5px;
+  height: 9px;
+  border: 2px solid #000000;
+  border-top: none;
+  border-left: none;
+  transform: rotate(45deg);
+}
+
+.action-item--done {
+  opacity: 0.6;
+}
+
+.action-task--done {
+  text-decoration: line-through;
+  color: #525252 !important;
+}
+
 .action-info {
   flex: 1;
+  cursor: pointer;
 }
 
 .action-task {

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -524,9 +524,6 @@ body::-webkit-scrollbar-thumb,
 .action-checkbox:hover {
   border-color: #fafafa;
   background: #171717;
-.action-check:hover {
-  border-color: var(--text-main);
-  background: var(--bg-card);
 }
 
 .action-checkbox:checked {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -648,7 +648,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (state.actionItems?.length) {
       markdown += `## Action Items\n`;
       state.actionItems.forEach((a: ActionItem) => {
-        markdown += `- [ ] ${a.task}`;
+        const task = resolveActionKey(a);
+        const done = actionStatuses.get(task) === true;
+        markdown += done ? `- [x] ${task}` : `- [ ] ${task}`;
         if (a.owner) markdown += ` → ${a.owner}`;
         if (a.deadline) markdown += ` (due: ${a.deadline})`;
         markdown += "\n";
@@ -687,17 +689,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   const exportBtn = document.getElementById("export-btn") as HTMLButtonElement;
   const exportDropdown = document.getElementById("export-dropdown") as HTMLDivElement;
 
-  if (state.actionItems?.length) {
-    markdown += `## Action Items\n`;
-    state.actionItems.forEach((a: ActionItem) => {
-      const task = resolveActionKey(a);
-      const done = actionStatuses.get(task) === true;
-      markdown += done ? `- [x] ${task}` : `- [ ] ${task}`;
-      if (a.owner) markdown += ` → ${a.owner}`;
-      if (a.deadline) markdown += ` (due: ${a.deadline})`;
-      markdown += "\n";
-    });
-  }
   exportBtn?.addEventListener("click", () => {
     const isHidden = exportDropdown.hasAttribute("hidden");
     if (isHidden) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -687,17 +687,17 @@ document.addEventListener("DOMContentLoaded", async () => {
   const exportBtn = document.getElementById("export-btn") as HTMLButtonElement;
   const exportDropdown = document.getElementById("export-dropdown") as HTMLDivElement;
 
-      if (state.actionItems?.length) {
-        markdown += `## Action Items\n`;
-        state.actionItems.forEach((a: ActionItem) => {
-          const task = resolveActionKey(a);
-          const done = actionStatuses.get(task) === true;
-          markdown += done ? `- [x] ${task}` : `- [ ] ${task}`;
-          if (a.owner) markdown += ` → ${a.owner}`;
-          if (a.deadline) markdown += ` (due: ${a.deadline})`;
-          markdown += "\n";
-        });
-      }
+  if (state.actionItems?.length) {
+    markdown += `## Action Items\n`;
+    state.actionItems.forEach((a: ActionItem) => {
+      const task = resolveActionKey(a);
+      const done = actionStatuses.get(task) === true;
+      markdown += done ? `- [x] ${task}` : `- [ ] ${task}`;
+      if (a.owner) markdown += ` → ${a.owner}`;
+      if (a.deadline) markdown += ` (due: ${a.deadline})`;
+      markdown += "\n";
+    });
+  }
   exportBtn?.addEventListener("click", () => {
     const isHidden = exportDropdown.hasAttribute("hidden");
     if (isHidden) {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -5,30 +5,56 @@ initTheme();
 
 // ——— Action Item Status Persistence ———
 const actionStatuses = new Map<string, boolean>();
+let currentMeetingId = "unknown";
 
 function resolveActionKey(item: ActionItem | unknown): string {
   if (item && typeof item === "object" && "task" in (item as object)) {
-    return ((item as ActionItem).task || "").trim();
+    const task = (item as { task?: unknown }).task;
+    return String(task ?? "").trim();
   }
-  return String(item || "").trim();
+  return String(item ?? "").trim();
+}
+
+function buildActionStatusKey(meetingId: string, task: string): string {
+  return `${meetingId}::${task}`;
+}
+
+function normalizeActionItem(input: unknown): ActionItem | null {
+  if (!input || typeof input !== "object") return null;
+  const raw = input as { task?: unknown; owner?: unknown; deadline?: unknown };
+  const task = String(raw.task ?? "").trim();
+  if (!task) return null;
+  return {
+    task,
+    owner: String(raw.owner ?? "").trim() || undefined,
+    deadline: String(raw.deadline ?? "").trim() || undefined,
+  } as ActionItem;
 }
 
 async function loadActionStatuses() {
-  const result = await chrome.storage.local.get("actionItemStatuses");
-  const stored = result.actionItemStatuses;
-  if (stored && typeof stored === "object") {
-    for (const [k, v] of Object.entries(stored as Record<string, unknown>)) {
-      actionStatuses.set(k, Boolean(v));
+  try {
+    const result = await chrome.storage.local.get("actionItemStatuses");
+    const stored = result.actionItemStatuses;
+    if (stored && typeof stored === "object") {
+      for (const [k, v] of Object.entries(stored as Record<string, unknown>)) {
+        actionStatuses.set(k, Boolean(v));
+      }
     }
+  } catch (err) {
+    console.error("[Dashboard] Failed to load action statuses:", err);
   }
 }
 
 async function persistActionStatuses() {
-  const obj: Record<string, boolean> = {};
-  actionStatuses.forEach((v, k) => {
-    obj[k] = v;
-  });
-  await chrome.storage.local.set({ actionItemStatuses: obj });
+  try {
+    const obj: Record<string, boolean> = {};
+    actionStatuses.forEach((v, k) => {
+      obj[k] = v;
+    });
+    await chrome.storage.local.set({ actionItemStatuses: obj });
+  } catch (err) {
+    console.error("[Dashboard] Failed to persist action statuses:", err);
+  }
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -275,6 +301,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ——— Update Dashboard ———
   function updateDashboard(state: State) {
+    currentMeetingId = state.meetingId || "unknown";
     // Status
     const statusDot = document.querySelector(".dash-status-dot");
     const statusText = document.getElementById("dash-status-text");
@@ -421,43 +448,68 @@ document.addEventListener("DOMContentLoaded", async () => {
       return;
     }
 
-    container.innerHTML = actions
-      .map((a, idx) => {
-        const task = resolveActionKey(a);
-        const owner = (a as ActionItem).owner;
-        const deadline = (a as ActionItem).deadline;
-        const done = actionStatuses.get(task) === true;
-        return `
-      <div class="action-item${done ? " action-item--done" : ""}">
-        <input
-          type="checkbox"
-          class="action-checkbox"
-          id="action-cb-${idx}"
-          data-task="${escapeHtml(task)}"
-          ${done ? "checked" : ""}
-          aria-label="Mark task complete"
-        />
-        <label class="action-info" for="action-cb-${idx}">
-          <div class="action-task${done ? " action-task--done" : ""}">${escapeHtml(task)}</div>
-          ${owner ? `<span class="action-owner"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:2px"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>${escapeHtml(owner)}</span>` : ""}
-          ${deadline ? `<div class="action-deadline"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:2px"><rect width="18" height="18" x="3" y="4" rx="2" ry="2"></rect><line x1="16" x2="16" y1="2" y2="6"></line><line x1="8" x2="8" y1="2" y2="6"></line><line x1="3" x2="21" y1="10" y2="10"></line></svg>${escapeHtml(deadline)}</div>` : ""}
-        </label>
-      </div>
-    `;
-      })
-      .join("");
+    container.innerHTML = "";
+    actions.forEach((a, idx) => {
+      const normalized = normalizeActionItem(a);
+      const task = normalized?.task ?? resolveActionKey(a);
+      if (!task) return;
+      const owner = normalized?.owner ?? "";
+      const deadline = normalized?.deadline ?? "";
+      const statusKey = buildActionStatusKey(currentMeetingId, task);
+      const done = actionStatuses.get(statusKey) === true;
+      const cbId = `action-cb-${idx}`;
 
-    container.querySelectorAll<HTMLInputElement>(".action-checkbox").forEach((cb) => {
-      cb.addEventListener("change", () => {
-        const task = cb.dataset.task || "";
-        const done = cb.checked;
-        actionStatuses.set(task, done);
-        persistActionStatuses();
-        const item = cb.closest(".action-item");
-        if (item) item.classList.toggle("action-item--done", done);
-        const taskEl = item?.querySelector(".action-task");
-        if (taskEl) taskEl.classList.toggle("action-task--done", done);
+      const wrapper = document.createElement("div");
+      wrapper.className = "action-item" + (done ? " action-item--done" : "");
+
+      const checkbox = document.createElement("input");
+      checkbox.type = "checkbox";
+      checkbox.className = "action-checkbox";
+      checkbox.id = cbId;
+      checkbox.checked = done;
+      checkbox.setAttribute("aria-label", "Mark task complete");
+      checkbox.dataset.task = task;
+      checkbox.dataset.meetingId = currentMeetingId;
+
+      const label = document.createElement("label");
+      label.className = "action-info";
+      label.htmlFor = cbId;
+
+      const taskDiv = document.createElement("div");
+      taskDiv.className = "action-task" + (done ? " action-task--done" : "");
+      taskDiv.textContent = task;
+      label.appendChild(taskDiv);
+
+      if (owner) {
+        const ownerSpan = document.createElement("span");
+        ownerSpan.className = "action-owner";
+        ownerSpan.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:2px"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>`;
+        ownerSpan.appendChild(document.createTextNode(owner));
+        label.appendChild(ownerSpan);
+      }
+
+      if (deadline) {
+        const deadlineDiv = document.createElement("div");
+        deadlineDiv.className = "action-deadline";
+        deadlineDiv.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:2px"><rect width="18" height="18" x="3" y="4" rx="2" ry="2"></rect><line x1="16" x2="16" y1="2" y2="6"></line><line x1="8" x2="8" y1="2" y2="6"></line><line x1="3" x2="21" y1="10" y2="10"></line></svg>`;
+        deadlineDiv.appendChild(document.createTextNode(deadline));
+        label.appendChild(deadlineDiv);
+      }
+
+      checkbox.addEventListener("change", () => {
+        const taskText = checkbox.dataset.task || "";
+        const meetId = checkbox.dataset.meetingId || currentMeetingId;
+        const key = buildActionStatusKey(meetId, taskText);
+        const isDone = checkbox.checked;
+        actionStatuses.set(key, isDone);
+        void persistActionStatuses();
+        wrapper.classList.toggle("action-item--done", isDone);
+        taskDiv.classList.toggle("action-task--done", isDone);
       });
+
+      wrapper.appendChild(checkbox);
+      wrapper.appendChild(label);
+      container.appendChild(wrapper);
     });
   }
 
@@ -649,7 +701,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       markdown += `## Action Items\n`;
       state.actionItems.forEach((a: ActionItem) => {
         const task = resolveActionKey(a);
-        const done = actionStatuses.get(task) === true;
+        if (!task) return;
+        const statusKey = buildActionStatusKey(currentMeetingId, task);
+        const done = actionStatuses.get(statusKey) === true;
         markdown += done ? `- [x] ${task}` : `- [ ] ${task}`;
         if (a.owner) markdown += ` → ${a.owner}`;
         if (a.deadline) markdown += ` (due: ${a.deadline})`;
@@ -899,10 +953,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       md += "\n";
     }
     if (session.actionItems?.length) {
+      const sessionMeetingId = session.meetingId || "unknown";
       md += `## Action Items\n`;
       session.actionItems.forEach((a: ActionItem) => {
         const task = resolveActionKey(a);
-        const done = actionStatuses.get(task) === true;
+        if (!task) return;
+        const statusKey = buildActionStatusKey(sessionMeetingId, task);
+        const done = actionStatuses.get(statusKey) === true;
         md += done ? `- [x] ${task}` : `- [ ] ${task}`;
         if (a.owner) md += ` → ${a.owner}`;
         if (a.deadline) md += ` (due: ${a.deadline})`;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,6 +1,36 @@
 import { State, Topic, TranscriptEntry, TimelineEvent, Decision, ActionItem } from "./types";
 
+// ——— Action Item Status Persistence ———
+const actionStatuses = new Map<string, boolean>();
+
+function resolveActionKey(item: ActionItem | unknown): string {
+  if (item && typeof item === "object" && "task" in (item as object)) {
+    return ((item as ActionItem).task || "").trim();
+  }
+  return String(item || "").trim();
+}
+
+async function loadActionStatuses() {
+  const result = await chrome.storage.local.get("actionItemStatuses");
+  const stored = result.actionItemStatuses;
+  if (stored && typeof stored === "object") {
+    for (const [k, v] of Object.entries(stored as Record<string, unknown>)) {
+      actionStatuses.set(k, Boolean(v));
+    }
+  }
+}
+
+async function persistActionStatuses() {
+  const obj: Record<string, boolean> = {};
+  actionStatuses.forEach((v, k) => {
+    obj[k] = v;
+  });
+  await chrome.storage.local.set({ actionItemStatuses: obj });
+}
+
 document.addEventListener("DOMContentLoaded", async () => {
+  await loadActionStatuses();
+
   // ——— Tab Switching ———
   const tabs = document.querySelectorAll(".dash-tab");
   const panels = document.querySelectorAll(".tab-panel");
@@ -305,20 +335,45 @@ document.addEventListener("DOMContentLoaded", async () => {
       container.innerHTML = '<div class="empty-msg">No action items detected yet</div>';
       return;
     }
+
     container.innerHTML = actions
-      .map(
-        (a) => `
-      <div class="action-item">
-        <div class="action-check"></div>
-        <div class="action-info">
-          <div class="action-task">${escapeHtml(a.task || "")}</div>
-          ${a.owner ? `<span class="action-owner"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:2px"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>${escapeHtml(a.owner)}</span>` : ""}
-          ${a.deadline ? `<div class="action-deadline"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:2px"><rect width="18" height="18" x="3" y="4" rx="2" ry="2"></rect><line x1="16" x2="16" y1="2" y2="6"></line><line x1="8" x2="8" y1="2" y2="6"></line><line x1="3" x2="21" y1="10" y2="10"></line></svg>${escapeHtml(a.deadline)}</div>` : ""}
-        </div>
+      .map((a, idx) => {
+        const task = resolveActionKey(a);
+        const owner = (a as ActionItem).owner;
+        const deadline = (a as ActionItem).deadline;
+        const done = actionStatuses.get(task) === true;
+        return `
+      <div class="action-item${done ? " action-item--done" : ""}">
+        <input
+          type="checkbox"
+          class="action-checkbox"
+          id="action-cb-${idx}"
+          data-task="${escapeHtml(task)}"
+          ${done ? "checked" : ""}
+          aria-label="Mark task complete"
+        />
+        <label class="action-info" for="action-cb-${idx}">
+          <div class="action-task${done ? " action-task--done" : ""}">${escapeHtml(task)}</div>
+          ${owner ? `<span class="action-owner"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:2px"><path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"></path><circle cx="12" cy="7" r="4"></circle></svg>${escapeHtml(owner)}</span>` : ""}
+          ${deadline ? `<div class="action-deadline"><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right:2px"><rect width="18" height="18" x="3" y="4" rx="2" ry="2"></rect><line x1="16" x2="16" y1="2" y2="6"></line><line x1="8" x2="8" y1="2" y2="6"></line><line x1="3" x2="21" y1="10" y2="10"></line></svg>${escapeHtml(deadline)}</div>` : ""}
+        </label>
       </div>
-    `,
-      )
+    `;
+      })
       .join("");
+
+    container.querySelectorAll<HTMLInputElement>(".action-checkbox").forEach((cb) => {
+      cb.addEventListener("change", () => {
+        const task = cb.dataset.task || "";
+        const done = cb.checked;
+        actionStatuses.set(task, done);
+        persistActionStatuses();
+        const item = cb.closest(".action-item");
+        if (item) item.classList.toggle("action-item--done", done);
+        const taskEl = item?.querySelector(".action-task");
+        if (taskEl) taskEl.classList.toggle("action-task--done", done);
+      });
+    });
   }
 
   // ——— People ———
@@ -515,7 +570,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (state.actionItems?.length) {
         markdown += `## Action Items\n`;
         state.actionItems.forEach((a: ActionItem) => {
-          markdown += `- [ ] ${a.task}`;
+          const task = resolveActionKey(a);
+          const done = actionStatuses.get(task) === true;
+          markdown += done ? `- [x] ${task}` : `- [ ] ${task}`;
           if (a.owner) markdown += ` → ${a.owner}`;
           if (a.deadline) markdown += ` (due: ${a.deadline})`;
           markdown += "\n";
@@ -662,7 +719,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (session.actionItems?.length) {
       md += `## Action Items\n`;
       session.actionItems.forEach((a: ActionItem) => {
-        md += `- [ ] ${a.task}`;
+        const task = resolveActionKey(a);
+        const done = actionStatuses.get(task) === true;
+        md += done ? `- [x] ${task}` : `- [ ] ${task}`;
         if (a.owner) md += ` → ${a.owner}`;
         if (a.deadline) md += ` (due: ${a.deadline})`;
         md += "\n";

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "Late Meet",
   "version": "1.1.0",
   "description": "AI meeting copilot for Google Meet with local-first transcription and summaries",
-  "permissions": ["storage", "tabs", "tabCapture", "offscreen", "sidePanel"],
+  "permissions": ["storage", "tabs", "tabCapture", "offscreen", "sidePanel", "notifications"],
   "host_permissions": [
     "https://meet.google.com/*",
     "https://api.openai.com/*",


### PR DESCRIPTION
## What was the problem

Action items extracted by the AI were rendered as static, non-interactive elements in the dashboard. Users with the side panel closed had no way of knowing when a new critical action item was detected — they would miss it entirely until they manually opened the panel.

## What was changed and in which files

### `src/manifest.json`
Added `"notifications"` to the permissions array so the background service worker can call `chrome.notifications.create()`.

### `src/background.ts`
- Imported `ActionItem` from `./types`.
- Added a module-level `notifiedActionItems: Set<string>` that tracks which action item task strings have already triggered a notification, preventing duplicate toasts on re-parses of the same LLM response.
- The set is cleared in `resetState()` so each new meeting session starts fresh.
- Added `actionItemKey()` to extract the stable task string from either an `ActionItem` object or a raw string (defensive against the LLM occasionally returning strings).
- Added `notifyNewActionItems()` which iterates new items, skips already-notified ones, and fires `chrome.notifications.create()` with `type: "basic"`, a unique ID, the extension icon, and the task text truncated to 100 characters.
- Called `notifyNewActionItems()` immediately after `state.actionItems` is updated in `summarizeTranscriptIfNeeded()`.

### `src/dashboard.ts`
- Added module-level `actionStatuses: Map<string, boolean>` to hold in-memory completed/pending state for the current session.
- Added `resolveActionKey()` to defensively extract the task string from either an object or a raw string value.
- Added `loadActionStatuses()` — called once on `DOMContentLoaded` — which hydrates the map from `chrome.storage.local` under the key `actionItemStatuses`.
- Added `persistActionStatuses()` which serialises the map back to storage after every checkbox change.
- Rewrote `updateActions()`: each item now renders a real `<input type="checkbox">` paired with a `<label>` wrapping the task info. On re-render, the checkbox is pre-checked based on the in-memory map. After setting `innerHTML`, the function queries all `.action-checkbox` elements and attaches `change` listeners that update the map, persist to storage, and toggle `action-item--done` / `action-task--done` CSS classes without a full re-render.
- Updated both the live export and `exportSessionMarkdown()` to emit `- [x]` for completed items and `- [ ]` for pending items, so exported Markdown reflects the user's actual progress.

### `src/dashboard.css`
- Replaced `.action-check` (a cosmetic div) with `.action-checkbox` — a fully custom-styled `<input type="checkbox">` that matches the monochromatic design system: `appearance: none`, custom border, white fill and a black checkmark SVG-less tick on `:checked`.
- Added `.action-item--done` (reduces opacity to 0.6) and `.action-task--done` (applies strikethrough and dims to `#525252`) for clear visual feedback when a task is marked complete.
- Added `cursor: pointer` to `.action-info` so the associated `<label>` is obviously clickable.

## Why this approach fixes the root cause

The root cause was two-fold:
1. **Silent detection** — new action items appeared in the panel with no signal to the user when the panel was closed. Native Chrome notifications solve this at the OS level regardless of panel state.
2. **No persistence** — the static `.action-check` div had no state. The new checkbox writes to `chrome.storage.local` on every change and reads it back on every panel open, so completed status survives panel closes, extension reloads, and meeting re-opens.

## Steps to test

1. Build with `npm run build` and load `dist/` as an unpacked extension in Chrome.
2. Join a Google Meet call and start the copilot.
3. Start audio capture from the dashboard and let the AI process a few transcript chunks.
4. **Notification test:** Once the LLM extracts an action item, a native Chrome toast should appear in the OS notification area with the title "New Action Item" and the task as the message. Re-triggering summarisation for the same item should **not** produce a second notification.
5. **Checkbox test (Actions tab):** Open the dashboard → Actions tab. Each action item should display a styled checkbox to its left. Click a checkbox — the item dims and the task text gains a strikethrough. Refresh the side panel (close and reopen) — the checked state should still be there.
6. **Export test:** Click "Export Summary" with some items checked. The clipboard Markdown should contain `- [x]` for completed items and `- [ ]` for unchecked ones.

## Edge cases covered

- Action items returned as plain strings by the LLM (not objects) are handled by `resolveActionKey()` in both background and dashboard.
- Notification API is guarded with `if (!chrome.notifications) return` — no crash if the permission is somehow absent.
- Duplicate notifications are suppressed per session via the `notifiedActionItems` Set.
- The `notifiedActionItems` Set resets on `resetState()` so a brand-new meeting session starts with a clean slate.
- Checkbox state survives full re-renders (every `STATE_UPDATE` calls `updateActions`) because the in-memory map is read before building HTML.
- Panel close/reopen hydrates from `chrome.storage.local` so state is never lost.

## No regressions

- `npm run type-check` passes with zero errors.
- `npm run lint` passes with zero errors (one pre-existing warning in the catch block at `tabs.onActivated` is unrelated).
- `npm run build` completes cleanly.
- All existing functionality (waveform, transcript, export, sessions, late-joiner flow) is untouched.

Please review and merge this under GSSoC 2026.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop notifications for newly detected action items with in-session de-duplication
  * Persistent action-item completion state across sessions
  * Interactive checkboxes to mark action items complete
  * Markdown export now emits GitHub-style task lists reflecting completion status
  * Browser notifications permission enabled

* **Style**
  * Updated checkbox visuals, hover effects, and muted/strikethrough styles for completed items

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->