### PR TITLE
test: add native test coverage for isValidAccent utility

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -913,7 +913,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     md += `## Key Insights\n`;
     if (state.keyInsights?.length) {
-      state.keyInsights.forEach((i: string) => (md += `- ${i}\n`));
+      state.keyInsights.forEach((insight) => {
+        md += `- ${insight}\n`;
+      });
       md += "\n";
     } else {
       md += `_No insights available_\n\n`;

--- a/src/sessionStorage.test.ts
+++ b/src/sessionStorage.test.ts
@@ -32,6 +32,8 @@ function makeSession(id: string, savedAt: number): StoredSession {
     timeline: [{ event: "Meeting ended", timestamp: savedAt, elapsed: 10 }],
     transcript: [{ speaker: "Audio", text: "A long transcript entry", timestamp: savedAt }],
     audioActive: false,
+    unresolvedDiscussions: [],
+    contradictions: [],
   };
 }
 

--- a/src/theme.test.ts
+++ b/src/theme.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { isValidAccent } from "./theme";
+
+describe("isValidAccent", () => {
+  // Valid hex colors
+  it("should accept valid 3-digit hex colors", () => {
+    assert.strictEqual(isValidAccent("#ABC"), true);
+    assert.strictEqual(isValidAccent("#fff"), true);
+    assert.strictEqual(isValidAccent("#FFF"), true);
+  });
+
+  it("should accept valid 6-digit hex colors", () => {
+    assert.strictEqual(isValidAccent("#ABCDEF"), true);
+    assert.strictEqual(isValidAccent("#ffffff"), true);
+    assert.strictEqual(isValidAccent("#123456"), true);
+  });
+
+  // Valid HSL formats
+  it("should accept HSL format with commas and spaces", () => {
+    assert.strictEqual(isValidAccent("210, 100%, 50%"), true);
+    assert.strictEqual(isValidAccent("0, 0%, 0%"), true);
+    assert.strictEqual(isValidAccent("360, 100%, 100%"), true);
+  });
+
+  it("should accept HSL format with spaces only", () => {
+    assert.strictEqual(isValidAccent("210 100% 50%"), true);
+    assert.strictEqual(isValidAccent("0 0% 0%"), true);
+  });
+
+  // Invalid formats
+  it("should reject invalid hex colors", () => {
+    assert.strictEqual(isValidAccent("#GG"), false);
+    assert.strictEqual(isValidAccent("#12"), false);
+    assert.strictEqual(isValidAccent("#1234567"), false);
+  });
+
+  it("should reject malformed HSL", () => {
+    assert.strictEqual(isValidAccent("210, 100, 50"), false);
+    assert.strictEqual(isValidAccent("210, 100%, 50"), false);
+    assert.strictEqual(isValidAccent("abc, def%, ghi%"), false);
+  });
+
+  // Whitespace handling
+  it("should trim whitespace before validation", () => {
+    assert.strictEqual(isValidAccent("  #FFF  "), true);
+    assert.strictEqual(isValidAccent("  210, 100%, 50%  "), true);
+  });
+});

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -24,7 +24,7 @@ function resolveTheme(theme: ThemeMode): "light" | "dark" {
   return theme;
 }
 
-function isValidAccent(value: string): boolean {
+export function isValidAccent(value: string): boolean {
   const accent = value.trim();
   return (
     /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(accent) ||


### PR DESCRIPTION
## Description
Following up on the maintainer's suggestion to improve testing coverage! This PR introduces a native `node:test` suite for the `isValidAccent()` utility function in `src/theme.ts`. 

Fixes #197

## Type of Change
- [x] 🧪 Tests (Added unit tests for existing logic)

## Technical Details
- Exported the `isValidAccent` function for testability.
- Wrote 7 comprehensive test cases covering valid hex/HSL colors, edge cases (whitespace), and malformed inputs.
- Used `node:test` and `node:assert` to align seamlessly with the project's existing `tsx --test` architecture (no external dependencies like vitest required).

## How Has This Been Tested?
- [x] Executed `npx tsx --test src/theme.test.ts` locally (All 7 assertions pass).
- [x] Ensured no breaking changes to the existing theme rendering logic.

## Checklist
- [x] I have **starred the repository** ⭐
- [x] My code follows the project's style guidelines
- [x] TypeScript type checks pass locally
- [x] My changes generate no new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for accent color validation, including hex and HSL format validation.

* **Refactor**
  * Internal improvements to code structure.

---

**Note:** This release contains primarily internal development changes with no user-visible feature updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->