### PR TITLE
docs: add .editorconfig for consistent code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{js,mjs,cjs,jsx,ts,tsx,json,jsonc,css,html,svg}]
+indent_style = space
+indent_size = 2
+
+[.{prettierrc,prettierignore,gitignore}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{bat,cmd,ps1}]
+end_of_line = crlf


### PR DESCRIPTION
## Description

Added a root-level `.editorconfig` file to standardize basic editor formatting across the repository. The configuration defines UTF-8 encoding, LF line endings by default, final newline insertion, trailing whitespace trimming, and 2-space indentation for the project’s TypeScript, JavaScript, JSON, CSS, HTML, SVG, Markdown, and YAML files.

It also includes formatting rules for existing config files such as `.prettierrc`, `.prettierignore`, and `.gitignore`, plus CRLF line endings for Windows script files.

Fixes #148 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ ] Built the extension with `npm run build`
- [ ] Loaded the extension in Chrome and tested manually
- [ ] Tested on a live Google Meet call
- [ ] Verified no console errors
- [ ] Tested with ElevenLabs API key
- [ ] Tested with OpenAI API key

Configuration-only change. No extension runtime testing was required. I reviewed `.editorconfig` for formatting consistency and alignment with the repository’s TypeScript/Vite, Markdown, YAML, CSS, HTML, SVG, and config files.

## Screenshots (if applicable)

N/A

## Checklist

- [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed