### PR TITLE
Fix API key storage mismatch

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -17,6 +17,7 @@ const MIN_MEETING_DURATION_FOR_WELCOME = 10;
 
 import { State } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
+import { getElevenLabsApiKey, getOpenAiApiKey } from "./utils/credentials";
 
 const state: State = {
   isActive: false,
@@ -138,13 +139,6 @@ async function broadcastStateUpdate() {
   }
 }
 
-async function getApiKey() {
-  const sessionResult = await chrome.storage.session.get("openai_api_key");
-  if (sessionResult.openai_api_key) return sessionResult.openai_api_key;
-  const localResult = await chrome.storage.local.get("openai_api_key");
-  return localResult.openai_api_key || null;
-}
-
 interface Settings {
   summarizationInterval?: number;
   aiModel?: string;
@@ -217,14 +211,7 @@ function getTranscriptionPrompt() {
 async function transcribeChunk(base64Audio: string, mimeType = "audio/webm", prompt = "") {
   // Use ElevenLabs API key if available, fallback to OpenAI if not?
   // No, the requirement is to use ElevenLabs.
-  let elevenlabsKey = await chrome.storage.session
-    .get("elevenlabs_api_key")
-    .then((r) => r.elevenlabs_api_key);
-  if (!elevenlabsKey) {
-    elevenlabsKey = await chrome.storage.local
-      .get("elevenlabs_api_key")
-      .then((r) => r.elevenlabs_api_key);
-  }
+  const elevenlabsKey = await getElevenLabsApiKey();
 
   const bytes = Uint8Array.from(atob(base64Audio), (c) => c.charCodeAt(0));
   const blob = new Blob([bytes], { type: mimeType });
@@ -283,7 +270,7 @@ async function transcribeChunk(base64Audio: string, mimeType = "audio/webm", pro
   }
 
   // Fallback to Whisper
-  const apiKey = await getApiKey();
+  const apiKey = await getOpenAiApiKey();
   if (!apiKey) return null;
 
   const normalizedMime = mimeType.split(";")[0].trim();
@@ -321,7 +308,7 @@ async function refineTranscription(rawText: string) {
   const words = rawText.trim().split(/\s+/);
   if (words.length < 3) return rawText;
 
-  const apiKey = await getApiKey();
+  const apiKey = await getOpenAiApiKey();
   if (!apiKey) return rawText;
 
   const systemPrompt = `You are an expert AI transcription editor. 
@@ -382,7 +369,7 @@ async function summarizeTranscriptIfNeeded() {
   const elapsed = Math.floor((Date.now() - lastSum) / 1000);
   if (lastSum > 0 && elapsed < intervalSeconds) return;
 
-  const apiKey = await getApiKey();
+  const apiKey = await getOpenAiApiKey();
   if (!apiKey) return;
 
   const transcriptWindow = state.transcript
@@ -553,7 +540,7 @@ async function generateLateJoinerMessage(joinerName: string) {
   const fallback = `Hi ${joinerName}, welcome to the meeting! We are currently discussing ${context.currentTopic || "project updates"}.`;
 
   try {
-    const apiKey = await getApiKey();
+    const apiKey = await getOpenAiApiKey();
     if (!apiKey) return fallback;
 
     const prompt = `A participant named ${safeJoinerName} joined late. Meeting duration: ${Math.round(context.duration / 60)} minutes. Current topic: ${sanitizePromptText(context.currentTopic || "General discussion")}. Recent topics: ${sanitizePromptText(JSON.stringify(context.topics || []))}. Decisions: ${sanitizePromptText(JSON.stringify(context.decisions || []))}. Write a short welcome message under 3 sentences. Output plain text only.`;

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,3 +1,5 @@
+import { getApiCredentials, saveApiCredentials } from "./utils/credentials";
+
 interface Settings {
   summarizationInterval?: number;
   vadThreshold?: number;
@@ -27,11 +29,10 @@ function applyThemePreview(theme: "system" | "light" | "dark", accent: string) {
 
 document.addEventListener("DOMContentLoaded", async () => {
   // ——— Load saved settings ———
-  const config = (await chrome.storage.local.get([
-    "openai_api_key",
-    "elevenlabs_api_key",
-    "settings",
-  ])) as { openai_api_key?: string; elevenlabs_api_key?: string; settings?: Settings };
+  const [credentials, config] = await Promise.all([
+    getApiCredentials(),
+    chrome.storage.local.get("settings") as Promise<{ settings?: Settings }>,
+  ]);
 
   const settings: Settings = config.settings || {};
 
@@ -49,13 +50,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   const openaiKeyInput = document.getElementById("openai-key") as HTMLInputElement | null;
-  if (openaiKeyInput && config.openai_api_key) {
-    openaiKeyInput.value = config.openai_api_key;
+  if (openaiKeyInput && credentials.openai_api_key) {
+    openaiKeyInput.value = credentials.openai_api_key;
   }
 
   const elevenlabsKeyInput = document.getElementById("elevenlabs-key") as HTMLInputElement | null;
-  if (elevenlabsKeyInput && config.elevenlabs_api_key) {
-    elevenlabsKeyInput.value = config.elevenlabs_api_key;
+  if (elevenlabsKeyInput && credentials.elevenlabs_api_key) {
+    elevenlabsKeyInput.value = credentials.elevenlabs_api_key;
   }
 
   // Interval slider
@@ -186,14 +187,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         "210, 100%, 50%",
     };
 
-    const saveData: { settings: Settings; openai_api_key?: string; elevenlabs_api_key?: string } = {
-      settings: newSettings,
-    };
-
-    saveData.openai_api_key = openaiKey || "";
-    saveData.elevenlabs_api_key = elevenlabsKey || "";
-
-    await chrome.storage.local.set(saveData);
+    await Promise.all([
+      chrome.storage.local.set({ settings: newSettings }),
+      saveApiCredentials({ openai_api_key: openaiKey, elevenlabs_api_key: elevenlabsKey }),
+    ]);
 
     // Show success
     const status = document.getElementById("save-status");

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,5 +1,6 @@
 import { State } from "./types";
 import { initTheme } from "./theme.js";
+import { getApiCredentials, saveApiCredentials } from "./utils/credentials";
 
 initTheme();
 
@@ -13,12 +14,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   let lastState: State | null = null;
 
   // ——— Check if API key is configured ———
-  const sessionConfig = await chrome.storage.session.get(["openai_api_key", "elevenlabs_api_key"]);
-  const localConfig = await chrome.storage.local.get(["openai_api_key", "elevenlabs_api_key"]);
-  const config = {
-    openai_api_key: sessionConfig.openai_api_key || localConfig.openai_api_key,
-    elevenlabs_api_key: sessionConfig.elevenlabs_api_key || localConfig.elevenlabs_api_key,
-  };
+  const config = await getApiCredentials();
 
   if (!config.openai_api_key && !config.elevenlabs_api_key) {
     setupView.style.display = "block";
@@ -40,7 +36,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     // Since the popup only has one input currently, we'll save it as openai_api_key
     // Users can configure ElevenLabs in the options page.
-    await chrome.storage.session.set({ openai_api_key: apiKey });
+    await saveApiCredentials({ openai_api_key: apiKey });
 
     setupView.style.display = "none";
     mainView.style.display = "block";

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,6 +1,7 @@
 // OpenAI and ElevenLabs API wrappers for Meeting Copilot
 
 import { ElevenLabsClient } from "@elevenlabs/elevenlabs-js";
+import { getOpenAiApiKey } from "./credentials";
 
 const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
@@ -40,12 +41,7 @@ export interface ChatCompletionResponse {
  * Get the stored OpenAI API key
  */
 export async function getApiKey(): Promise<string | null> {
-  const sessionResult = await chrome.storage.session.get("openai_api_key");
-  if (sessionResult.openai_api_key) {
-    return sessionResult.openai_api_key as string;
-  }
-  const localResult = await chrome.storage.local.get("openai_api_key");
-  return (localResult.openai_api_key as string) || null;
+  return getOpenAiApiKey();
 }
 /**
  * Call OpenAI Chat Completions API

--- a/src/utils/credentials.test.ts
+++ b/src/utils/credentials.test.ts
@@ -1,0 +1,75 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  getApiCredentials,
+  getElevenLabsApiKey,
+  getOpenAiApiKey,
+  saveApiCredentials,
+} from "./credentials.ts";
+
+type StorageArea = Record<string, unknown>;
+
+function setupChromeStorage(sessionInitial: StorageArea = {}, localInitial: StorageArea = {}) {
+  const session: StorageArea = { ...sessionInitial };
+  const local: StorageArea = { ...localInitial };
+
+  function createStorageArea(store: StorageArea) {
+    return {
+      async get(keys: string | string[]) {
+        const keyList = Array.isArray(keys) ? keys : [keys];
+        return keyList.reduce<StorageArea>((result, key) => {
+          result[key] = store[key];
+          return result;
+        }, {});
+      },
+      async set(values: StorageArea) {
+        Object.assign(store, values);
+      },
+    };
+  }
+
+  (globalThis as any).chrome = {
+    storage: {
+      session: createStorageArea(session),
+      local: createStorageArea(local),
+    },
+  };
+
+  return { session, local };
+}
+
+test("credentials prefer session values over local values", async () => {
+  setupChromeStorage(
+    { openai_api_key: "session-openai" },
+    { openai_api_key: "local-openai", elevenlabs_api_key: "local-elevenlabs" },
+  );
+
+  assert.deepEqual(await getApiCredentials(), {
+    openai_api_key: "session-openai",
+    elevenlabs_api_key: "local-elevenlabs",
+  });
+});
+
+test("local credentials are synced into session as a migration fallback", async () => {
+  const { session } = setupChromeStorage(
+    {},
+    { openai_api_key: "local-openai", elevenlabs_api_key: "local-elevenlabs" },
+  );
+
+  assert.equal(await getOpenAiApiKey(), "local-openai");
+  assert.equal(await getElevenLabsApiKey(), "local-elevenlabs");
+  assert.deepEqual(session, {
+    openai_api_key: "local-openai",
+    elevenlabs_api_key: "local-elevenlabs",
+  });
+});
+
+test("saving credentials writes the same values to local and session storage", async () => {
+  const { session, local } = setupChromeStorage();
+
+  await saveApiCredentials({ openai_api_key: " openai ", elevenlabs_api_key: " elevenlabs " });
+
+  assert.deepEqual(session, { openai_api_key: "openai", elevenlabs_api_key: "elevenlabs" });
+  assert.deepEqual(local, { openai_api_key: "openai", elevenlabs_api_key: "elevenlabs" });
+});

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -1,0 +1,69 @@
+export type CredentialKey = "openai_api_key" | "elevenlabs_api_key";
+
+export interface ApiCredentials {
+  openai_api_key?: string;
+  elevenlabs_api_key?: string;
+}
+
+const CREDENTIAL_KEYS: CredentialKey[] = ["openai_api_key", "elevenlabs_api_key"];
+
+function normalizedCredential(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export async function getApiCredentials(): Promise<ApiCredentials> {
+  const [sessionCredentials, localCredentials] = await Promise.all([
+    chrome.storage.session.get(CREDENTIAL_KEYS),
+    chrome.storage.local.get(CREDENTIAL_KEYS),
+  ]);
+
+  const credentials: ApiCredentials = {};
+  const sessionSync: ApiCredentials = {};
+
+  for (const key of CREDENTIAL_KEYS) {
+    const sessionValue = normalizedCredential(sessionCredentials[key]);
+    const localValue = normalizedCredential(localCredentials[key]);
+    const resolvedValue = sessionValue || localValue;
+
+    if (resolvedValue) {
+      credentials[key] = resolvedValue;
+    }
+
+    if (!sessionValue && localValue) {
+      sessionSync[key] = localValue;
+    }
+  }
+
+  if (Object.keys(sessionSync).length > 0) {
+    await chrome.storage.session.set(sessionSync);
+  }
+
+  return credentials;
+}
+
+export async function getOpenAiApiKey(): Promise<string | null> {
+  const credentials = await getApiCredentials();
+  return credentials.openai_api_key || null;
+}
+
+export async function getElevenLabsApiKey(): Promise<string | null> {
+  const credentials = await getApiCredentials();
+  return credentials.elevenlabs_api_key || null;
+}
+
+export async function saveApiCredentials(credentials: ApiCredentials): Promise<void> {
+  const saveData: ApiCredentials = {};
+
+  for (const key of CREDENTIAL_KEYS) {
+    const value = normalizedCredential(credentials[key]);
+    if (value) {
+      saveData[key] = value;
+    }
+  }
+
+  if (Object.keys(saveData).length === 0) {
+    return;
+  }
+
+  await Promise.all([chrome.storage.session.set(saveData), chrome.storage.local.set(saveData)]);
+}


### PR DESCRIPTION
## Summary
- Add a shared credential helper for OpenAI and ElevenLabs keys
- Prefer session storage, fall back to existing local keys, and sync local keys into session
- Update Options, Popup, Background, and API wrappers to use the same credential path
- Add focused tests for credential resolution and sync behavior

## Verification
- npm run type-check
- npm run lint
- npm run build
- node --test src/utils/credentials.test.ts

Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Implemented centralized API credential management system for OpenAI and ElevenLabs keys
  * Unified credential retrieval and storage logic across all extension components
  * Added fallback mechanisms for credential resolution

* **Tests**
  * Added test coverage for credential storage, retrieval, and fallback behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->