### PR TITLE
a11y(#102): add descriptive alt text to README badges and architectur…

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 **Catch up instantly when you join a meeting late — without bots, servers, or transcript storage.**
 
-[![GSSoC 2026](https://img.shields.io/badge/GSSoC-2026-orange?style=for-the-badge&logo=git&logoColor=white)](https://gssoc.girlscript.tech/)
-[![Version](https://img.shields.io/badge/Version-1.1.0-black?style=for-the-badge&logo=googlechrome&logoColor=white)](https://github.com/shouri123/Late-Meet)
-[![License](https://img.shields.io/badge/License-MIT-black?style=for-the-badge)](LICENSE)
-[![Platform](https://img.shields.io/badge/Platform-Google_Meet-black?style=for-the-badge&logo=googlemeet)](https://meet.google.com)
-[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-black?style=for-the-badge)](CONTRIBUTING.md)
+[![GSSoC 2026 Open Source Program Badge](https://img.shields.io/badge/GSSoC-2026-orange?style=for-the-badge&logo=git&logoColor=white)](https://gssoc.girlscript.tech/)
+[![Current Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-black?style=for-the-badge&logo=googlechrome&logoColor=white)](https://github.com/shouri123/Late-Meet)
+[![MIT License Badge](https://img.shields.io/badge/License-MIT-black?style=for-the-badge)](LICENSE)
+[![Supported Platform: Google Meet](https://img.shields.io/badge/Platform-Google_Meet-black?style=for-the-badge&logo=googlemeet)](https://meet.google.com)
+[![Pull Requests Welcome Badge](https://img.shields.io/badge/PRs-welcome-black?style=for-the-badge)](CONTRIBUTING.md)
 
 </div>
 


### PR DESCRIPTION
Added descriptive alt text to all README images and badges for 
accessibility (A11Y). Added a brief architecture diagram text 
summary so screen reader users can understand the diagram content.

Closes #102

## Type of Change
- [x] 📝 Documentation update

## Changes Made
- Improved alt text for all 5 badge images to be more descriptive
- Added architecture diagram text summary before ASCII diagram
- Verified all existing image alt texts are correct
- No image URLs modified, no broken references

## How Has This Been Tested?
- [x] Verified README renders correctly on GitHub preview
- [x] All image URLs unchanged and working
- [x] No broken image references

## Checklist
- [x] I have starred the repository ⭐
- [x] I have performed a self-review
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation