### PR TITLE
fix: add defensive validation for MAX_PARTICIPANT_NAME_LEN

### DIFF
--- a/src/participantDetection.ts
+++ b/src/participantDetection.ts
@@ -48,10 +48,16 @@ export function participantNameFromCandidate(candidate: ParticipantNameCandidate
   const participantAriaName = ariaLabel.startsWith("Participant:")
     ? ariaLabel.replace(/^Participant:\s*/, "")
     : "";
+
   const rawName = selfName || participantAriaName || text;
   const name = cleanText(rawName);
 
-  if (!name || name.length > MAX_PARTICIPANT_NAME_LEN || name.includes("…")) {
+  const maxParticipantNameLength =
+    typeof MAX_PARTICIPANT_NAME_LEN === "number" && Number.isFinite(MAX_PARTICIPANT_NAME_LEN)
+      ? MAX_PARTICIPANT_NAME_LEN
+      : 120;
+
+  if (!name || name.length > maxParticipantNameLength || name.includes("…")) {
     return null;
   }
 


### PR DESCRIPTION
## Description

Added defensive validation for `MAX_PARTICIPANT_NAME_LEN` in `participantDetection.ts` to prevent potential runtime issues if the constant becomes invalid (`undefined`, `null`, or `NaN`).

Previously, the participant name length check directly relied on the constant value without verifying its type or validity. This update introduces a safe fallback mechanism to ensure participant name filtering continues working reliably even under unexpected import or runtime corruption scenarios.

Fixes #181 

---

## Type of Change

* [x] 🐛 Bug fix (non-breaking change that fixes an issue)
* [ ] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] 📝 Documentation update
* [ ] 🎨 UI/UX improvement
* [x] ♻️ Code refactoring (no functional changes)
* [ ] 🧪 Tests

---

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

* [x] Built the extension with `npm run build`
* [x] Verified participant names are filtered correctly
* [x] Tested long participant names (>120 characters)
* [x] Verified fallback logic works for invalid constant values
* [x] Verified no console errors
* [x] Ran TypeScript type checks

---

## Screenshots (if applicable)

N/A – internal validation logic update.

---

## Checklist

* [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
* [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [x] My code follows the formatting of this project (run `npm run format`)
* [x] ESLint checks pass locally without any errors (run `npm run lint`)
* [x] TypeScript type checks pass locally (run `npm run type-check`)
* [x] My changes generate no new warnings or errors
* [x] I have updated the documentation if needed
