### PR TITLE
Fix dashboard tab capture gesture ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
+    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts src/dashboardCapture.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1,6 +1,7 @@
 import { State, Topic, TranscriptEntry, TimelineEvent, Decision, ActionItem } from "./types";
 import { initTheme } from "./theme.js";
 import { resolveManualMeetTab } from "./meetingTabs";
+import { startDashboardAudioCapture } from "./dashboardCapture";
 
 initTheme();
 
@@ -178,6 +179,31 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ——— Start Audio Capture (User Gesture via tabCapture) ———
   const audioBtn = document.getElementById("dash-start-audio-btn") as HTMLButtonElement | null;
+
+  function getDashboardMediaStreamId(tabId: number): Promise<string> {
+    return new Promise((resolve, reject) => {
+      chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, (streamId) => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message || "Unknown tab capture error"));
+          return;
+        }
+
+        resolve(streamId || "");
+      });
+    });
+  }
+
+  async function requestDashboardMicrophonePermission(): Promise<boolean> {
+    try {
+      const micStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+      micStream.getTracks().forEach((t) => t.stop());
+      return true;
+    } catch {
+      console.warn("[Dashboard] Mic permission not granted — waveform will use tab audio only");
+      return false;
+    }
+  }
+
   audioBtn?.addEventListener("click", async () => {
     if (lastState?.audioActive) {
       try {
@@ -195,68 +221,30 @@ document.addEventListener("DOMContentLoaded", async () => {
       audioBtn.disabled = true;
       audioBtn.textContent = "Starting...";
 
-      // Request mic permission from this user-facing page while the gesture is still live.
-      // Chrome grants the permission to the extension origin so the offscreen doc inherits it.
-      try {
-        const micStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
-        micStream.getTracks().forEach((t) => t.stop());
-      } catch {
-        console.warn("[Dashboard] Mic permission not granted — waveform will use tab audio only");
+      const { meetingId } = await startDashboardAudioCapture({
+        resolveMeetTab: resolveManualMeetTab,
+        getMediaStreamId: getDashboardMediaStreamId,
+        requestMicrophonePermission: requestDashboardMicrophonePermission,
+        startAudioCapture: (payload) =>
+          chrome.runtime.sendMessage({
+            type: "MANUAL_START_AUDIO",
+            ...payload,
+          }),
+      });
+
+      setAudioBtnActive(true);
+      // Start timer immediately
+      startTimer(Date.now());
+      const statusText = document.getElementById("dash-status-text");
+      const statusDot = document.querySelector(".dash-status-dot");
+      if (statusText) statusText.textContent = `Meeting active — ${meetingId || "unknown"}`;
+      if (statusDot) statusDot.classList.add("active");
+    } catch (err: any) {
+      if ((err.message || "").includes("active stream")) {
+        setAudioBtnActive(true);
+        return;
       }
 
-      resolveManualMeetTab()
-        .then(({ tab: meetTab, meetingId, meetingUrl }) => {
-          // --- Get Media Stream ID in foreground (dashboard) to ensure user gesture propagation ---
-          chrome.tabCapture.getMediaStreamId({ targetTabId: meetTab.id }, async (streamId) => {
-            if (chrome.runtime.lastError) {
-              const err = chrome.runtime.lastError.message || "Unknown error";
-              console.error("[Dashboard] getMediaStreamId error:", err);
-              if (err.includes("active stream")) {
-                setAudioBtnActive(true);
-                return;
-              } else {
-                handleDashboardAudioError(
-                  new Error('Capture permission denied. Try clicking "Start Audio" again.'),
-                );
-                return;
-              }
-            }
-
-            if (!streamId) {
-              handleDashboardAudioError(
-                new Error('Capture permission denied. Try clicking "Start Audio" again.'),
-              );
-            }
-
-            try {
-              const response = await chrome.runtime.sendMessage({
-                type: "MANUAL_START_AUDIO",
-                tabId: meetTab.id,
-                meetingId: meetingId,
-                meetingUrl: meetingUrl || meetTab.url || null,
-                streamId: streamId,
-                includeMicrophone: true,
-              });
-
-              if (response && response.success) {
-                setAudioBtnActive(true);
-                // Start timer immediately
-                startTimer(Date.now());
-                const statusText = document.getElementById("dash-status-text");
-                const statusDot = document.querySelector(".dash-status-dot");
-                if (statusText)
-                  statusText.textContent = `Meeting active — ${meetingId || "unknown"}`;
-                if (statusDot) statusDot.classList.add("active");
-              } else {
-                throw new Error(response?.error || "Failed to start audio");
-              }
-            } catch (err: any) {
-              handleDashboardAudioError(err);
-            }
-          });
-        })
-        .catch(handleDashboardAudioError);
-    } catch (err: any) {
       handleDashboardAudioError(err);
     }
 

--- a/src/dashboardCapture.test.ts
+++ b/src/dashboardCapture.test.ts
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { startDashboardAudioCapture } from "./dashboardCapture.ts";
+import { MeetTabSelection } from "./meetingTabs.ts";
+
+function meetSelection(): MeetTabSelection {
+  return {
+    tab: {
+      id: 42,
+      url: "https://meet.google.com/abc-defg-hij",
+    } as chrome.tabs.Tab,
+    meetingId: "abc-defg-hij",
+    meetingUrl: "https://meet.google.com/abc-defg-hij",
+  };
+}
+
+test("dashboard capture gets tab stream id before microphone permission", async () => {
+  const calls: string[] = [];
+
+  const result = await startDashboardAudioCapture({
+    resolveMeetTab: async () => {
+      calls.push("resolve-meet-tab");
+      return meetSelection();
+    },
+    getMediaStreamId: async (tabId) => {
+      calls.push(`get-stream-id:${tabId}`);
+      return "stream-id";
+    },
+    requestMicrophonePermission: async () => {
+      calls.push("request-microphone");
+      return true;
+    },
+    startAudioCapture: async (payload) => {
+      calls.push(`start-audio:${payload.streamId}`);
+      return { success: true };
+    },
+  });
+
+  assert.equal(result.meetingId, "abc-defg-hij");
+  assert.deepEqual(calls, [
+    "resolve-meet-tab",
+    "get-stream-id:42",
+    "request-microphone",
+    "start-audio:stream-id",
+  ]);
+});
+
+test("dashboard capture still starts tab audio when microphone permission fails", async () => {
+  const calls: string[] = [];
+
+  await startDashboardAudioCapture({
+    resolveMeetTab: async () => meetSelection(),
+    getMediaStreamId: async () => "stream-id",
+    requestMicrophonePermission: async () => {
+      calls.push("request-microphone");
+      throw new Error("Permission denied");
+    },
+    startAudioCapture: async () => {
+      calls.push("start-audio");
+      return { success: true };
+    },
+  });
+
+  assert.deepEqual(calls, ["request-microphone", "start-audio"]);
+});
+
+test("dashboard capture does not request microphone when tab capture is denied", async () => {
+  const calls: string[] = [];
+
+  await assert.rejects(
+    startDashboardAudioCapture({
+      resolveMeetTab: async () => meetSelection(),
+      getMediaStreamId: async () => "",
+      requestMicrophonePermission: async () => {
+        calls.push("request-microphone");
+        return true;
+      },
+      startAudioCapture: async () => {
+        calls.push("start-audio");
+        return { success: true };
+      },
+    }),
+    /Capture permission denied/,
+  );
+
+  assert.deepEqual(calls, []);
+});

--- a/src/dashboardCapture.ts
+++ b/src/dashboardCapture.ts
@@ -1,0 +1,67 @@
+import { MeetTabSelection } from "./meetingTabs";
+
+export interface DashboardCaptureStartPayload {
+  tabId: number;
+  meetingId: string;
+  meetingUrl: string | null;
+  streamId: string;
+  includeMicrophone: boolean;
+}
+
+export interface DashboardCaptureStartResponse {
+  success?: boolean;
+  error?: string;
+}
+
+export interface DashboardCaptureStartResult {
+  meetingId: string;
+  response: DashboardCaptureStartResponse;
+}
+
+interface DashboardCaptureStartOptions {
+  resolveMeetTab: () => Promise<MeetTabSelection>;
+  getMediaStreamId: (tabId: number) => Promise<string>;
+  requestMicrophonePermission: () => Promise<boolean>;
+  startAudioCapture: (
+    payload: DashboardCaptureStartPayload,
+  ) => Promise<DashboardCaptureStartResponse>;
+}
+
+export async function startDashboardAudioCapture({
+  resolveMeetTab,
+  getMediaStreamId,
+  requestMicrophonePermission,
+  startAudioCapture,
+}: DashboardCaptureStartOptions): Promise<DashboardCaptureStartResult> {
+  const { tab: meetTab, meetingId, meetingUrl } = await resolveMeetTab();
+
+  if (meetTab.id === undefined) {
+    throw new Error("Target Meet tab is missing an id");
+  }
+
+  const streamId = await getMediaStreamId(meetTab.id);
+
+  if (!streamId) {
+    throw new Error('Capture permission denied. Try clicking "Start Audio" again.');
+  }
+
+  try {
+    await requestMicrophonePermission();
+  } catch {
+    // Microphone capture is optional; the offscreen document can still record tab audio.
+  }
+
+  const response = await startAudioCapture({
+    tabId: meetTab.id,
+    meetingId,
+    meetingUrl: meetingUrl || meetTab.url || null,
+    streamId,
+    includeMicrophone: true,
+  });
+
+  if (!response?.success) {
+    throw new Error(response?.error || "Failed to start audio");
+  }
+
+  return { meetingId, response };
+}


### PR DESCRIPTION
## Summary
- extract the dashboard audio-start orchestration into a testable helper
- request the tab capture stream ID before microphone permission preflight to preserve the Chrome user gesture
- keep microphone permission failure non-fatal so tab-only capture can still start
- add regression tests for call ordering, mic fallback, and tab-capture denial behavior

## Tests
- npm test
- npm run type-check
- npm run lint

Closes #172