### PR TITLE
fix: secure pull request CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,17 @@
 name: Late-Meet Build Validation
 
 on:
-  pull_request_target:
+  pull_request:
+    branches:
+      - main
+      - develop
   push:
     branches:
       - main
       - develop
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -14,8 +20,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,13 @@
 name: Lint & Format Check
 
 on:
-  pull_request_target:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
+
+permissions:
+  contents: read
 
 jobs:
   lint:
@@ -11,8 +15,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

This PR improves CI workflow security by updating workflows that execute contributor code.

## Changes Made

* Replaced `pull_request_target` with `pull_request` in:

  * `.github/workflows/build.yml`
  * `.github/workflows/lint.yml`
* Removed checkout of pull request head SHA using:

  ```yaml
  ref: ${{ github.event.pull_request.head.sha }}
  ```
* Added minimal workflow permissions:

  ```yaml
  permissions:
    contents: read
  ```
* Preserved existing push-based workflow behavior.

## Why

Workflows that install dependencies and execute project code should use `pull_request` instead of `pull_request_target` to reduce the risk of running untrusted fork code in a privileged workflow context.

This change follows GitHub's recommended security practices for CI workflows that build, lint, test, or otherwise execute contributor code.

## Files Modified

* `.github/workflows/build.yml`
* `.github/workflows/lint.yml`

## Testing

* Verified workflow YAML syntax after modifications.
* Confirmed removal of `pull_request_target`.
* Confirmed removal of PR-head checkout references.
* Verified existing build and lint steps remain unchanged.

Closes #190 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to enhance security with explicit permissions configuration
  * Simplified workflow trigger configuration for build and lint validation processes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->