### PR TITLE
Fix active speaker transcript attribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
+    "test": "tsx --test src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/participantDetection.test.ts src/speakerAttribution.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/background.ts
+++ b/src/background.ts
@@ -3,6 +3,7 @@
 import { State } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
 import { AudioChunkQueue, AudioChunkQueueItem } from "./audioChunkQueue";
+import { normalizeActiveSpeakerName, resolveTranscriptSpeaker } from "./speakerAttribution";
 
 const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
@@ -207,6 +208,7 @@ const state: State = {
   timeline: [],
   transcript: [],
   audioActive: false,
+  currentSpeaker: null,
   targetTabId: null,
   lastSummarizedAt: 0,
   pendingJoiners: new Set(),
@@ -240,6 +242,7 @@ function resetState() {
   state.timeline = [];
   state.transcript = [];
   state.audioActive = false;
+  state.currentSpeaker = null;
   state.targetTabId = null;
   state.lastSummarizedAt = 0;
   state.pendingJoiners.clear();
@@ -281,6 +284,7 @@ function snapshot() {
     timeline: state.timeline,
     transcript: state.transcript,
     audioActive: state.audioActive,
+    currentSpeaker: state.currentSpeaker,
     participantCount: state.participantCount,
   };
 }
@@ -711,6 +715,7 @@ interface QueuedAudioChunk {
   mimeType: string;
   approxBytes: number;
   receivedAt: number;
+  speaker: string;
 }
 
 async function processQueuedAudioChunk({ id, item }: AudioChunkQueueItem<QueuedAudioChunk>) {
@@ -736,7 +741,7 @@ async function processQueuedAudioChunk({ id, item }: AudioChunkQueueItem<QueuedA
   console.log(`[LateMeet] transcript refined for chunk ${id} — ${refinedText.length} chars`);
 
   state.transcript.push({
-    speaker: "Audio",
+    speaker: resolveTranscriptSpeaker(item.speaker || state.currentSpeaker),
     text: refinedText,
     timestamp: item.receivedAt,
   });
@@ -1235,6 +1240,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           mimeType: typeof message.mimeType === "string" ? message.mimeType : "audio/webm",
           approxBytes,
           receivedAt: Date.now(),
+          speaker: resolveTranscriptSpeaker(state.currentSpeaker),
         });
 
         if (!result.accepted) {
@@ -1271,6 +1277,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         await maybeWelcomeJoiners(sender?.tab?.id || state.targetTabId || undefined, joiners);
         await broadcastStateUpdate();
         sendResponse({ success: true, joiners });
+        return;
+      }
+
+      case "ACTIVE_SPEAKER_CHANGED": {
+        const speaker = normalizeActiveSpeakerName(message.name);
+
+        if (!speaker) {
+          sendResponse({ success: false, error: "Invalid active speaker name" });
+          return;
+        }
+
+        state.currentSpeaker = speaker;
+        await broadcastStateUpdate();
+        sendResponse({ success: true, speaker });
         return;
       }
 

--- a/src/speakerAttribution.test.ts
+++ b/src/speakerAttribution.test.ts
@@ -1,0 +1,26 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  DEFAULT_TRANSCRIPT_SPEAKER,
+  normalizeActiveSpeakerName,
+  resolveTranscriptSpeaker,
+} from "./speakerAttribution.ts";
+
+test("active speaker names are normalized with participant-name filtering", () => {
+  assert.equal(normalizeActiveSpeakerName("Ada Lovelace"), "Ada Lovelace");
+  assert.equal(normalizeActiveSpeakerName("Ada Lovelace Mute More options"), "Ada Lovelace");
+});
+
+test("invalid active speaker payloads are rejected", () => {
+  assert.equal(normalizeActiveSpeakerName(undefined), null);
+  assert.equal(normalizeActiveSpeakerName(""), null);
+  assert.equal(normalizeActiveSpeakerName("Mute"), null);
+  assert.equal(normalizeActiveSpeakerName("Ada…"), null);
+});
+
+test("transcript speaker falls back to the default audio label", () => {
+  assert.equal(resolveTranscriptSpeaker("Grace Hopper"), "Grace Hopper");
+  assert.equal(resolveTranscriptSpeaker(null), DEFAULT_TRANSCRIPT_SPEAKER);
+  assert.equal(resolveTranscriptSpeaker("Pin"), DEFAULT_TRANSCRIPT_SPEAKER);
+});

--- a/src/speakerAttribution.ts
+++ b/src/speakerAttribution.ts
@@ -1,0 +1,13 @@
+import { participantNameFromCandidate } from "./participantDetection";
+
+export const DEFAULT_TRANSCRIPT_SPEAKER = "Audio";
+
+export function normalizeActiveSpeakerName(value: unknown): string | null {
+  return participantNameFromCandidate({
+    text: typeof value === "string" ? value : "",
+  });
+}
+
+export function resolveTranscriptSpeaker(value: string | null | undefined): string {
+  return normalizeActiveSpeakerName(value) || DEFAULT_TRANSCRIPT_SPEAKER;
+}


### PR DESCRIPTION
## Summary
- handle `ACTIVE_SPEAKER_CHANGED` messages in the background worker and expose `currentSpeaker` in state snapshots
- stamp queued audio chunks with the current speaker at receive time so delayed transcription keeps the right attribution
- add speaker attribution helpers and unit tests for name normalization/fallback behavior

## Tests
- npm test
- npm run type-check
- npm run lint

Closes #170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved speaker attribution for audio and transcripts by tracking the active speaker in real-time.

* **Tests**
  * Added comprehensive test coverage for speaker name normalization and speaker resolution logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->