### PR TITLE
fix(a11y): add keyboard focus indicator to icon button in popup

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -303,6 +303,11 @@ body::-webkit-scrollbar-thumb {
   border-color: var(--border-main);
 }
 
+.icon-btn:focus-visible {
+  outline: 2px solid hsl(var(--accent-color));
+  outline-offset: 2px;
+}
+
 /* ——— Duration Bar ——— */
 .duration-bar {
   display: flex;

--- a/src/popup.html
+++ b/src/popup.html
@@ -81,7 +81,7 @@
             </div>
           </div>
         </div>
-        <button id="settings-btn" class="icon-btn" title="Settings">⚙️</button>
+        <button id="settings-btn" class="icon-btn" aria-label="Settings">⚙️</button>
       </header>
 
       <!-- Content Sections -->


### PR DESCRIPTION
## Description
This PR addresses an accessibility (a11y) issue where the settings icon button in the popup lacked a keyboard-accessible focus state. I have added a `:focus-visible` outline for keyboard navigation and updated the semantic attribute for screen readers.

Fixes #189

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🎨 UI/UX improvement

## How Has This Been Tested?
- [x] Built the extension with `npm run build`
- [x] Loaded the extension in Chrome and verified no compilation or console errors.
- [ ] Visual UI test for the settings button (Blocked: Requires OpenAI API key initialization to bypass the onboarding screen and access the main dashboard. The CSS implementation follows standard WCAG constraints).

## Screenshots
**N/A** (Main UI is gated behind the API key initialization screen).

## Checklist

- [x] I have **starred the repository** ⭐
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My code follows the formatting of this project
- [x] ESLint checks pass locally without any errors
- [x] TypeScript type checks pass locally
- [x] My changes generate no new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added visible focus outline for icon buttons to improve keyboard navigation feedback.

* **Accessibility**
  * Updated Settings button labeling to enhance screen reader compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/192?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->