### PR TITLE
refactor: move pendingJoiners to transient internal state

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -219,11 +219,20 @@ const state: State = {
   audioActive: false,
   targetTabId: null,
   lastSummarizedAt: 0,
-  pendingJoiners: new Set(),
   participantCount: 0,
 };
 
 let selfParticipantName: string | null = null;
+
+// ---------------------------------------------------------------------------
+// Transient Late-Joiner Processing State
+// ---------------------------------------------------------------------------
+// Tracks which late joiners are currently being processed for welcome messages.
+// This is NOT persisted or shared with UI — it's purely for preventing duplicate
+// welcome message sends during the maybeWelcomeJoiners() workflow.
+// Entries are added when processing begins and removed when it completes (see finally block).
+// This state is discarded on service worker suspension and not restored.
+const pendingJoinersInFlight = new Set<string>();
 
 function normalizeParticipantName(value: string | null | undefined): string {
   return String(value || "")
@@ -252,7 +261,7 @@ function resetState() {
   state.audioActive = false;
   state.targetTabId = null;
   state.lastSummarizedAt = 0;
-  state.pendingJoiners.clear();
+  pendingJoinersInFlight.clear();
   audioChunkQueue.clear();
   state.participantCount = 0;
   selfParticipantName = null;
@@ -881,18 +890,18 @@ async function maybeWelcomeJoiners(tabId: number | undefined, joiners: string[])
       !name ||
       normalizedName === normalizeParticipantName("You") ||
       (normalizedSelf && normalizedName === normalizedSelf) ||
-      state.pendingJoiners.has(name)
+      pendingJoinersInFlight.has(name)
     ) {
       continue;
     }
 
-    state.pendingJoiners.add(name);
+    pendingJoinersInFlight.add(name);
     try {
       const text = await generateLateJoinerMessage(name);
       await sendChatToTab(tabId, text);
       addTimeline(`Late joiner brief sent to ${name}`);
     } finally {
-      state.pendingJoiners.delete(name);
+      pendingJoinersInFlight.delete(name);
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,7 +54,6 @@ export interface State {
   targetTabId?: number | null;
   lastSummarizedAt?: number;
   duration?: number;
-  pendingJoiners?: any;
   participantCount?: number;
   id?: string;
   savedAt?: number;


### PR DESCRIPTION
## Overview

This PR resolves the architectural inconsistency around `pendingJoiners` by moving it out of the shared `State` interface into module-level transient state.

After investigating usage across the codebase, `pendingJoiners` appears to be used exclusively as temporary in-flight tracking for the Late Joiner Briefing workflow and is never consumed by UI components or persistence logic.

## Changes

### src/background.ts
- Move `pendingJoiners` from shared `state` object → module-level `pendingJoinersInFlight`
- Rename for clearer intent (`pendingJoiners` → `pendingJoinersInFlight`)
- Add inline comment documenting lifecycle and purpose
- Update `resetState()` cleanup
- Update `maybeWelcomeJoiners()` references

### src/types.ts
- Remove `pendingJoiners?: any` from `State` interface

## Why?

Previously, `pendingJoiners` lived inside the shared `State` object but was:

- Never included in `snapshot()`
- Never referenced by dashboard/popup UI
- Never persisted in sessions
- Used only internally in `background.ts`

This created ambiguity about whether the field was intended to be serialized or externally consumed.

Moving it to module-level state clarifies that it is transient internal tracking rather than shareable meeting state.

## Impact

- No behavior changes
- No snapshot/persistence changes
- No UI impact
- Improved type safety and maintainability
- Clearer separation between internal vs shared state

## Testing

- Verified late-joiner flow still works
- Updated all references to `pendingJoiners`
- Confirmed no snapshot or UI dependencies exist



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when participants join meetings late, preventing potential duplicate notifications from being sent

* **Refactor**
  * Enhanced state tracking system with expanded session metadata for improved meeting information management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->