### PR TITLE
Fix #80 stop capture lifecycle

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -786,10 +786,21 @@ async function stopAudioCapture(reason = "Stopped") {
   await closeOffscreenDocumentIfPresent();
 }
 
+function parseMeetUrl(value: string | undefined | null): URL | null {
+  try {
+    const parsed = new URL(String(value || ""));
+    if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+    if (parsed.hostname !== "meet.google.com") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 function extractMeetCode(url: string | undefined | null): string | null {
-  const value = String(url || "");
-  if (!value.includes("meet.google.com/")) return null;
-  const match = value.match(/meet\.google\.com\/([a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{3})/i);
+  const parsed = parseMeetUrl(url);
+  if (!parsed) return null;
+  const match = parsed.pathname.match(/^\/([a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{3})(?:\/|$)/i);
   return match ? match[1] : null;
 }
 
@@ -803,8 +814,9 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   // If we are actively capturing from this tab, stop capture as soon as the tab
   // navigates away from a Meet meeting scope (privacy safety default).
   if (state.audioActive && state.targetTabId && tabId === state.targetTabId) {
+    const isMeetUrl = Boolean(parseMeetUrl(nextUrl));
     const meetCode = extractMeetCode(nextUrl);
-    if (!nextUrl?.includes("meet.google.com/")) {
+    if (!isMeetUrl) {
       await stopAudioCapture("Navigated away from Meet");
       return;
     }
@@ -818,9 +830,9 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     }
   }
 
-  if (changeInfo.status === "complete" && nextUrl?.includes("meet.google.com/")) {
+  if (changeInfo.status === "complete") {
     const meetingId = extractMeetCode(nextUrl);
-    if (meetingId && meetingId !== "new") {
+    if (meetingId) {
       if (!state.isActive) {
         resetState();
         state.isActive = true;
@@ -838,19 +850,16 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 chrome.tabs.onActivated.addListener(async (activeInfo) => {
   try {
     const tab = await chrome.tabs.get(activeInfo.tabId);
-    if (tab.url?.includes("meet.google.com/")) {
-      const urlMatch = tab.url.match(/meet\.google\.com\/([a-z\-]+)/);
-      const meetingId = urlMatch ? urlMatch[1] : null;
-      if (meetingId && meetingId !== "new" && !state.isActive) {
-        state.meetingId = meetingId;
-        state.meetingUrl = tab.url;
-        state.targetTabId = activeInfo.tabId;
-        await broadcastStateUpdate();
-      }
+    const meetingId = extractMeetCode(tab.url);
+    if (meetingId && !state.isActive) {
+      state.meetingId = meetingId;
+      state.meetingUrl = tab.url || null;
+      state.targetTabId = activeInfo.tabId;
+      await broadcastStateUpdate();
     }
   } catch (err) {
     // Tab might be closed by now
-    console.log(err); // since lint is giving error
+    console.debug("[LateMeet] tab activation handler failed:", err);
   }
 });
 
@@ -913,6 +922,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       case "MANUAL_STOP_AUDIO": {
         if (state.audioActive || state.isActive) {
           await stopAudioCapture("Stopped by user");
+        }
+        sendResponse({ success: true });
+        return;
+      }
+
+      case "MEETING_ENDED":
+      case "CALL_ENDED": {
+        if (state.audioActive || state.isActive) {
+          await stopAudioCapture("Call ended");
         }
         sendResponse({ success: true });
         return;

--- a/src/background.ts
+++ b/src/background.ts
@@ -771,6 +771,9 @@ async function stopAudioCapture(reason = "Stopped") {
 
   state.audioActive = false;
   state.isActive = false;
+  state.meetingId = null;
+  state.meetingUrl = null;
+  state.targetTabId = null;
 
   await broadcastStateUpdate();
 
@@ -783,17 +786,46 @@ async function stopAudioCapture(reason = "Stopped") {
   await closeOffscreenDocumentIfPresent();
 }
 
-chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-  if (changeInfo.status === "complete" && tab.url?.includes("meet.google.com/")) {
-    const urlMatch = tab.url.match(/meet\.google\.com\/([a-z\-]+)/);
-    const meetingId = urlMatch ? urlMatch[1] : null;
+function extractMeetCode(url: string | undefined | null): string | null {
+  const value = String(url || "");
+  if (!value.includes("meet.google.com/")) return null;
+  const match = value.match(/meet\.google\.com\/([a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{3})/i);
+  return match ? match[1] : null;
+}
 
+function isMeetCode(value: string | null | undefined): boolean {
+  return /^[a-z0-9]{3}-[a-z0-9]{4}-[a-z0-9]{3}$/i.test(String(value || ""));
+}
+
+chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  const nextUrl = changeInfo.url || tab.url;
+
+  // If we are actively capturing from this tab, stop capture as soon as the tab
+  // navigates away from a Meet meeting scope (privacy safety default).
+  if (state.audioActive && state.targetTabId && tabId === state.targetTabId) {
+    const meetCode = extractMeetCode(nextUrl);
+    if (!nextUrl?.includes("meet.google.com/")) {
+      await stopAudioCapture("Navigated away from Meet");
+      return;
+    }
+    if (!meetCode) {
+      await stopAudioCapture("Left meeting");
+      return;
+    }
+    if (isMeetCode(state.meetingId) && meetCode !== state.meetingId) {
+      await stopAudioCapture("Switched meeting");
+      return;
+    }
+  }
+
+  if (changeInfo.status === "complete" && nextUrl?.includes("meet.google.com/")) {
+    const meetingId = extractMeetCode(nextUrl);
     if (meetingId && meetingId !== "new") {
       if (!state.isActive) {
         resetState();
         state.isActive = true;
         state.meetingId = meetingId;
-        state.meetingUrl = tab.url || null;
+        state.meetingUrl = nextUrl || null;
         state.targetTabId = tabId || null;
         state.startTime = Date.now();
         state.participants = ["You"];
@@ -874,6 +906,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           message.streamId,
           message.includeMicrophone !== false,
         );
+        sendResponse({ success: true });
+        return;
+      }
+
+      case "MANUAL_STOP_AUDIO": {
+        if (state.audioActive || state.isActive) {
+          await stopAudioCapture("Stopped by user");
+        }
         sendResponse({ success: true });
         return;
       }

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -124,7 +124,14 @@ document.addEventListener("DOMContentLoaded", async () => {
   const audioBtn = document.getElementById("dash-start-audio-btn") as HTMLButtonElement | null;
   audioBtn?.addEventListener("click", async () => {
     if (lastState?.audioActive) {
-      console.log("[Dashboard] Audio already active, skipping.");
+      try {
+        audioBtn.disabled = true;
+        await chrome.runtime.sendMessage({ type: "MANUAL_STOP_AUDIO" });
+      } catch (err) {
+        console.error("[Dashboard] Failed to stop audio:", err);
+      } finally {
+        audioBtn.disabled = false;
+      }
       return;
     }
 
@@ -221,10 +228,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   function setAudioBtnActive(active: boolean) {
     if (!audioBtn) return;
     if (active) {
-      audioBtn.style.display = "none";
       audioBtn.classList.add("active");
+      audioBtn.disabled = false;
+      audioBtn.innerHTML =
+        '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right: 6px;"><rect width="18" height="18" x="3" y="3" rx="2"></rect><path d="M9 12h6"></path></svg> Stop Audio';
     } else {
-      audioBtn.style.display = "flex";
       audioBtn.classList.remove("active");
       audioBtn.disabled = false;
       audioBtn.innerHTML =

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -213,8 +213,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       return (
         Array.from(miniBtn.childNodes)
           .reverse()
-          .find((n) => n.nodeType === Node.TEXT_NODE && String(n.textContent || "").trim()) ||
-        null
+          .find((n) => n.nodeType === Node.TEXT_NODE && String(n.textContent || "").trim()) || null
       );
     };
 

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -208,6 +208,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     const iconEl = copilotBtn.querySelector(".copilot-btn-icon");
     const textEl = copilotBtn.querySelector(".copilot-btn-text");
 
+    const getMiniBtnLabelNode = () => {
+      if (!miniBtn) return null;
+      return (
+        Array.from(miniBtn.childNodes)
+          .reverse()
+          .find((n) => n.nodeType === Node.TEXT_NODE && String(n.textContent || "").trim()) ||
+        null
+      );
+    };
+
     if (active) {
       copilotBtn.classList.remove("loading");
       copilotBtn.classList.add("active");
@@ -220,7 +230,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         miniBtn.style.display = "flex";
         miniBtn.classList.add("active");
         miniBtn.title = "Stop audio capture";
-        const labelNode = Array.from(miniBtn.childNodes).find((n) => n.nodeType === Node.TEXT_NODE);
+        const labelNode = getMiniBtnLabelNode();
         if (labelNode) labelNode.textContent = " Stop Audio";
       }
     } else {
@@ -234,7 +244,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         miniBtn.style.display = "flex";
         miniBtn.classList.remove("active");
         miniBtn.title = "Start audio capture";
-        const labelNode = Array.from(miniBtn.childNodes).find((n) => n.nodeType === Node.TEXT_NODE);
+        const labelNode = getMiniBtnLabelNode();
         if (labelNode) labelNode.textContent = " Start Audio";
       }
     }

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -70,6 +70,19 @@ document.addEventListener("DOMContentLoaded", async () => {
   // ——— Start Copilot (Audio Capture with User Gesture) ———
   const copilotBtn = document.getElementById("start-copilot-btn") as HTMLButtonElement | null;
 
+  async function handleStopAudio(btn?: HTMLButtonElement | null) {
+    if (!lastState?.audioActive) return;
+
+    try {
+      if (btn) btn.disabled = true;
+      await chrome.runtime.sendMessage({ type: "MANUAL_STOP_AUDIO" });
+    } catch (err) {
+      console.error("[LateMeet] Failed to stop audio:", err);
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
   async function handleStartAudio(btn: HTMLButtonElement) {
     const textEl = btn.querySelector(".copilot-btn-text");
     const originalText = textEl?.textContent || "Start";
@@ -181,7 +194,12 @@ document.addEventListener("DOMContentLoaded", async () => {
   copilotBtn?.addEventListener("click", () => handleStartAudio(copilotBtn));
   document.getElementById("meeting-start-audio-btn")?.addEventListener("click", (e) => {
     const btn = e.currentTarget as HTMLButtonElement | null;
-    if (btn) handleStartAudio(btn);
+    if (!btn) return;
+    if (lastState?.audioActive) {
+      handleStopAudio(btn);
+      return;
+    }
+    handleStartAudio(btn);
   });
 
   function setCopilotActive(active: boolean) {
@@ -198,7 +216,13 @@ document.addEventListener("DOMContentLoaded", async () => {
         iconEl.innerHTML =
           '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>';
       copilotBtn.disabled = true;
-      if (miniBtn) miniBtn.style.display = "none";
+      if (miniBtn) {
+        miniBtn.style.display = "flex";
+        miniBtn.classList.add("active");
+        miniBtn.title = "Stop audio capture";
+        const labelNode = Array.from(miniBtn.childNodes).find((n) => n.nodeType === Node.TEXT_NODE);
+        if (labelNode) labelNode.textContent = " Stop Audio";
+      }
     } else {
       copilotBtn.classList.remove("active");
       if (textEl) textEl.textContent = "Start Copilot";
@@ -206,7 +230,13 @@ document.addEventListener("DOMContentLoaded", async () => {
         iconEl.innerHTML =
           '<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/></svg>';
       copilotBtn.disabled = false;
-      if (miniBtn) miniBtn.style.display = "flex";
+      if (miniBtn) {
+        miniBtn.style.display = "flex";
+        miniBtn.classList.remove("active");
+        miniBtn.title = "Start audio capture";
+        const labelNode = Array.from(miniBtn.childNodes).find((n) => n.nodeType === Node.TEXT_NODE);
+        if (labelNode) labelNode.textContent = " Start Audio";
+      }
     }
   }
 


### PR DESCRIPTION
## Description

This PR fixes a privacy-critical lifecycle bug where tab (and optional mic) capture could continue after a user hangs up or navigates away from a Google Meet tab.

Changes:
- Auto-stop audio capture when the captured tab navigates away from `meet.google.com`, loses a valid meeting code, or switches to a different meeting.
- Add an explicit **Stop Audio** control while recording (popup mini button + dashboard button) that routes through the background as the single source of truth.

Fixes #80

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Built the extension with `npm run build`
- [x] Loaded the extension in Chrome and tested manually
- [x] Tested on a live Google Meet call
- [x] Verified no console errors
- [x] Tested with ElevenLabs API key
- [x] Tested with OpenAI API key

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual "Stop Audio" control added to dashboard and popup with disabled-state while stopping.
  * Mini button label and active-state updated to show "Start/Stop Audio" consistently.

* **Bug Fixes**
  * Audio capture now stops when leaving or switching Google Meet sessions; meeting identity is fully cleared on stop.
  * Meeting URL/code validation improved; session initialization and end events now trigger correct stop behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->