### PR TITLE
fix: preserve meeting URL on manual capture

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -933,7 +933,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         const meetingId = message.meetingId || state.meetingId;
-        const meetingUrl = sender?.tab?.url || state.meetingUrl;
+        const meetingUrl = message.meetingUrl || sender?.tab?.url || state.meetingUrl;
         await startAudioCapture(
           tabId,
           meetingId,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -178,6 +178,7 @@ document.addEventListener("DOMContentLoaded", async () => {
               type: "MANUAL_START_AUDIO",
               tabId: meetTab.id,
               meetingId: meetingId,
+              meetingUrl: meetTab.url || null,
               streamId: streamId,
               includeMicrophone: true,
             });

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -125,6 +125,7 @@ document.addEventListener("DOMContentLoaded", async () => {
               type: "MANUAL_START_AUDIO",
               tabId: meetTab.id,
               meetingId: meetingId,
+              meetingUrl: meetTab.url || null,
               streamId: streamId,
               includeMicrophone: true,
             });


### PR DESCRIPTION
## Summary
- Pass the matched Google Meet tab URL from popup manual capture requests.
- Pass the matched Google Meet tab URL from dashboard manual capture requests.
- Prefer the explicit meetingUrl in the background MANUAL_START_AUDIO handler before falling back to sender or existing state.

Closes #86

## Testing
- npm run type-check
- npm test
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting URL handling when starting audio. The extension now properly tracks and maintains meeting URL context across components, with appropriate fallback logic to ensure audio capture works reliably.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->