### PR TITLE
text(ui): add smooth hover effect and transitions to options cards

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -66,6 +66,14 @@ body {
   border-radius: 12px;
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
+  transition: all 0.3s cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.options-section:hover {
+  background: var(--bg-card);
+  border-color: var(--border-element);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  transform: translateY(-2px);
 }
 
 .section-title {


### PR DESCRIPTION
## Description

This PR introduces smooth hover elevation and transition effects to the `.options-section` container cards on the settings page. 

Previously, the settings cards were completely static. By adding a subtle `box-shadow`, a `border-color` change, and a `translateY(-2px)` lift on hover, this CSS-only update provides immediate visual feedback to the user and aligns the settings page with the modern, interactive design language of the rest of the extension.

Fixes #216 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [ ] Built the extension with `npm run build`
- [x] Loaded the extension in Chrome and tested manually
- [ ] Tested on a live Google Meet call
- [x] Verified no console errors
- [ ] Tested with ElevenLabs API key
- [ ] Tested with OpenAI API key

## Screenshots (if applicable)

*(I have verified the CSS visually locally. The `.options-section` cards smoothly lift and display a subtle shadow on mouse hover without causing any layout shifts).*

## Checklist

- [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation if needed