### PR TITLE
fix: guard saved sessions against storage quota

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
+    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/utils/credentials.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,6 +2,16 @@
 
 import { State } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
+import {
+  deleteSavedMeetingSession,
+  discardPendingMeetingSession,
+  getSavedMeetingSessions,
+  isStorageQuotaError,
+  persistMeetingSession,
+  persistPendingMeetingSession,
+  savePendingMeetingSession,
+  StoredSession,
+} from "./sessionStorage";
 
 const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
@@ -274,6 +284,7 @@ function snapshot() {
     keyInsights: state.keyInsights,
     questionsRaised: state.questionsRaised,
     participants: state.participants,
+    initialParticipants: state.initialParticipants,
     lateJoiners: state.lateJoiners,
     timeline: state.timeline,
     transcript: state.transcript,
@@ -835,16 +846,29 @@ async function maybeWelcomeJoiners(tabId: number | undefined, joiners: string[])
 }
 
 async function savePendingSession() {
-  const session = {
+  const session: StoredSession = {
     id: crypto.randomUUID(),
     ...snapshot(),
     savedAt: Date.now(),
     isActive: false,
   };
-  await chrome.storage.local.set({ pendingSession: session });
+
+  inMemoryPendingSession = session;
+
+  try {
+    await savePendingMeetingSession(chrome.storage.local, session);
+  } catch (err) {
+    console.error("[LateMeet] Failed to save pending session:", err);
+    if (isStorageQuotaError(err)) {
+      console.error(
+        "[LateMeet] Storage quota reached while saving pending session. Keep this extension active and export the session before closing Chrome.",
+      );
+    }
+  }
 }
 
 let isProcessingSession = false;
+let inMemoryPendingSession: StoredSession | null = null;
 
 async function persistSession() {
   if (isProcessingSession) {
@@ -853,28 +877,15 @@ async function persistSession() {
   }
   isProcessingSession = true;
   try {
-    const { pendingSession, savedSessions } = await chrome.storage.local.get([
-      "pendingSession",
-      "savedSessions",
-    ]);
-    if (!pendingSession) {
-      console.log("[LateMeet] No pending session found to save.");
-      return;
+    let session: StoredSession;
+    try {
+      session = await persistPendingMeetingSession(chrome.storage.local);
+    } catch (err) {
+      if (!inMemoryPendingSession) throw err;
+      session = await persistMeetingSession(chrome.storage.local, inMemoryPendingSession);
     }
-
-    const sessions = Array.isArray(savedSessions) ? savedSessions : [];
-
-    // Check if the session ID already exists in savedSessions to prevent duplicate entries
-    const sessionExists = sessions.some((s: any) => s.id === pendingSession.id);
-    if (sessionExists) {
-      await chrome.storage.local.set({ pendingSession: null });
-      console.log("[LateMeet] Session already persisted, cleared pending session.");
-      return;
-    }
-
-    sessions.unshift(pendingSession);
-    await chrome.storage.local.set({ savedSessions: sessions, pendingSession: null });
-    console.log("[LateMeet] Session successfully saved:", pendingSession.id);
+    inMemoryPendingSession = null;
+    console.log("[LateMeet] Session successfully saved:", session.id);
   } catch (err) {
     console.error("[LateMeet] Error persisting session:", err);
     throw err;
@@ -890,7 +901,8 @@ async function discardPendingSession() {
   }
   isProcessingSession = true;
   try {
-    await chrome.storage.local.set({ pendingSession: null });
+    inMemoryPendingSession = null;
+    await discardPendingMeetingSession(chrome.storage.local);
     console.log("[LateMeet] Pending session discarded.");
   } catch (err) {
     console.error("[LateMeet] Error discarding session:", err);
@@ -1226,16 +1238,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
 
       case "GET_SAVED_SESSIONS": {
-        const { savedSessions } = await chrome.storage.local.get("savedSessions");
-        sendResponse(Array.isArray(savedSessions) ? savedSessions : []);
+        const sessions = await getSavedMeetingSessions(chrome.storage.local);
+        sendResponse(sessions);
         return;
       }
 
       case "DELETE_SAVED_SESSION": {
-        const { savedSessions } = await chrome.storage.local.get("savedSessions");
-        const sessions = Array.isArray(savedSessions) ? savedSessions : [];
-        const next = sessions.filter((s) => s.id !== message.sessionId);
-        await chrome.storage.local.set({ savedSessions: next });
+        await deleteSavedMeetingSession(chrome.storage.local, message.sessionId);
         sendResponse({ success: true });
         return;
       }

--- a/src/popup.css
+++ b/src/popup.css
@@ -772,6 +772,17 @@ body::-webkit-scrollbar-thumb {
   line-height: 1.5;
 }
 
+.session-modal-error {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.35);
+  border-radius: 8px;
+  color: #fecaca;
+  font-size: 12px;
+  line-height: 1.4;
+  margin: -8px 0 16px;
+  padding: 10px 12px;
+}
+
 .session-modal-actions {
   display: flex;
   gap: 10px;

--- a/src/popup.html
+++ b/src/popup.html
@@ -226,6 +226,7 @@
         <p class="session-modal-text">
           Would you like to save the intelligence and transcript for this session?
         </p>
+        <p id="session-modal-error" class="session-modal-error" hidden></p>
         <div class="session-modal-actions">
           <button id="discard-session-btn" class="session-btn discard">Discard</button>
           <button id="save-session-btn" class="session-btn save">Save Session</button>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -12,6 +12,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   const meetingSection = document.getElementById("meeting-section") as HTMLDivElement;
   const noMeetingSection = document.getElementById("no-meeting-section") as HTMLDivElement;
   const sessionModal = document.getElementById("session-modal") as HTMLDivElement;
+  const sessionModalError = document.getElementById(
+    "session-modal-error",
+  ) as HTMLParagraphElement | null;
 
   let lastState: State | null = null;
 
@@ -274,6 +277,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   function showSessionModal() {
     const saveBtn = document.getElementById("save-session-btn") as HTMLButtonElement | null;
     const discardBtn = document.getElementById("discard-session-btn") as HTMLButtonElement | null;
+    if (sessionModalError) {
+      sessionModalError.hidden = true;
+      sessionModalError.textContent = "";
+    }
     if (saveBtn) {
       saveBtn.disabled = false;
       saveBtn.textContent = "Save Session";
@@ -303,6 +310,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     btn.disabled = true;
     btn.textContent = "Saving...";
     btn.classList.add("loading");
+    if (sessionModalError) {
+      sessionModalError.hidden = true;
+      sessionModalError.textContent = "";
+    }
     if (discardBtn) {
       discardBtn.disabled = true;
     }
@@ -315,6 +326,13 @@ document.addEventListener("DOMContentLoaded", async () => {
       hideSessionModal();
     } catch (err) {
       console.error("[LateMeet] Failed to save session:", err);
+      if (sessionModalError) {
+        sessionModalError.hidden = false;
+        sessionModalError.textContent =
+          err instanceof Error
+            ? err.message
+            : "Unable to save this session. Export it from the dashboard before closing Chrome.";
+      }
       // Restore states on error
       btn.disabled = false;
       btn.textContent = originalText;

--- a/src/sessionStorage.test.ts
+++ b/src/sessionStorage.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSessionListItem,
+  estimateStorageBytes,
+  getSavedSessionKey,
+  isStorageQuotaError,
+  StoredSession,
+  upsertSessionIndex,
+} from "./sessionStorage";
+
+function makeSession(id: string, savedAt: number): StoredSession {
+  return {
+    id,
+    savedAt,
+    isActive: false,
+    meetingId: `meet-${id}`,
+    meetingUrl: null,
+    startTime: savedAt,
+    summary: `Summary ${id}`,
+    topics: [],
+    decisions: [],
+    actionItems: [],
+    currentTopic: "",
+    sentiment: "neutral",
+    keyInsights: [],
+    questionsRaised: [],
+    participants: [],
+    initialParticipants: [],
+    lateJoiners: [],
+    timeline: [{ event: "Meeting ended", timestamp: savedAt, elapsed: 10 }],
+    transcript: [{ speaker: "Audio", text: "A long transcript entry", timestamp: savedAt }],
+    audioActive: false,
+  };
+}
+
+test("saved session keys are namespaced by id", () => {
+  assert.equal(getSavedSessionKey("abc-123"), "savedSession:abc-123");
+});
+
+test("session list items omit large transcript and timeline payloads", () => {
+  const session = makeSession("one", 100);
+  const listItem = createSessionListItem(session);
+
+  assert.equal(listItem.id, session.id);
+  assert.equal(listItem.summary, session.summary);
+  assert.deepEqual(listItem.transcript, []);
+  assert.deepEqual(listItem.timeline, []);
+});
+
+test("upsertSessionIndex places newest sessions first and deduplicates ids", () => {
+  const first = makeSession("first", 100);
+  const second = makeSession("second", 200);
+  const updatedFirst = { ...first, savedAt: 300, summary: "Updated summary" };
+
+  const index = upsertSessionIndex(upsertSessionIndex([first], second), updatedFirst);
+
+  assert.deepEqual(
+    index.map((session) => session.id),
+    ["first", "second"],
+  );
+  assert.equal(index[0].summary, "Updated summary");
+});
+
+test("upsertSessionIndex enforces max session count", () => {
+  const sessions = Array.from({ length: 5 }, (_, index) => makeSession(`session-${index}`, index));
+  const next = upsertSessionIndex(sessions, makeSession("new", 10), 3);
+
+  assert.deepEqual(
+    next.map((session) => session.id),
+    ["new", "session-0", "session-1"],
+  );
+});
+
+test("quota errors are detected from Chrome storage messages", () => {
+  assert.equal(isStorageQuotaError(new Error("QUOTA_BYTES quota exceeded")), true);
+  assert.equal(isStorageQuotaError(new Error("Network request failed")), false);
+});
+
+test("storage byte estimates increase with payload size", () => {
+  assert.ok(estimateStorageBytes({ text: "large payload" }) > estimateStorageBytes({ text: "" }));
+});

--- a/src/sessionStorage.ts
+++ b/src/sessionStorage.ts
@@ -1,0 +1,202 @@
+import { State } from "./types";
+
+export const PENDING_SESSION_KEY = "pendingSession";
+export const SAVED_SESSIONS_LEGACY_KEY = "savedSessions";
+export const SAVED_SESSION_INDEX_KEY = "savedSessionIndex";
+export const MAX_SAVED_SESSIONS = 20;
+export const STORAGE_SOFT_LIMIT_BYTES = 8_500_000;
+
+export type StoredSession = State & {
+  id: string;
+  savedAt: number;
+};
+
+type StorageArea = Pick<chrome.storage.StorageArea, "get" | "set" | "remove"> & {
+  getBytesInUse?: chrome.storage.StorageArea["getBytesInUse"];
+};
+
+function asStoredSession(value: unknown): StoredSession | null {
+  if (!value || typeof value !== "object") return null;
+  const session = value as Partial<StoredSession>;
+  if (!session.id || !session.savedAt) return null;
+  return session as StoredSession;
+}
+
+export function getSavedSessionKey(sessionId: string): string {
+  return `savedSession:${sessionId}`;
+}
+
+export function estimateStorageBytes(value: unknown): number {
+  const serialized = JSON.stringify(value ?? null);
+  return new TextEncoder().encode(serialized).byteLength;
+}
+
+export function isStorageQuotaError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err || "");
+  return /quota|QUOTA_BYTES|storage/i.test(message);
+}
+
+export function createSessionListItem(session: StoredSession): StoredSession {
+  return {
+    ...session,
+    transcript: [],
+    timeline: [],
+  };
+}
+
+export function upsertSessionIndex(
+  index: StoredSession[],
+  session: StoredSession,
+  maxSessions = MAX_SAVED_SESSIONS,
+): StoredSession[] {
+  return [createSessionListItem(session), ...index.filter((item) => item.id !== session.id)].slice(
+    0,
+    maxSessions,
+  );
+}
+
+async function getBytesInUse(storage: StorageArea, keys?: string | string[] | null) {
+  if (!storage.getBytesInUse) return 0;
+  return storage.getBytesInUse(keys ?? null);
+}
+
+async function removeSessionPayloads(storage: StorageArea, sessions: StoredSession[]) {
+  const keys = sessions.map((session) => getSavedSessionKey(session.id));
+  if (keys.length > 0) {
+    await storage.remove(keys);
+  }
+}
+
+async function pruneSessionsForQuota(
+  storage: StorageArea,
+  index: StoredSession[],
+  incomingBytes: number,
+) {
+  const nextIndex = [...index];
+  const pruned: StoredSession[] = [];
+
+  while (nextIndex.length > MAX_SAVED_SESSIONS - 1) {
+    const session = nextIndex.pop();
+    if (session) pruned.push(session);
+  }
+
+  let currentBytes = await getBytesInUse(storage, null);
+  while (
+    currentBytes > 0 &&
+    currentBytes + incomingBytes > STORAGE_SOFT_LIMIT_BYTES &&
+    nextIndex.length > 0
+  ) {
+    const session = nextIndex.pop();
+    if (!session) break;
+
+    const key = getSavedSessionKey(session.id);
+    const payloadBytes = await getBytesInUse(storage, key);
+    pruned.push(session);
+    currentBytes = Math.max(0, currentBytes - payloadBytes);
+  }
+
+  if (pruned.length > 0) {
+    await removeSessionPayloads(storage, pruned);
+  }
+
+  return nextIndex;
+}
+
+export async function savePendingMeetingSession(
+  storage: StorageArea,
+  session: StoredSession,
+): Promise<void> {
+  await storage.set({ [PENDING_SESSION_KEY]: session });
+}
+
+export async function persistPendingMeetingSession(storage: StorageArea): Promise<StoredSession> {
+  const values = await storage.get([
+    PENDING_SESSION_KEY,
+    SAVED_SESSION_INDEX_KEY,
+    SAVED_SESSIONS_LEGACY_KEY,
+  ]);
+  const pendingSession = asStoredSession(values[PENDING_SESSION_KEY]);
+
+  if (!pendingSession) {
+    throw new Error("No pending session found to save.");
+  }
+
+  const session = await persistMeetingSession(storage, pendingSession);
+  await storage.set({ [PENDING_SESSION_KEY]: null });
+
+  return session;
+}
+
+export async function persistMeetingSession(
+  storage: StorageArea,
+  pendingSession: StoredSession,
+): Promise<StoredSession> {
+  const values = await storage.get([SAVED_SESSION_INDEX_KEY, SAVED_SESSIONS_LEGACY_KEY]);
+  const legacySessions = Array.isArray(values[SAVED_SESSIONS_LEGACY_KEY])
+    ? (values[SAVED_SESSIONS_LEGACY_KEY].map(asStoredSession).filter(Boolean) as StoredSession[])
+    : [];
+  const indexedSessions = Array.isArray(values[SAVED_SESSION_INDEX_KEY])
+    ? (values[SAVED_SESSION_INDEX_KEY].map(asStoredSession).filter(Boolean) as StoredSession[])
+    : [];
+  const currentIndex =
+    indexedSessions.length > 0 ? indexedSessions : legacySessions.map(createSessionListItem);
+
+  if (currentIndex.some((session) => session.id === pendingSession.id)) {
+    return pendingSession;
+  }
+
+  const sessionKey = getSavedSessionKey(pendingSession.id);
+  const incomingBytes = estimateStorageBytes({
+    [sessionKey]: pendingSession,
+    [SAVED_SESSION_INDEX_KEY]: upsertSessionIndex(currentIndex, pendingSession),
+  });
+  const prunedIndex = await pruneSessionsForQuota(storage, currentIndex, incomingBytes);
+  const nextIndex = upsertSessionIndex(prunedIndex, pendingSession);
+
+  await storage.set({
+    [sessionKey]: pendingSession,
+    [SAVED_SESSION_INDEX_KEY]: nextIndex,
+  });
+
+  return pendingSession;
+}
+
+export async function discardPendingMeetingSession(storage: StorageArea): Promise<void> {
+  await storage.set({ [PENDING_SESSION_KEY]: null });
+}
+
+export async function getSavedMeetingSessions(storage: StorageArea): Promise<StoredSession[]> {
+  const values = await storage.get([SAVED_SESSION_INDEX_KEY, SAVED_SESSIONS_LEGACY_KEY]);
+  const indexedSessions = Array.isArray(values[SAVED_SESSION_INDEX_KEY])
+    ? (values[SAVED_SESSION_INDEX_KEY].map(asStoredSession).filter(Boolean) as StoredSession[])
+    : [];
+
+  if (indexedSessions.length > 0) {
+    return indexedSessions;
+  }
+
+  return Array.isArray(values[SAVED_SESSIONS_LEGACY_KEY])
+    ? (values[SAVED_SESSIONS_LEGACY_KEY].map(asStoredSession).filter(Boolean) as StoredSession[])
+    : [];
+}
+
+export async function deleteSavedMeetingSession(
+  storage: StorageArea,
+  sessionId: string,
+): Promise<void> {
+  const values = await storage.get([SAVED_SESSION_INDEX_KEY, SAVED_SESSIONS_LEGACY_KEY]);
+  const indexedSessions = Array.isArray(values[SAVED_SESSION_INDEX_KEY])
+    ? (values[SAVED_SESSION_INDEX_KEY].map(asStoredSession).filter(Boolean) as StoredSession[])
+    : [];
+  const legacySessions = Array.isArray(values[SAVED_SESSIONS_LEGACY_KEY])
+    ? values[SAVED_SESSIONS_LEGACY_KEY].filter(
+        (session: Partial<StoredSession>) => session.id !== sessionId,
+      )
+    : [];
+
+  await storage.remove(getSavedSessionKey(sessionId));
+  await storage.set({
+    [SAVED_SESSION_INDEX_KEY]: indexedSessions.filter((session) => session.id !== sessionId),
+    [SAVED_SESSIONS_LEGACY_KEY]: legacySessions,
+  });
+}


### PR DESCRIPTION
## Description

  Fixes saved meeting sessions hitting Chrome storage quota by moving full session payloads into per-session
  storage keys and keeping the saved sessions list as a lightweight index. This also prunes older saved session
  payloads when storage is near the soft limit, keeps an in-memory pending session fallback if pending-session
  storage fails, and shows a popup error when saving a session cannot complete.

  Adds focused tests for session storage namespacing, index deduplication, quota detection, payload trimming,
  and storage byte estimation.

  Fixes #128 

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] 📝 Documentation update
  - [ ] 🎨 UI/UX improvement
  - [ ] ♻️ Code refactoring (no functional changes)
  - [x] 🧪 Tests

  ## How Has This Been Tested?

  - [x] Built the extension with `npm run build`
  - [ ] Loaded the extension in Chrome and tested manually
  - [ ] Tested on a live Google Meet call
  - [ ] Verified no console errors
  - [ ] Tested with ElevenLabs API key
  - [ ] Tested with OpenAI API key

  Additional checks run:

  - `npm run type-check`
  - `npm run lint`
  - `npm test`

  ## Screenshots (if applicable)

  Not applicable. No visual UI changes beyond an error message area in the existing save-session modal.

  ## Checklist

  - [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
  - [x] I have performed a self-review of my code
  - [x] I have commented my code where necessary
  - [ ] My code follows the formatting of this project (run `npm run format`)
  - [x] ESLint checks pass locally without any errors (run `npm run lint`)
  - [x] TypeScript type checks pass locally (run `npm run type-check`)
  - [x] My changes generate no new warnings or errors
  - [x] I have updated the documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session persistence with automatic storage management to retain meeting data
  * Added error notifications when session save or discard operations fail

* **Chores**
  * Updated test script configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->