### PR TITLE
Fix popup microphone permission fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
+    "test": "tsx --test src/audioProcessing.test.ts src/participantDetection.test.ts src/popupCapture.test.ts src/meetingTabs.test.ts src/utils/credentials.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -3,6 +3,7 @@ import { initTheme } from "./theme.js";
 import { getApiCredentials, saveApiCredentials } from "./utils/credentials";
 import { validateOpenAIKey } from "./utils/api.js";
 import { resolveManualMeetTab } from "./meetingTabs";
+import { startPopupAudioCapture } from "./popupCapture";
 
 initTheme();
 
@@ -98,6 +99,30 @@ document.addEventListener("DOMContentLoaded", async () => {
   // ——— Start Copilot (Audio Capture with User Gesture) ———
   const copilotBtn = document.getElementById("start-copilot-btn") as HTMLButtonElement | null;
 
+  function getPopupMediaStreamId(tabId: number): Promise<string> {
+    return new Promise((resolve, reject) => {
+      chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, (streamId) => {
+        if (chrome.runtime.lastError) {
+          reject(new Error(chrome.runtime.lastError.message || "Unknown tab capture error"));
+          return;
+        }
+
+        resolve(streamId || "");
+      });
+    });
+  }
+
+  async function requestPopupMicrophonePermission(): Promise<boolean> {
+    try {
+      const micStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+      micStream.getTracks().forEach((track) => track.stop());
+      return true;
+    } catch {
+      console.warn("[LateMeet] Microphone permission not granted — recording tab audio only");
+      return false;
+    }
+  }
+
   async function handleStopAudio(btn?: HTMLButtonElement | null) {
     if (!lastState?.audioActive) return;
 
@@ -126,75 +151,45 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (textEl) textEl.textContent = "Starting...";
       btn.classList.add("loading");
 
-      resolveManualMeetTab()
-        .then(({ tab: meetTab, meetingId, meetingUrl }) => {
-          // --- Get Media Stream ID in foreground (popup) to ensure user gesture propagation ---
-          chrome.tabCapture.getMediaStreamId({ targetTabId: meetTab.id }, async (streamId) => {
-            if (chrome.runtime.lastError) {
-              const err = chrome.runtime.lastError.message || "Unknown error";
-              console.error("[LateMeet] Popup getMediaStreamId error:", err);
-              // If already capturing, we can treat it as success or inform the background
-              if (err.includes("active stream")) {
-                setCopilotActive(true);
-                return;
-              } else {
-                handleStartAudioError(
-                  new Error(
-                    "Capture permission denied. Try clicking the extension icon again on the Meet tab.",
-                  ),
-                );
-                return;
-              }
-            }
+      const { meetingId, microphoneEnabled } = await startPopupAudioCapture({
+        resolveMeetTab: resolveManualMeetTab,
+        getMediaStreamId: getPopupMediaStreamId,
+        requestMicrophonePermission: requestPopupMicrophonePermission,
+        startAudioCapture: (payload) =>
+          chrome.runtime.sendMessage({
+            type: "MANUAL_START_AUDIO",
+            ...payload,
+          }),
+      });
 
-            if (!streamId) {
-              handleStartAudioError(
-                new Error(
-                  "Capture permission denied. Try clicking the extension icon again on the Meet tab.",
-                ),
-              );
-              return;
-            }
+      if (!microphoneEnabled) {
+        console.warn("[LateMeet] Started without microphone input — tab audio only");
+      }
 
-            try {
-              const response = await chrome.runtime.sendMessage({
-                type: "MANUAL_START_AUDIO",
-                tabId: meetTab.id,
-                meetingId: meetingId,
-                meetingUrl: meetingUrl || meetTab.url || null,
-                streamId: streamId,
-                includeMicrophone: true,
-              });
-
-              if (response && response.success) {
-                // Clear loading state before setting active state
-                btn.disabled = false;
-                btn.classList.remove("loading");
-                setCopilotActive(true);
-                // Immediately show meeting section and start timer
-                if (meetingSection) meetingSection.style.display = "block";
-                if (noMeetingSection) noMeetingSection.style.display = "none";
-                if (meetingId) {
-                  const meetingIdEl = document.getElementById("meeting-id");
-                  if (meetingIdEl) meetingIdEl.textContent = meetingId;
-                }
-                const badge = document.getElementById("status-badge");
-                if (badge) {
-                  badge.className = "status-badge active";
-                  const statusText = badge.querySelector(".status-text");
-                  if (statusText) statusText.textContent = "Recording...";
-                }
-                startDurationTimer(Date.now());
-              } else {
-                throw new Error(response?.error || "Failed to start audio capture");
-              }
-            } catch (err: any) {
-              handleStartAudioError(err);
-            }
-          });
-        })
-        .catch(handleStartAudioError);
+      // Clear loading state before setting active state
+      btn.disabled = false;
+      btn.classList.remove("loading");
+      setCopilotActive(true);
+      // Immediately show meeting section and start timer
+      if (meetingSection) meetingSection.style.display = "block";
+      if (noMeetingSection) noMeetingSection.style.display = "none";
+      if (meetingId) {
+        const meetingIdEl = document.getElementById("meeting-id");
+        if (meetingIdEl) meetingIdEl.textContent = meetingId;
+      }
+      const badge = document.getElementById("status-badge");
+      if (badge) {
+        badge.className = "status-badge active";
+        const statusText = badge.querySelector(".status-text");
+        if (statusText) statusText.textContent = "Recording...";
+      }
+      startDurationTimer(Date.now());
     } catch (err: any) {
+      if ((err.message || "").includes("active stream")) {
+        setCopilotActive(true);
+        return;
+      }
+
       handleStartAudioError(err);
     }
 

--- a/src/popupCapture.test.ts
+++ b/src/popupCapture.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { startPopupAudioCapture } from "./popupCapture.ts";
+import { MeetTabSelection } from "./meetingTabs.ts";
+
+function meetSelection(): MeetTabSelection {
+  return {
+    tab: {
+      id: 42,
+      url: "https://meet.google.com/abc-defg-hij",
+    } as chrome.tabs.Tab,
+    meetingId: "abc-defg-hij",
+    meetingUrl: "https://meet.google.com/abc-defg-hij",
+  };
+}
+
+test("popup capture gets tab stream id before requesting microphone permission", async () => {
+  const calls: string[] = [];
+
+  const result = await startPopupAudioCapture({
+    resolveMeetTab: async () => {
+      calls.push("resolve-meet-tab");
+      return meetSelection();
+    },
+    getMediaStreamId: async (tabId) => {
+      calls.push(`get-stream-id:${tabId}`);
+      return "stream-id";
+    },
+    requestMicrophonePermission: async () => {
+      calls.push("request-microphone");
+      return true;
+    },
+    startAudioCapture: async (payload) => {
+      calls.push(`start-audio:mic-${payload.includeMicrophone}`);
+      return { success: true };
+    },
+  });
+
+  assert.equal(result.meetingId, "abc-defg-hij");
+  assert.equal(result.microphoneEnabled, true);
+  assert.deepEqual(calls, [
+    "resolve-meet-tab",
+    "get-stream-id:42",
+    "request-microphone",
+    "start-audio:mic-true",
+  ]);
+});
+
+test("popup capture starts tab-only audio when microphone permission is denied", async () => {
+  const payloads: boolean[] = [];
+
+  const result = await startPopupAudioCapture({
+    resolveMeetTab: async () => meetSelection(),
+    getMediaStreamId: async () => "stream-id",
+    requestMicrophonePermission: async () => false,
+    startAudioCapture: async (payload) => {
+      payloads.push(payload.includeMicrophone);
+      return { success: true };
+    },
+  });
+
+  assert.equal(result.microphoneEnabled, false);
+  assert.deepEqual(payloads, [false]);
+});
+
+test("popup capture treats microphone permission errors as tab-only fallback", async () => {
+  const payloads: boolean[] = [];
+
+  await startPopupAudioCapture({
+    resolveMeetTab: async () => meetSelection(),
+    getMediaStreamId: async () => "stream-id",
+    requestMicrophonePermission: async () => {
+      throw new Error("Permission prompt dismissed");
+    },
+    startAudioCapture: async (payload) => {
+      payloads.push(payload.includeMicrophone);
+      return { success: true };
+    },
+  });
+
+  assert.deepEqual(payloads, [false]);
+});
+
+test("popup capture does not request microphone when tab capture is denied", async () => {
+  const calls: string[] = [];
+
+  await assert.rejects(
+    startPopupAudioCapture({
+      resolveMeetTab: async () => meetSelection(),
+      getMediaStreamId: async () => "",
+      requestMicrophonePermission: async () => {
+        calls.push("request-microphone");
+        return true;
+      },
+      startAudioCapture: async () => {
+        calls.push("start-audio");
+        return { success: true };
+      },
+    }),
+    /Capture permission denied/,
+  );
+
+  assert.deepEqual(calls, []);
+});

--- a/src/popupCapture.ts
+++ b/src/popupCapture.ts
@@ -1,0 +1,69 @@
+import { MeetTabSelection } from "./meetingTabs";
+
+export interface PopupCaptureStartPayload {
+  tabId: number;
+  meetingId: string;
+  meetingUrl: string | null;
+  streamId: string;
+  includeMicrophone: boolean;
+}
+
+export interface PopupCaptureStartResponse {
+  success?: boolean;
+  error?: string;
+}
+
+export interface PopupCaptureStartResult {
+  meetingId: string;
+  microphoneEnabled: boolean;
+  response: PopupCaptureStartResponse;
+}
+
+interface PopupCaptureStartOptions {
+  resolveMeetTab: () => Promise<MeetTabSelection>;
+  getMediaStreamId: (tabId: number) => Promise<string>;
+  requestMicrophonePermission: () => Promise<boolean>;
+  startAudioCapture: (payload: PopupCaptureStartPayload) => Promise<PopupCaptureStartResponse>;
+}
+
+export async function startPopupAudioCapture({
+  resolveMeetTab,
+  getMediaStreamId,
+  requestMicrophonePermission,
+  startAudioCapture,
+}: PopupCaptureStartOptions): Promise<PopupCaptureStartResult> {
+  const { tab: meetTab, meetingId, meetingUrl } = await resolveMeetTab();
+
+  if (meetTab.id === undefined) {
+    throw new Error("Target Meet tab is missing an id");
+  }
+
+  const streamId = await getMediaStreamId(meetTab.id);
+
+  if (!streamId) {
+    throw new Error(
+      "Capture permission denied. Try clicking the extension icon again on the Meet tab.",
+    );
+  }
+
+  let microphoneEnabled = false;
+  try {
+    microphoneEnabled = await requestMicrophonePermission();
+  } catch {
+    microphoneEnabled = false;
+  }
+
+  const response = await startAudioCapture({
+    tabId: meetTab.id,
+    meetingId,
+    meetingUrl: meetingUrl || meetTab.url || null,
+    streamId,
+    includeMicrophone: microphoneEnabled,
+  });
+
+  if (!response?.success) {
+    throw new Error(response?.error || "Failed to start audio capture");
+  }
+
+  return { meetingId, microphoneEnabled, response };
+}


### PR DESCRIPTION
## Summary
- add a testable popup capture startup helper
- request the tab capture stream ID before microphone permission to preserve the Chrome user gesture
- request microphone permission from the visible popup and pass `includeMicrophone` based on the result
- keep microphone denial non-fatal by starting tab-only capture explicitly
- add regression tests for ordering, denied mic permission, thrown mic errors, and tab-capture denial

## Tests
- npm test
- npm run type-check
- npm run lint

Closes #175