### PR TITLE
fix: decouple audio chunk processing from capture

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
+    "test": "tsx --test src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/audioChunkQueue.test.ts
+++ b/src/audioChunkQueue.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { AudioChunkQueue } from "./audioChunkQueue.ts";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+async function waitForDrain() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+test("audio chunk queue acknowledges enqueue before processing finishes", async () => {
+  const gate = deferred<void>();
+  const processed: string[] = [];
+  const queue = new AudioChunkQueue<string>({
+    maxPending: 4,
+    process: async ({ item }) => {
+      await gate.promise;
+      processed.push(item);
+    },
+  });
+
+  const result = queue.enqueue("first");
+
+  assert.equal(result.accepted, true);
+  assert.equal(queue.isProcessing, true);
+  assert.deepEqual(processed, []);
+
+  gate.resolve();
+  await waitForDrain();
+
+  assert.deepEqual(processed, ["first"]);
+});
+
+test("audio chunk queue processes chunks in deterministic FIFO order", async () => {
+  const processed: string[] = [];
+  const queue = new AudioChunkQueue<string>({
+    maxPending: 4,
+    process: async ({ item }) => {
+      processed.push(item);
+    },
+  });
+
+  queue.enqueue("one");
+  queue.enqueue("two");
+  queue.enqueue("three");
+
+  await waitForDrain();
+
+  assert.deepEqual(processed, ["one", "two", "three"]);
+});
+
+test("audio chunk queue continues after a chunk processing failure", async () => {
+  const processed: string[] = [];
+  const errors: string[] = [];
+  const queue = new AudioChunkQueue<string>({
+    maxPending: 4,
+    process: async ({ item }) => {
+      if (item === "bad") throw new Error("stt failed");
+      processed.push(item);
+    },
+    onError: (err) => {
+      errors.push(err instanceof Error ? err.message : String(err));
+    },
+  });
+
+  queue.enqueue("bad");
+  queue.enqueue("next");
+
+  await waitForDrain();
+
+  assert.deepEqual(errors, ["stt failed"]);
+  assert.deepEqual(processed, ["next"]);
+});
+
+test("audio chunk queue rejects new chunks when pending backlog is full", async () => {
+  const gate = deferred<void>();
+  const queue = new AudioChunkQueue<string>({
+    maxPending: 2,
+    process: async () => {
+      await gate.promise;
+    },
+  });
+
+  assert.equal(queue.enqueue("active").accepted, true);
+  assert.equal(queue.enqueue("pending-1").accepted, true);
+  assert.equal(queue.enqueue("pending-2").accepted, true);
+
+  const rejected = queue.enqueue("overflow");
+
+  assert.equal(rejected.accepted, false);
+  assert.equal(rejected.error, "Audio chunk queue is full");
+
+  gate.resolve();
+  await waitForDrain();
+});

--- a/src/audioChunkQueue.ts
+++ b/src/audioChunkQueue.ts
@@ -1,0 +1,90 @@
+export interface AudioChunkQueueItem<T> {
+  id: number;
+  item: T;
+}
+
+export interface AudioChunkQueueResult {
+  accepted: boolean;
+  id?: number;
+  pending: number;
+  error?: string;
+}
+
+interface AudioChunkQueueOptions<T> {
+  maxPending: number;
+  process: (entry: AudioChunkQueueItem<T>) => Promise<void>;
+  onError?: (error: unknown, entry: AudioChunkQueueItem<T>) => void | Promise<void>;
+}
+
+export class AudioChunkQueue<T> {
+  private readonly maxPending: number;
+  private readonly process: AudioChunkQueueOptions<T>["process"];
+  private readonly onError?: AudioChunkQueueOptions<T>["onError"];
+  private pendingItems: AudioChunkQueueItem<T>[] = [];
+  private processing = false;
+  private nextId = 1;
+
+  constructor(options: AudioChunkQueueOptions<T>) {
+    this.maxPending = Math.max(1, options.maxPending);
+    this.process = options.process;
+    this.onError = options.onError;
+  }
+
+  get pending() {
+    return this.pendingItems.length;
+  }
+
+  get isProcessing() {
+    return this.processing;
+  }
+
+  enqueue(item: T): AudioChunkQueueResult {
+    if (this.pendingItems.length >= this.maxPending) {
+      return {
+        accepted: false,
+        pending: this.pendingItems.length,
+        error: "Audio chunk queue is full",
+      };
+    }
+
+    const entry = {
+      id: this.nextId,
+      item,
+    };
+    this.nextId += 1;
+
+    this.pendingItems.push(entry);
+    void this.drain();
+
+    return {
+      accepted: true,
+      id: entry.id,
+      pending: this.pendingItems.length,
+    };
+  }
+
+  clear() {
+    this.pendingItems = [];
+  }
+
+  private async drain() {
+    if (this.processing) return;
+
+    this.processing = true;
+
+    try {
+      while (this.pendingItems.length > 0) {
+        const entry = this.pendingItems.shift();
+        if (!entry) continue;
+
+        try {
+          await this.process(entry);
+        } catch (err) {
+          await this.onError?.(err, entry);
+        }
+      }
+    } finally {
+      this.processing = false;
+    }
+  }
+}

--- a/src/background.ts
+++ b/src/background.ts
@@ -2,6 +2,7 @@
 
 import { State } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
+import { AudioChunkQueue, AudioChunkQueueItem } from "./audioChunkQueue";
 
 const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
@@ -12,6 +13,7 @@ const TRANSCRIPT_WINDOW_SIZE = 25;
 const SUMMARIZATION_MAX_TOKENS = 1200;
 const JOINER_MESSAGE_MAX_TOKENS = 120;
 const ELEVENLABS_STT_MODEL = "scribe_v2";
+const MAX_PENDING_AUDIO_CHUNKS = 8;
 // Delay late-joiner auto messages until 10s to avoid lobby/join churn spam.
 const MIN_MEETING_DURATION_FOR_WELCOME = 10;
 
@@ -241,6 +243,7 @@ function resetState() {
   state.targetTabId = null;
   state.lastSummarizedAt = 0;
   state.pendingJoiners.clear();
+  audioChunkQueue.clear();
   state.participantCount = 0;
   selfParticipantName = null;
 }
@@ -702,6 +705,55 @@ Return a JSON object with these exact keys:
     summaryInFlight = false;
   }
 }
+
+interface QueuedAudioChunk {
+  audioBase64: string;
+  mimeType: string;
+  approxBytes: number;
+  receivedAt: number;
+}
+
+async function processQueuedAudioChunk({ id, item }: AudioChunkQueueItem<QueuedAudioChunk>) {
+  if (!state.isActive) {
+    console.warn(`[LateMeet] queued audio chunk ${id} ignored because session is inactive`);
+    return;
+  }
+
+  console.log(
+    `[LateMeet] processing queued chunk ${id} — ~${item.approxBytes} bytes  mimeType=${item.mimeType}`,
+  );
+
+  const prompt = getTranscriptionPrompt();
+  const rawText = await transcribeChunk(item.audioBase64, item.mimeType, prompt);
+
+  if (!rawText) {
+    console.warn(`[LateMeet] STT returned empty for queued chunk ${id}`);
+    return;
+  }
+
+  console.log(`[LateMeet] transcript received for chunk ${id} — ${rawText.length} chars`);
+  const refinedText = await refineTranscription(rawText);
+  console.log(`[LateMeet] transcript refined for chunk ${id} — ${refinedText.length} chars`);
+
+  state.transcript.push({
+    speaker: "Audio",
+    text: refinedText,
+    timestamp: item.receivedAt,
+  });
+
+  await summarizeTranscriptIfNeeded();
+  await broadcastStateUpdate();
+}
+
+const audioChunkQueue = new AudioChunkQueue<QueuedAudioChunk>({
+  maxPending: MAX_PENDING_AUDIO_CHUNKS,
+  process: processQueuedAudioChunk,
+  onError: async (err, { id }) => {
+    console.error(`[LateMeet] queued chunk ${id} processing failed:`, err);
+    addTimeline(`Audio chunk ${id} processing failed`);
+    await broadcastStateUpdate();
+  },
+});
 
 function detectNewJoiners(currentList: string[]) {
   if (state.participants.length === 0 && state.initialParticipants.length === 0) {
@@ -1167,30 +1219,41 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           return;
         }
 
+        if (typeof message.audioBase64 !== "string" || !message.audioBase64) {
+          sendResponse({ success: false, error: "Missing audio chunk payload" });
+          return;
+        }
+
         const base64Len = message.audioBase64?.length ?? 0;
         const approxBytes = Math.round((base64Len * 3) / 4);
         console.log(
           `[LateMeet] chunk received — ~${approxBytes} bytes  mimeType=${message.mimeType}`,
         );
 
-        try {
-          const prompt = getTranscriptionPrompt();
-          const rawText = await transcribeChunk(message.audioBase64, message.mimeType, prompt);
-          if (rawText) {
-            console.log(`[LateMeet] transcript received — ${rawText.length} chars`);
-            const refinedText = await refineTranscription(rawText);
-            console.log(`[LateMeet] transcript refined — ${refinedText.length} chars`);
-            state.transcript.push({ speaker: "Audio", text: refinedText, timestamp: Date.now() });
-            await summarizeTranscriptIfNeeded();
-            await broadcastStateUpdate();
-          } else {
-            console.warn("[LateMeet] STT returned empty — chunk may be silent or too short");
-          }
-          sendResponse({ success: true });
-        } catch (err) {
-          console.error("[LateMeet] chunk processing failed:", err);
-          sendResponse({ success: false, error: (err as Error).message });
+        const result = audioChunkQueue.enqueue({
+          audioBase64: message.audioBase64,
+          mimeType: typeof message.mimeType === "string" ? message.mimeType : "audio/webm",
+          approxBytes,
+          receivedAt: Date.now(),
+        });
+
+        if (!result.accepted) {
+          console.warn("[LateMeet] audio chunk queue full — chunk rejected");
+          sendResponse({
+            success: false,
+            queued: false,
+            pending: result.pending,
+            error: result.error,
+          });
+          return;
         }
+
+        sendResponse({
+          success: true,
+          queued: true,
+          chunkId: result.id,
+          pending: result.pending,
+        });
         return;
       }
 

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -186,11 +186,15 @@ async function postChunk(blob: Blob) {
   relay(`sending chunk — ${blob.size} bytes  mimeType=${mimeType}`);
 
   try {
-    await chrome.runtime.sendMessage({
+    const response = await chrome.runtime.sendMessage({
       type: "OFFSCREEN_AUDIO_CHUNK",
       audioBase64,
       mimeType,
     });
+
+    if (!response?.success) {
+      relay(`chunk rejected by background — ${response?.error || "unknown error"}`);
+    }
   } catch (err) {
     console.error("[LateMeet][offscreen] Failed to send chunk:", err);
   }


### PR DESCRIPTION
## Description

Fixes #127

This PR prevents the offscreen MediaRecorder/VAD loop from waiting on slow STT, refinement, or summarization API calls. The background service worker now acknowledges audio chunks quickly after validation and enqueues them into a bounded FIFO processor, so capture can continue enforcing VAD timing and the 25s overflow cap independently of remote API latency.

Changes include:
- Add a reusable bounded `AudioChunkQueue` helper for serial chunk processing.
- Move `OFFSCREEN_AUDIO_CHUNK` transcription/refinement/summarization work behind the queue.
- Keep processing order deterministic while allowing failed chunks to be logged and skipped without stopping later chunks.
- Report background queue rejection back to the offscreen document when the backlog is full.
- Add focused tests for quick enqueue acknowledgement, FIFO ordering, failure recovery, and bounded backlog behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [x] Tests

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [ ] Loaded the extension in Chrome and tested manually
- [ ] Tested on a live Google Meet call
- [ ] Verified no console errors
- [ ] Tested with ElevenLabs API key
- [ ] Tested with OpenAI API key

Additional checks:
- `npm run type-check`
- `npm test`
- `npm run lint`
- `npm run format:check`

## Screenshots (if applicable)

Not applicable. No visual UI changes.

## Checklist

- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed
