### PR TITLE
Fix: Persist meeting sessions automatically on unexpected track end

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1238,6 +1238,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         return;
       }
 
+      case "UNEXPECTED_TRACK_END": {
+        await stopAudioCapture("Tab closed");
+        sendResponse({ success: true });
+        return;
+      }
+
       case "OFFSCREEN_LOG": {
         console.log("[LateMeet][offscreen]", message.message);
         sendResponse({ success: true });

--- a/src/background.ts
+++ b/src/background.ts
@@ -1239,7 +1239,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
 
       case "UNEXPECTED_TRACK_END": {
-        await stopAudioCapture("Tab closed");
+        await stopAudioCapture("Unexpected track end");
         sendResponse({ success: true });
         return;
       }

--- a/src/background.ts
+++ b/src/background.ts
@@ -1112,30 +1112,41 @@ async function scanForMeetTabs() {
   }
 }
 
+let isStoppingAudio = false;
+
 async function stopAudioCapture(reason = "Stopped") {
+  if (isStoppingAudio) {
+    console.log("[LateMeet] stop already in progress, skipping duplicate request.");
+    return;
+  }
+  isStoppingAudio = true;
   try {
-    await chrome.runtime.sendMessage({ type: "OFFSCREEN_STOP_CAPTURE" });
-  } catch {
-    // Ignore if offscreen not running
+    try {
+      await chrome.runtime.sendMessage({ type: "OFFSCREEN_STOP_CAPTURE" });
+    } catch {
+      // Ignore if offscreen not running
+    }
+
+    if (state.audioActive) {
+      addTimeline(`Meeting ended (${reason})`);
+      await savePendingSession();
+    }
+
+    state.audioActive = false;
+    state.isActive = false;
+
+    await broadcastStateUpdate();
+
+    try {
+      await chrome.runtime.sendMessage({ type: "SESSION_ENDED" });
+    } catch {
+      // no listeners
+    }
+
+    await closeOffscreenDocumentIfPresent();
+  } finally {
+    isStoppingAudio = false;
   }
-
-  if (state.audioActive) {
-    addTimeline(`Meeting ended (${reason})`);
-    await savePendingSession();
-  }
-
-  state.audioActive = false;
-  state.isActive = false;
-
-  await broadcastStateUpdate();
-
-  try {
-    await chrome.runtime.sendMessage({ type: "SESSION_ENDED" });
-  } catch {
-    // no listeners
-  }
-
-  await closeOffscreenDocumentIfPresent();
 }
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1239,7 +1239,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
 
       case "UNEXPECTED_TRACK_END": {
-        await stopAudioCapture("Unexpected track end");
+        await stopAudioCapture(message.reason || "Unexpected track end");
         sendResponse({ success: true });
         return;
       }

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -333,6 +333,8 @@ async function startCapture(
         await stopCapture();
       } catch (err) {
         console.error("[LateMeet][offscreen] Cleanup after track end failed:", err);
+      } finally {
+        await chrome.runtime.sendMessage({ type: "UNEXPECTED_TRACK_END" }).catch(() => {});
       }
     };
   });

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -334,7 +334,12 @@ async function startCapture(
       } catch (err) {
         console.error("[LateMeet][offscreen] Cleanup after track end failed:", err);
       } finally {
-        await chrome.runtime.sendMessage({ type: "UNEXPECTED_TRACK_END" }).catch(() => {});
+        await chrome.runtime
+          .sendMessage({
+            type: "UNEXPECTED_TRACK_END",
+            reason: "Track ended unexpectedly (tab closed or mic disconnected)",
+          })
+          .catch(() => {});
       }
     };
   });


### PR DESCRIPTION
## Description

This PR resolves a critical silent data loss bug that occurs when a user leaves a Google Meet by closing the tab directly rather than using the "Stop Recording" UI. 

Previously, `offscreen.ts` correctly handled the `track.onended` event by cleaning up local memory but failed to notify `background.ts` that the track unexpectedly ended. As a result, the background worker never executed `savePendingSession()`, leaving the entire meeting transcript stuck in memory until the Service Worker eventually suspended (destroying the data) and leaving `state.isActive` permanently desynced.

This fix wires up an `UNEXPECTED_TRACK_END` message dispatch within the `offscreen.ts` teardown block, ensuring the background worker gracefully wraps up the session, resets state, and persists the transcript properly when the tab closes.

Fixes #153 

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Built the extension with `npm run build`
- [x] Loaded the extension in Chrome and tested manually
- [x] Verified no console errors
- [ ] Tested on a live Google Meet call
- [ ] Tested with ElevenLabs API key
- [ ] Tested with OpenAI API key

## Screenshots (if applicable)

*(N/A - This is a background script data-lifecycle fix, so no UI changes occurred)*

## Checklist

- [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio capture reliability when a recording track ends unexpectedly: capture now stops cleanly, resources are released, and the system notifies the background service to ensure smooth recovery.
  * Reduced chance of stalled or orphaned captures by adding consistent cleanup and notification steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->