### PR TITLE
feat: add keyboard shortcuts for recording toggle and side panel (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - [🚀 Active & Open GSSoC 2026 Issues](#-active--open-gssoc-2026-issues)
 - [🗺️ Project Roadmap](#%EF%B8%8F-project-roadmap)
 - [🐛 Known Issues](#-known-issues)
-- [⌨️ Keyboard Shortcuts](#️-keyboard-shortcuts)
+- [⌨️ Keyboard Shortcuts](#keyboard-shortcuts)
 - [🔒 Security & Privacy First](#-security--privacy-first)
 - [📜 License](#-license)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [🚀 Active & Open GSSoC 2026 Issues](#-active--open-gssoc-2026-issues)
 - [🗺️ Project Roadmap](#%EF%B8%8F-project-roadmap)
 - [🐛 Known Issues](#-known-issues)
+- [⌨️ Keyboard Shortcuts](#️-keyboard-shortcuts)
 - [🔒 Security & Privacy First](#-security--privacy-first)
 - [📜 License](#-license)
 
@@ -322,6 +323,19 @@ Here is the official bank of active and open issues currently available for GSSo
 | Audio capture intermittently fails after migration from OpenAI Whisper to ElevenLabs Scribe STT | 🟢 Resolved | [#1](https://github.com/shouri123/Late-Meet/issues/1) |
 
 > Found another bug? Choose one of our GSSoC templates and open a detailed bug report on our [Issues](https://github.com/shouri123/Late-Meet/issues) board.
+
+---
+
+## ⌨️ Keyboard Shortcuts
+
+Control Late Meet without touching your mouse — perfect for accessibility and power users.
+
+| Shortcut       | Mac           | Action                  |
+| :------------- | :------------ | :---------------------- |
+| `Ctrl+Shift+S` | `Cmd+Shift+S` | Toggle recording on/off |
+| `Ctrl+Shift+P` | `Cmd+Shift+P` | Open the side panel     |
+
+> Shortcuts can be customized at `chrome://extensions/shortcuts`.
 
 ---
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1092,7 +1092,7 @@ async function stopAudioCapture(reason = "Stopped") {
     // Ignore if offscreen not running
   }
 
-  if (state.isActive) {
+  if (state.audioActive) {
     addTimeline(`Meeting ended (${reason})`);
     await savePendingSession();
   }
@@ -1326,26 +1326,30 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Keyboard Shortcut Commands
 chrome.commands.onCommand.addListener(async (command) => {
-  if (command === "toggle-recording") {
-    if (state.isActive) {
-      await stopAudioCapture("Keyboard shortcut stop");
+  try {
+    if (command === "toggle-recording") {
+      if (state.audioActive) {
+        await stopAudioCapture("Keyboard shortcut stop");
+        return;
+      }
+
+      await scanForMeetTabs();
+      if (state.targetTabId) {
+        await startAudioCapture(state.targetTabId, state.meetingId, state.meetingUrl);
+      } else {
+        console.warn("[LateMeet] No active Meet tab found for keyboard shortcut.");
+      }
       return;
     }
 
-    await scanForMeetTabs();
-
-    if (state.targetTabId) {
-      await startAudioCapture(state.targetTabId, state.meetingId, state.meetingUrl);
-    } else {
-      console.warn("[LateMeet] No active Meet tab found for keyboard shortcut.");
+    if (command === "open-side-panel") {
+      const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+      if (activeTab?.id) {
+        await chrome.sidePanel.open({ tabId: activeTab.id });
+      }
     }
-  }
-
-  if (command === "open-side-panel") {
-    const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    if (activeTab?.id) {
-      await chrome.sidePanel.open({ tabId: activeTab.id });
-    }
+  } catch (err) {
+    console.error("[LateMeet] Keyboard command failed:", command, err);
   }
 });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -1324,5 +1324,30 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return true;
 });
 
+// Keyboard Shortcut Commands
+chrome.commands.onCommand.addListener(async (command) => {
+  if (command === "toggle-recording") {
+    if (state.isActive) {
+      await stopAudioCapture("Keyboard shortcut stop");
+      return;
+    }
+
+    await scanForMeetTabs();
+
+    if (state.targetTabId) {
+      await startAudioCapture(state.targetTabId, state.meetingId, state.meetingUrl);
+    } else {
+      console.warn("[LateMeet] No active Meet tab found for keyboard shortcut.");
+    }
+  }
+
+  if (command === "open-side-panel") {
+    const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (activeTab?.id) {
+      await chrome.sidePanel.open({ tabId: activeTab.id });
+    }
+  }
+});
+
 // Proactive scan on startup/load
 scanForMeetTabs();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -30,5 +30,21 @@
   },
   "icons": {
     "128": "src/icons/icon128.png"
+  },
+  "commands": {
+    "toggle-recording": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+S",
+        "mac": "Command+Shift+S"
+      },
+      "description": "Start/Stop recording toggle"
+    },
+    "open-side-panel": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+P",
+        "mac": "Command+Shift+P"
+      },
+      "description": "Open the Late Meet side panel"
+    }
   }
 }


### PR DESCRIPTION
## Description

Adds keyboard shortcuts to control Late Meet without using the mouse, 
improving accessibility for power users.

Fixes #105

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [x] Loaded the extension in Chrome and tested manually
- [x] Verified shortcuts are registered at chrome://extensions/shortcuts

## Screenshots

<img width="1036" height="362" alt="Screenshot 2026-05-29 171354" src="https://github.com/user-attachments/assets/58bc599d-c0a1-44f5-a60e-e6693365e2e6" />

## Checklist

- [x] I have starred the repository ⭐
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My code follows the formatting of this project (npm run format ✅)
- [x] ESLint checks pass locally (npm run lint ✅)
- [x] TypeScript type checks pass locally (npm run type-check ✅)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed (README.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts to toggle recording (Ctrl+Shift+S / Command+Shift+S on macOS) and open the side panel (Ctrl+Shift+P / Command+Shift+P on macOS). Shortcuts are customizable via Chrome's extension settings.

* **Documentation**
  * Updated README with keyboard shortcuts reference guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->