### PR TITLE
Fix: Resolve DOM race condition and state persistence for Accent Colors

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -93,10 +93,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
+  let selectedAccentColor = settings.accent || "210, 100%, 50%";
+
   // ——— NEW: Theme & Color Initializations ———
   const themeSelect = document.getElementById("theme-select") as HTMLSelectElement | null;
   const currentTheme = settings.theme || "system";
-  const currentAccent = settings.accent || "210, 100%, 50%";
+  const currentAccent = selectedAccentColor;
 
   if (themeSelect) {
     themeSelect.value = currentTheme;
@@ -118,9 +120,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       dot.classList.add("active");
 
       const selectedTheme = (themeSelect?.value as Settings["theme"]) || "system";
-      const selectedAccent =
-        dot.getAttribute("data-color") || settings.accent || currentAccent || "210, 100%, 50%";
-      applyThemePreview(selectedTheme, selectedAccent);
+      selectedAccentColor = dot.getAttribute("data-color") || "210, 100%, 50%";
+      applyThemePreview(selectedTheme, selectedAccentColor);
     });
   });
 
@@ -130,9 +131,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (!selectedTheme) {
       selectedTheme = "system";
     }
-    const activeDot = document.querySelector(".color-dot.active");
-    const selectedAccent = activeDot?.getAttribute("data-color") || "210, 100%, 50%";
-    applyThemePreview(selectedTheme, selectedAccent);
+    applyThemePreview(selectedTheme, selectedAccentColor);
   });
 
   // ——— Toggle password visibility ———
@@ -189,10 +188,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           ? 0.012
           : parsedVadThreshold;
 
-      // Grab the active selected color dot element from the document view
-      const activeColorDot = document.querySelector(".color-dot.active");
-
       const newSettings: Settings = {
+        ...settings, // Retain existing unmapped fields
         summarizationInterval: validatedInterval,
         vadThreshold: validatedVadThreshold,
         aiModel: (document.getElementById("ai-model") as HTMLSelectElement)?.value,
@@ -207,11 +204,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
         // Save theme selections into the global config tree bundle block
         theme: (themeSelect?.value as Settings["theme"]) || "system",
-        accent:
-          activeColorDot?.getAttribute("data-color") ||
-          settings.accent ||
-          currentAccent ||
-          "210, 100%, 50%",
+        accent: selectedAccentColor,
       };
 
       await Promise.all([


### PR DESCRIPTION
## Description

This PR resolves a bug where the user's accent color preferences were failing to update or reflect across the UI properly after clicking "Save Settings". 

The save handler in `options.ts` was relying on a fragile DOM query (`document.querySelector(".color-dot.active")`) precisely at the moment of saving, causing race conditions where it fell back to the old color. Furthermore, `newSettings` was entirely overwriting the Chrome storage payload without spreading the previous settings (`...settings`), risking silent data loss for unmapped properties.

This fix refactors the color selection logic to track state explicitly via a variable tied to grid `click` events, and safely preserves existing configurations during saves using the spread operator.

Fixes #150 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Built the extension with `npm run build`
- [x] Loaded the extension in Chrome and tested manually
- [ ] Tested on a live Google Meet call
- [x] Verified no console errors
- [ ] Tested with ElevenLabs API key
- [ ] Tested with OpenAI API key


## Checklist

- [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined accent color selection and persistence logic in the options page for improved code reliability and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->