### PR TITLE
[PERF]: Redundant theme initialization in headless offscreen document

### DIFF
--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,7 +1,4 @@
 import { VoiceActivityTracker, isChunkViable } from "./audioProcessing";
-import { initTheme } from "./theme.js";
-
-initTheme();
 
 let mediaStream: MediaStream | null = null;
 let microphoneStream: MediaStream | null = null;


### PR DESCRIPTION
Fixes #162

### Description
In `src/offscreen.ts`, `initTheme()` was imported and executed. Since the offscreen document is completely headless, does not display any user interface, and doesn't load any stylesheet styles, setting the active data theme and registering storage/system theme event listeners is completely redundant and wastes background CPU cycles.

### Proposed Changes
- Removed the unused `initTheme` import from `src/theme.js`.
- Removed the `initTheme()` invocation on line 4 of `src/offscreen.ts`.
- Verified that all logic compiles, lint checks pass, and tests execute cleanly.

---
I am contributing on behalf of GSSoc'26.