### PR TITLE
fix: target active Meet tab for manual capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts",
+    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/background.ts
+++ b/src/background.ts
@@ -18,6 +18,7 @@ const MIN_MEETING_DURATION_FOR_WELCOME = 10;
 import { ActionItem, Decision, State } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
 import { getElevenLabsApiKey, getOpenAiApiKey } from "./utils/credentials";
+import { resolveDetectedMeetTab } from "./meetingTabs";
 
 const state: State = {
   isActive: false,
@@ -797,27 +798,17 @@ async function startAudioCapture(
 
 async function scanForMeetTabs() {
   try {
-    const tabs = await chrome.tabs.query({ url: "https://meet.google.com/*" });
-    if (tabs.length > 0) {
-      // Find the first tab with a meeting code
-      for (const tab of tabs) {
-        const urlMatch = tab.url?.match(/meet\.google\.com\/([a-z\-]+)/);
-        const meetingId = urlMatch ? urlMatch[1] : null;
-        if (meetingId && meetingId !== "new") {
-          if (!state.isActive) {
-            resetState();
-            state.isActive = true;
-            state.meetingId = meetingId;
-            state.meetingUrl = tab.url || null;
-            state.targetTabId = tab.id || null;
-            state.startTime = Date.now();
-            state.participants = ["You"];
-            console.log("[LateMeet] Proactively detected meeting:", meetingId);
-            await broadcastStateUpdate();
-          }
-          return;
-        }
-      }
+    const meetTab = await resolveDetectedMeetTab();
+    if (meetTab && !state.isActive) {
+      resetState();
+      state.isActive = true;
+      state.meetingId = meetTab.meetingId;
+      state.meetingUrl = meetTab.meetingUrl;
+      state.targetTabId = meetTab.tab.id || null;
+      state.startTime = Date.now();
+      state.participants = ["You"];
+      console.log("[LateMeet] Proactively detected meeting:", meetTab.meetingId);
+      await broadcastStateUpdate();
     }
   } catch (err) {
     console.error("[LateMeet] Scan for meet tabs failed:", err);
@@ -933,7 +924,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         }
 
         const meetingId = message.meetingId || state.meetingId;
-        const meetingUrl = sender?.tab?.url || state.meetingUrl;
+        const meetingUrl = message.meetingUrl || sender?.tab?.url || state.meetingUrl;
         await startAudioCapture(
           tabId,
           meetingId,

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,5 +1,6 @@
 import { State, Topic, TranscriptEntry, TimelineEvent, Decision, ActionItem } from "./types";
 import { initTheme } from "./theme.js";
+import { resolveManualMeetTab } from "./meetingTabs";
 
 initTheme();
 
@@ -141,63 +142,59 @@ document.addEventListener("DOMContentLoaded", async () => {
         console.warn("[Dashboard] Mic permission not granted — waveform will use tab audio only");
       }
 
-      chrome.tabs.query({ url: "https://meet.google.com/*" }, (meetTabs) => {
-        if (meetTabs.length === 0) {
-          handleDashboardAudioError(new Error("No Google Meet tab found"));
-          return;
-        }
-        const meetTab = meetTabs[0];
-        const urlMatch = meetTab.url?.match(/meet\.google\.com\/([a-z\-]+)/);
-        const meetingId = urlMatch ? urlMatch[1] : null;
+      resolveManualMeetTab()
+        .then(({ tab: meetTab, meetingId, meetingUrl }) => {
+          // --- Get Media Stream ID in foreground (dashboard) to ensure user gesture propagation ---
+          chrome.tabCapture.getMediaStreamId({ targetTabId: meetTab.id }, async (streamId) => {
+            if (chrome.runtime.lastError) {
+              const err = chrome.runtime.lastError.message || "Unknown error";
+              console.error("[Dashboard] getMediaStreamId error:", err);
+              if (err.includes("active stream")) {
+                setAudioBtnActive(true);
+                return;
+              } else {
+                handleDashboardAudioError(
+                  new Error('Capture permission denied. Try clicking "Start Audio" again.'),
+                );
+                return;
+              }
+            }
 
-        // --- Get Media Stream ID in foreground (dashboard) to ensure user gesture propagation ---
-        chrome.tabCapture.getMediaStreamId({ targetTabId: meetTab.id }, async (streamId) => {
-          if (chrome.runtime.lastError) {
-            const err = chrome.runtime.lastError.message || "Unknown error";
-            console.error("[Dashboard] getMediaStreamId error:", err);
-            if (err.includes("active stream")) {
-              setAudioBtnActive(true);
-              return;
-            } else {
+            if (!streamId) {
               handleDashboardAudioError(
                 new Error('Capture permission denied. Try clicking "Start Audio" again.'),
               );
               return;
             }
-          }
 
-          if (!streamId) {
-            handleDashboardAudioError(
-              new Error('Capture permission denied. Try clicking "Start Audio" again.'),
-            );
-            return;
-          }
+            try {
+              const response = await chrome.runtime.sendMessage({
+                type: "MANUAL_START_AUDIO",
+                tabId: meetTab.id,
+                meetingId: meetingId,
+                meetingUrl: meetingUrl,
+                streamId: streamId,
+                includeMicrophone: true,
+              });
 
-          try {
-            const response = await chrome.runtime.sendMessage({
-              type: "MANUAL_START_AUDIO",
-              tabId: meetTab.id,
-              meetingId: meetingId,
-              streamId: streamId,
-              includeMicrophone: true,
-            });
-
-            if (response && response.success) {
-              setAudioBtnActive(true);
-              // Start timer immediately
-              startTimer(Date.now());
-              const statusText = document.getElementById("dash-status-text");
-              const statusDot = document.querySelector(".dash-status-dot");
-              if (statusText) statusText.textContent = `Meeting active — ${meetingId || "unknown"}`;
-              if (statusDot) statusDot.classList.add("active");
-            } else {
-              throw new Error(response?.error || "Failed to start audio");
+              if (response && response.success) {
+                setAudioBtnActive(true);
+                // Start timer immediately
+                startTimer(Date.now());
+                const statusText = document.getElementById("dash-status-text");
+                const statusDot = document.querySelector(".dash-status-dot");
+                if (statusText)
+                  statusText.textContent = `Meeting active — ${meetingId || "unknown"}`;
+                if (statusDot) statusDot.classList.add("active");
+              } else {
+                throw new Error(response?.error || "Failed to start audio");
+              }
+            } catch (err: any) {
+              handleDashboardAudioError(err);
             }
-          } catch (err: any) {
-            handleDashboardAudioError(err);
-          }
-        });
-      });
+          });
+        })
+        .catch(handleDashboardAudioError);
     } catch (err: any) {
       handleDashboardAudioError(err);
     }

--- a/src/meetingTabs.test.ts
+++ b/src/meetingTabs.test.ts
@@ -1,0 +1,120 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { getMeetingIdFromUrl, resolveManualMeetTab } from "./meetingTabs.ts";
+
+type MockTab = Pick<chrome.tabs.Tab, "id" | "url" | "active"> & {
+  currentWindow?: boolean;
+};
+
+function mockChromeTabs(tabs: MockTab[]) {
+  const previousChrome = (globalThis as any).chrome;
+
+  (globalThis as any).chrome = {
+    tabs: {
+      query: async (queryInfo: chrome.tabs.QueryInfo) => {
+        if (queryInfo.active && queryInfo.currentWindow) {
+          return tabs.filter((tab) => tab.active && tab.currentWindow) as chrome.tabs.Tab[];
+        }
+
+        if (queryInfo.url === "https://meet.google.com/*") {
+          return tabs.filter((tab) =>
+            tab.url?.startsWith("https://meet.google.com/"),
+          ) as chrome.tabs.Tab[];
+        }
+
+        return [];
+      },
+    },
+  };
+
+  return () => {
+    (globalThis as any).chrome = previousChrome;
+  };
+}
+
+test("meeting id extraction accepts real Meet rooms and rejects non-room URLs", () => {
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/abc-defg-hij"), "abc-defg-hij");
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/new"), null);
+  assert.equal(getMeetingIdFromUrl("https://example.com/abc-defg-hij"), null);
+  assert.equal(getMeetingIdFromUrl(undefined), null);
+});
+
+test("manual Meet tab resolution prefers the active meeting tab", async () => {
+  const cleanup = mockChromeTabs([
+    {
+      id: 1,
+      url: "https://meet.google.com/old-room-aaa",
+      active: false,
+      currentWindow: true,
+    },
+    {
+      id: 2,
+      url: "https://meet.google.com/live-room-bbb",
+      active: true,
+      currentWindow: true,
+    },
+  ]);
+
+  try {
+    const selected = await resolveManualMeetTab();
+    assert.equal(selected.tab.id, 2);
+    assert.equal(selected.meetingId, "live-room-bbb");
+  } finally {
+    cleanup();
+  }
+});
+
+test("manual Meet tab resolution falls back when exactly one meeting tab is open", async () => {
+  const cleanup = mockChromeTabs([
+    {
+      id: 3,
+      url: "https://example.com/",
+      active: true,
+      currentWindow: true,
+    },
+    {
+      id: 4,
+      url: "https://meet.google.com/only-room-ccc",
+      active: false,
+      currentWindow: true,
+    },
+  ]);
+
+  try {
+    const selected = await resolveManualMeetTab();
+    assert.equal(selected.tab.id, 4);
+    assert.equal(selected.meetingUrl, "https://meet.google.com/only-room-ccc");
+  } finally {
+    cleanup();
+  }
+});
+
+test("manual Meet tab resolution rejects ambiguous background meetings", async () => {
+  const cleanup = mockChromeTabs([
+    {
+      id: 5,
+      url: "https://example.com/",
+      active: true,
+      currentWindow: true,
+    },
+    {
+      id: 6,
+      url: "https://meet.google.com/first-room-ddd",
+      active: false,
+      currentWindow: true,
+    },
+    {
+      id: 7,
+      url: "https://meet.google.com/second-room-eee",
+      active: false,
+      currentWindow: false,
+    },
+  ]);
+
+  try {
+    await assert.rejects(resolveManualMeetTab(), /Multiple Meet tabs/);
+  } finally {
+    cleanup();
+  }
+});

--- a/src/meetingTabs.ts
+++ b/src/meetingTabs.ts
@@ -1,0 +1,62 @@
+export interface MeetTabSelection {
+  tab: chrome.tabs.Tab;
+  meetingId: string;
+  meetingUrl: string;
+}
+
+const MEET_TAB_URL = "https://meet.google.com/*";
+
+export function getMeetingIdFromUrl(url: string | undefined): string | null {
+  if (!url) return null;
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== "meet.google.com") return null;
+
+    const meetingId = parsed.pathname.split("/").filter(Boolean)[0];
+    if (!meetingId || meetingId === "new") return null;
+
+    return meetingId;
+  } catch {
+    return null;
+  }
+}
+
+function toMeetTabSelection(tab: chrome.tabs.Tab | undefined): MeetTabSelection | null {
+  const meetingId = getMeetingIdFromUrl(tab?.url);
+  if (!tab || tab.id === undefined || !meetingId || !tab.url) return null;
+
+  return {
+    tab,
+    meetingId,
+    meetingUrl: tab.url,
+  };
+}
+
+export async function resolveManualMeetTab(): Promise<MeetTabSelection> {
+  const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  const activeMeetTab = toMeetTabSelection(activeTab);
+  if (activeMeetTab) return activeMeetTab;
+
+  const meetTabs = (await chrome.tabs.query({ url: MEET_TAB_URL }))
+    .map(toMeetTabSelection)
+    .filter((tab): tab is MeetTabSelection => Boolean(tab));
+
+  if (meetTabs.length === 0) {
+    throw new Error("No Google Meet tab found. Join a meeting first.");
+  }
+
+  if (meetTabs.length === 1) {
+    return meetTabs[0];
+  }
+
+  throw new Error("Multiple Meet tabs are open. Switch to the meeting tab and start again.");
+}
+
+export async function resolveDetectedMeetTab(): Promise<MeetTabSelection | null> {
+  try {
+    return await resolveManualMeetTab();
+  } catch {
+    return null;
+  }
+}

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -1,6 +1,7 @@
 import { State } from "./types";
 import { initTheme } from "./theme.js";
 import { getApiCredentials, saveApiCredentials } from "./utils/credentials";
+import { resolveManualMeetTab } from "./meetingTabs";
 
 initTheme();
 
@@ -81,27 +82,28 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (textEl) textEl.textContent = "Starting...";
       btn.classList.add("loading");
 
-      chrome.tabs.query({ url: "https://meet.google.com/*" }, (tabs) => {
-        if (tabs.length === 0) {
-          handleStartAudioError(new Error("No Google Meet tab found. Join a meeting first."));
-          return;
-        }
-        const meetTab = tabs[0];
+      resolveManualMeetTab()
+        .then(({ tab: meetTab, meetingId, meetingUrl }) => {
+          // --- Get Media Stream ID in foreground (popup) to ensure user gesture propagation ---
+          chrome.tabCapture.getMediaStreamId({ targetTabId: meetTab.id }, async (streamId) => {
+            if (chrome.runtime.lastError) {
+              const err = chrome.runtime.lastError.message || "Unknown error";
+              console.error("[LateMeet] Popup getMediaStreamId error:", err);
+              // If already capturing, we can treat it as success or inform the background
+              if (err.includes("active stream")) {
+                setCopilotActive(true);
+                return;
+              } else {
+                handleStartAudioError(
+                  new Error(
+                    "Capture permission denied. Try clicking the extension icon again on the Meet tab.",
+                  ),
+                );
+                return;
+              }
+            }
 
-        // Extract meeting ID from tab URL
-        const urlMatch = meetTab.url?.match(/meet\.google\.com\/([a-z\-]+)/);
-        const meetingId = urlMatch ? urlMatch[1] : null;
-
-        // --- Get Media Stream ID in foreground (popup) to ensure user gesture propagation ---
-        chrome.tabCapture.getMediaStreamId({ targetTabId: meetTab.id }, async (streamId) => {
-          if (chrome.runtime.lastError) {
-            const err = chrome.runtime.lastError.message || "Unknown error";
-            console.error("[LateMeet] Popup getMediaStreamId error:", err);
-            // If already capturing, we can treat it as success or inform the background
-            if (err.includes("active stream")) {
-              setCopilotActive(true);
-              return;
-            } else {
+            if (!streamId) {
               handleStartAudioError(
                 new Error(
                   "Capture permission denied. Try clicking the extension icon again on the Meet tab.",
@@ -109,53 +111,45 @@ document.addEventListener("DOMContentLoaded", async () => {
               );
               return;
             }
-          }
 
-          if (!streamId) {
-            handleStartAudioError(
-              new Error(
-                "Capture permission denied. Try clicking the extension icon again on the Meet tab.",
-              ),
-            );
-            return;
-          }
+            try {
+              const response = await chrome.runtime.sendMessage({
+                type: "MANUAL_START_AUDIO",
+                tabId: meetTab.id,
+                meetingId: meetingId,
+                meetingUrl: meetingUrl,
+                streamId: streamId,
+                includeMicrophone: true,
+              });
 
-          try {
-            const response = await chrome.runtime.sendMessage({
-              type: "MANUAL_START_AUDIO",
-              tabId: meetTab.id,
-              meetingId: meetingId,
-              streamId: streamId,
-              includeMicrophone: true,
-            });
-
-            if (response && response.success) {
-              // Clear loading state before setting active state
-              btn.disabled = false;
-              btn.classList.remove("loading");
-              setCopilotActive(true);
-              // Immediately show meeting section and start timer
-              if (meetingSection) meetingSection.style.display = "block";
-              if (noMeetingSection) noMeetingSection.style.display = "none";
-              if (meetingId) {
-                const meetingIdEl = document.getElementById("meeting-id");
-                if (meetingIdEl) meetingIdEl.textContent = meetingId;
+              if (response && response.success) {
+                // Clear loading state before setting active state
+                btn.disabled = false;
+                btn.classList.remove("loading");
+                setCopilotActive(true);
+                // Immediately show meeting section and start timer
+                if (meetingSection) meetingSection.style.display = "block";
+                if (noMeetingSection) noMeetingSection.style.display = "none";
+                if (meetingId) {
+                  const meetingIdEl = document.getElementById("meeting-id");
+                  if (meetingIdEl) meetingIdEl.textContent = meetingId;
+                }
+                const badge = document.getElementById("status-badge");
+                if (badge) {
+                  badge.className = "status-badge active";
+                  const statusText = badge.querySelector(".status-text");
+                  if (statusText) statusText.textContent = "Recording...";
+                }
+                startDurationTimer(Date.now());
+              } else {
+                throw new Error(response?.error || "Failed to start audio capture");
               }
-              const badge = document.getElementById("status-badge");
-              if (badge) {
-                badge.className = "status-badge active";
-                const statusText = badge.querySelector(".status-text");
-                if (statusText) statusText.textContent = "Recording...";
-              }
-              startDurationTimer(Date.now());
-            } else {
-              throw new Error(response?.error || "Failed to start audio capture");
+            } catch (err: any) {
+              handleStartAudioError(err);
             }
-          } catch (err: any) {
-            handleStartAudioError(err);
-          }
-        });
-      });
+          });
+        })
+        .catch(handleStartAudioError);
     } catch (err: any) {
       handleStartAudioError(err);
     }


### PR DESCRIPTION
## Summary
- Add shared Meet tab resolution that prefers the active meeting tab.
- Avoid silently selecting the first `chrome.tabs.query` result when multiple Meet tabs are open.
- Pass the selected meeting URL through manual capture so metadata and capture target stay aligned.
- Add unit coverage for Meet URL parsing, active-tab preference, single-tab fallback, and ambiguous multi-tab rejection.

Closes #88

## Testing
- npm run type-check
- npm run lint
- npm run format:check
- npm test