### PR TITLE
docs: fix stale project structure references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,9 @@ src/
 ├── types.ts             # TypeScript type definitions
 ├── manifest.json        # Chrome extension manifest (MV3)
 └── utils/
-    └── api.js           # API helper functions
+    ├── api.ts           # API helper functions
+    ├── credentials.ts   # API credential storage helpers
+    └── prompts.ts       # Prompt templates for AI summaries
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ The extension is built natively on Manifest V3 using **TypeScript and Vite 5** f
 │   ├── options.ts & html        # Options page to configure API keys
 │   ├── popup.ts & html          # Quick-action extension popover
 │   └── types.ts                 # Type definitions used across components
-├── .eslintrc.json               # Logic checker settings (ESLint)
-├── .eslintignore                # ESLint path exclusions
+├── eslint.config.mjs            # Flat ESLint configuration
+├── .editorconfig                # Cross-editor coding style defaults
 ├── .prettierrc                  # Formatter code style preferences
 ├── .prettierignore              # Formatter file exclusions
 ├── lint-staged.config.js        # Config to format only staged files on commit


### PR DESCRIPTION
## Summary

Updated documentation to reflect the current repository structure and configuration files.

## Changes Made

* Replaced outdated ESLint references with `eslint.config.mjs`.
* Added current configuration files such as `.editorconfig`.
* Updated utility file references from JavaScript to TypeScript.
* Added references to current utility files including `api.ts`, `credentials.ts`, and `prompts.ts`.
* Removed references to files that no longer exist.

## Why

Some documentation referenced outdated files and project structure details, which could confuse contributors when navigating the repository.

This update aligns the documentation with the current codebase.

## Files Modified

* `README.md`
* `CONTRIBUTING.md`

## Verification

* Confirmed no remaining references to `.eslintrc.json`, `.eslintignore`, or `api.js`.
* Verified documented paths match the current repository structure.
* Ran `git diff --check` successfully.

Closes #195 