### PR TITLE
perf: implement lazy-loading and skeleton UI for dashboard tabs (#109)

### DIFF
--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -1037,3 +1037,75 @@ body::-webkit-scrollbar-thumb,
   border-color: rgba(239, 68, 68, 0.4);
   color: #fca5a5;
 }
+
+/* ——— Skeleton Loader ——— */
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.skeleton-item {
+  background: linear-gradient(
+    90deg,
+    var(--bg-card) 25%,
+    var(--border-main) 50%,
+    var(--bg-card) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite linear;
+  border-radius: 8px;
+  height: 40px;
+  margin-bottom: 8px;
+}
+
+.skeleton-avatar {
+  background: linear-gradient(
+    90deg,
+    var(--bg-card) 25%,
+    var(--border-main) 50%,
+    var(--bg-card) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite linear;
+  border-radius: 8px;
+  height: 32px;
+  width: 32px;
+  flex-shrink: 0;
+}
+
+.skeleton-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-main);
+}
+.skeleton-row:last-child {
+  border-bottom: none;
+}
+.skeleton-text-block {
+  flex: 1;
+}
+.skeleton-text {
+  background: linear-gradient(
+    90deg,
+    var(--bg-card) 25%,
+    var(--border-main) 50%,
+    var(--bg-card) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite linear;
+  border-radius: 4px;
+  height: 14px;
+  margin-bottom: 6px;
+  width: 80%;
+}
+.skeleton-text.short {
+  width: 40%;
+  height: 10px;
+  margin-bottom: 0;
+}

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -122,15 +122,79 @@ document.addEventListener("DOMContentLoaded", async () => {
   // ——— Tab Switching ———
   const tabs = document.querySelectorAll(".dash-tab");
   const panels = document.querySelectorAll(".tab-panel");
+  const loadedTabs = new Set<string>(["overview"]);
+
+  function showSkeletonForTab(tabId: string) {
+    const containerMap: Record<string, string> = {
+      topics: "dash-topics-full",
+      decisions: "dash-decisions-list",
+      actions: "dash-actions-list",
+      people: "dash-participants-list",
+      timeline: "dash-timeline",
+      transcript: "dash-transcript-list",
+      sessions: "dash-sessions-list",
+    };
+    const containerId = containerMap[tabId];
+    if (!containerId) return;
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    if (tabId === "people" || tabId === "transcript" || tabId === "timeline") {
+      container.innerHTML = Array(4)
+        .fill(0)
+        .map(
+          () => `
+        <div class="skeleton-row">
+          <div class="skeleton-avatar"></div>
+          <div class="skeleton-text-block">
+            <div class="skeleton-text"></div>
+            <div class="skeleton-text short"></div>
+          </div>
+        </div>
+      `,
+        )
+        .join("");
+    } else {
+      container.innerHTML = Array(4)
+        .fill(0)
+        .map(
+          () => `
+        <div class="skeleton-item"></div>
+      `,
+        )
+        .join("");
+    }
+  }
 
   tabs.forEach((tab) => {
     tab.addEventListener("click", () => {
+      const tabId = (tab as HTMLElement).dataset.tab;
+      if (!tabId) return;
+
       tabs.forEach((t) => t.classList.remove("active"));
       panels.forEach((p) => p.classList.remove("active"));
       (tab as HTMLElement).classList.add("active");
-      const tabId = (tab as HTMLElement).dataset.tab;
-      if (tabId) {
-        document.getElementById(`tab-${tabId}`)?.classList.add("active");
+
+      const panel = document.getElementById(`tab-${tabId}`);
+      if (panel) {
+        panel.classList.add("active");
+      }
+
+      if (!loadedTabs.has(tabId)) {
+        loadedTabs.add(tabId);
+        showSkeletonForTab(tabId);
+        setTimeout(() => {
+          if (lastState) {
+            if (tabId === "topics") updateTopics(lastState.topics);
+            else if (tabId === "decisions") updateDecisions(lastState.decisions);
+            else if (tabId === "actions") updateActions(lastState.actionItems);
+            else if (tabId === "people")
+              updatePeople(lastState.participants, lastState.lateJoiners);
+            else if (tabId === "timeline") updateTimeline(lastState.timeline);
+            else if (tabId === "transcript") updateTranscript(lastState.transcript);
+          }
+          if (tabId === "sessions") loadSavedSessions();
+        }, 150);
       }
     });
   });
@@ -165,6 +229,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       const sessionsTab = document.querySelector('[data-tab="sessions"]');
       if (sessionsTab?.classList.contains("active")) {
         loadSavedSessions();
+      } else {
+        loadedTabs.delete("sessions");
       }
     }
     if (message.type === "WAVEFORM_DATA" && Array.isArray(message.buckets)) {
@@ -351,22 +417,22 @@ document.addEventListener("DOMContentLoaded", async () => {
     updateInsights(state.keyInsights);
 
     // Topics Tab
-    updateTopics(state.topics);
+    if (loadedTabs.has("topics")) updateTopics(state.topics);
 
     // Decisions Tab
-    updateDecisions(state.decisions);
+    if (loadedTabs.has("decisions")) updateDecisions(state.decisions);
 
     // Actions Tab
-    updateActions(state.actionItems);
+    if (loadedTabs.has("actions")) updateActions(state.actionItems);
 
     // People Tab
-    updatePeople(state.participants, state.lateJoiners);
+    if (loadedTabs.has("people")) updatePeople(state.participants, state.lateJoiners);
 
     // Timeline Tab
-    updateTimeline(state.timeline);
+    if (loadedTabs.has("timeline")) updateTimeline(state.timeline);
 
     // Transcript Tab
-    updateTranscript(state.transcript);
+    if (loadedTabs.has("transcript")) updateTranscript(state.transcript);
   }
 
   // ——— Sentiment ———
@@ -997,6 +1063,5 @@ document.addEventListener("DOMContentLoaded", async () => {
     showToast("Downloaded as .md file", "success");
   }
 
-  // Load sessions on tab switch
-  document.querySelector('[data-tab="sessions"]')?.addEventListener("click", loadSavedSessions);
+  // Session loading is handled in the tab click listener now
 });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -184,16 +184,14 @@ document.addEventListener("DOMContentLoaded", async () => {
         loadedTabs.add(tabId);
         showSkeletonForTab(tabId);
         setTimeout(() => {
-          if (lastState) {
-            if (tabId === "topics") updateTopics(lastState.topics);
-            else if (tabId === "decisions") updateDecisions(lastState.decisions);
-            else if (tabId === "actions") updateActions(lastState.actionItems);
-            else if (tabId === "people")
-              updatePeople(lastState.participants, lastState.lateJoiners);
-            else if (tabId === "timeline") updateTimeline(lastState.timeline);
-            else if (tabId === "transcript") updateTranscript(lastState.transcript);
-          }
-          if (tabId === "sessions") loadSavedSessions();
+          if (tabId === "topics") updateTopics(lastState?.topics || []);
+          else if (tabId === "decisions") updateDecisions(lastState?.decisions || []);
+          else if (tabId === "actions") updateActions(lastState?.actionItems || []);
+          else if (tabId === "people")
+            updatePeople(lastState?.participants || [], lastState?.lateJoiners || []);
+          else if (tabId === "timeline") updateTimeline(lastState?.timeline || []);
+          else if (tabId === "transcript") updateTranscript(lastState?.transcript || []);
+          else if (tabId === "sessions") loadSavedSessions();
         }, 150);
       }
     });


### PR DESCRIPTION

Implemented lazy-loading for the dashboard side panel tabs to reduce initial DOM weight and improve startup performance, fulfilling the requirements for #109.

Key Changes:

🚀 Lazy Loading: Refactored the DOM rendering logic so that only the Overview tab loads initially. Other tabs are deferred until explicitly clicked.

💀 Skeleton UI: Added a lightweight, premium monochrome shimmering skeleton loader that displays while tab content is being fetched/rendered.

⚡ Optimized State: updateDashboard now only updates tabs that have been initialized, preventing unnecessary background processing.

Cleaned up console logs and ensured smooth, snappy transitions between tabs.

Fixes #109

Performance Metrics (Chrome DevTools)
Tested on Localhost via Chrome Performance Profiler.
Before Lazy-Loading: (LCP: 1.27s)
<img width="1919" height="978" alt="Screenshot 2026-05-28 183020" src="https://github.com/user-attachments/assets/31f4573b-8243-4db8-b465-a74634df6769" />
After Lazy-Loading: (LCP: 1.26s - with significantly reduced initial DOM tree size)
<img width="1919" height="988" alt="Screenshot 2026-05-28 183617" src="https://github.com/user-attachments/assets/cb6e4adc-cfc7-4b96-934c-9496c2545bf0" />
Type of Change
[x] ⚡ Performance improvement

Checklist
[x] My code follows the project's style guidelines

[x] Non-active tabs are not rendered until selected

[x] Smooth transition when switching tabs with skeleton loader

[x] ESLint checks pass locally without any errors

[x] TypeScript type checks pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added skeleton loader styling with shimmer animation and placeholder elements including avatars and text blocks

* **New Features**
  * Tabs now load content lazily upon first user activation

* **Refactor**
  * Dashboard now updates only visible tab panels instead of re-rendering all tabs on every state change
  * Sessions tab is automatically invalidated when a session ends, requiring refresh on next activation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->