### PR TITLE
[CHORE]: Use dynamic extension version in options page footer via Manifest API

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -391,7 +391,7 @@
       </div>
 
       <footer class="options-footer">
-        <p>AI Meeting Copilot v1.0.0 — Built with Precision</p>
+        <p>AI Meeting Copilot v<span id="version-display">1.1.0</span> — Built with Precision</p>
       </footer>
     </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -38,6 +38,10 @@ document.addEventListener("DOMContentLoaded", async () => {
   const settings: Settings = config.settings || {};
 
   // ——— Populate Existing UI Elements ———
+  const versionDisplay = document.getElementById("version-display");
+  if (versionDisplay) {
+    versionDisplay.textContent = chrome.runtime.getManifest().version;
+  }
 
   // VAD threshold slider
   const vadSlider = document.getElementById("vad-threshold") as HTMLInputElement | null;


### PR DESCRIPTION
Fixes #164

### Description
In `src/options.html`, the options footer version was hardcoded as `v1.0.0`. Since the extension is currently at `v1.1.0`, hardcoding it in the HTML requires manual overhead with every single update and can easily fall out of sync.

### Proposed Changes
- Replaced the hardcoded version in `src/options.html` with a dynamic span placeholder having the ID `version-display`.
- Updated `src/options.ts` to fetch the extension's version directly from the manifest via `chrome.runtime.getManifest().version` and insert it into the DOM on options page load.
- Validated that the code formats cleanly, complies with ESLint and TypeScript checks, and builds successfully.

---
I am contributing on behalf of GSSoc'26.