### PR TITLE
test: add chunk viability test coverage

### DIFF
--- a/src/audioProcessing.test.ts
+++ b/src/audioProcessing.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { VoiceActivityTracker, audioFileExtensionForMimeType } from "./audioProcessing.ts";
+import {
+  VoiceActivityTracker,
+  audioFileExtensionForMimeType,
+  isChunkViable,
+} from "./audioProcessing.ts";
 
 // ─── existing tests ───────────────────────────────────────────────────────────
 
@@ -163,5 +167,39 @@ test("vadThreshold forwarded in message falls back to 0.012 when absent", () => 
     withoutThreshold.vadThreshold ?? 0.012,
     0.012,
     "missing threshold must default to 0.012",
+  );
+});
+
+test("audio chunks smaller than the default minimum size are rejected", () => {
+  const blob = new Blob(["a".repeat(1000)]);
+
+  assert.equal(isChunkViable(blob), false, "chunks smaller than 5000 bytes must be rejected");
+});
+
+test("audio chunks equal to the default minimum size are accepted", () => {
+  const blob = new Blob(["a".repeat(5000)]);
+
+  assert.equal(isChunkViable(blob), true, "chunks equal to 5000 bytes must be accepted");
+});
+
+test("audio chunks larger than the default minimum size are accepted", () => {
+  const blob = new Blob(["a".repeat(6000)]);
+
+  assert.equal(isChunkViable(blob), true, "chunks larger than 5000 bytes must be accepted");
+});
+
+test("empty audio chunks are rejected", () => {
+  const blob = new Blob([]);
+
+  assert.equal(isChunkViable(blob), false, "empty chunks must be rejected");
+});
+
+test("custom minimum chunk size is respected", () => {
+  const blob = new Blob(["a".repeat(1500)]);
+
+  assert.equal(
+    isChunkViable(blob, 1000),
+    true,
+    "custom minimum size must override the default threshold",
   );
 });


### PR DESCRIPTION
## Description

Added missing unit test coverage for `isChunkViable()` in `audioProcessing.test.ts`.

The new tests cover:

* chunks smaller than the minimum size
* chunks equal to the minimum size
* chunks larger than the minimum size
* empty audio chunks
* custom minimum chunk size handling

Fixes #106

## Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📝 Documentation update
* [ ] 🎨 UI/UX improvement
* [ ] ♻️ Code refactoring (no functional changes)
* [x] 🧪 Tests

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

* [x] Built the extension with `npm run build`
* [ ] Loaded the extension in Chrome and tested manually
* [ ] Tested on a live Google Meet call
* [ ] Verified no console errors
* [ ] Tested with ElevenLabs API key
* [ ] Tested with OpenAI API key

## Screenshots (if applicable)

N/A

## Checklist

* [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
* [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
* [x] I have performed a self-review of my code
* [ ] I have commented my code where necessary
* [x] My code follows the formatting of this project (run `npm run format`)
* [x] ESLint checks pass locally without any errors (run `npm run lint`)
* [x] TypeScript type checks pass locally (run `npm run type-check`)
* [x] My changes generate no new warnings or errors
* [ ] I have updated the documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added unit tests for audio chunk validation, ensuring proper handling of various chunk sizes and custom configuration scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->