### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete URL substring sanitization

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1160,7 +1160,7 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
         return;
       }
 
-      const pathMatch = parsedUrl.pathname.match(/^\/([a-z\-]+)/);
+      const pathMatch = /^\/([a-z-]+)/.exec(parsedUrl.pathname);
       const meetingId = pathMatch ? pathMatch[1] : null;
 
       if (meetingId && meetingId !== "new") {
@@ -1193,7 +1193,7 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
       return;
     }
 
-    const pathMatch = parsedUrl.pathname.match(/^\/([a-z\-]+)/);
+    const pathMatch = /^\/([a-z-]+)/.exec(parsedUrl.pathname);
     const meetingId = pathMatch ? pathMatch[1] : null;
     if (meetingId && meetingId !== "new" && !state.isActive) {
       state.meetingId = meetingId;

--- a/src/background.ts
+++ b/src/background.ts
@@ -1153,21 +1153,30 @@ async function stopAudioCapture(reason = "Stopped") {
 }
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
-  if (changeInfo.status === "complete" && tab.url?.includes("meet.google.com/")) {
-    const urlMatch = tab.url.match(/meet\.google\.com\/([a-z\-]+)/);
-    const meetingId = urlMatch ? urlMatch[1] : null;
-
-    if (meetingId && meetingId !== "new") {
-      if (!state.isActive) {
-        resetState();
-        state.isActive = true;
-        state.meetingId = meetingId;
-        state.meetingUrl = tab.url || null;
-        state.targetTabId = tabId || null;
-        state.startTime = Date.now();
-        state.participants = ["You"];
-        await broadcastStateUpdate();
+  if (changeInfo.status === "complete" && tab.url) {
+    try {
+      const parsedUrl = new URL(tab.url);
+      if (parsedUrl.hostname !== "meet.google.com") {
+        return;
       }
+
+      const pathMatch = parsedUrl.pathname.match(/^\/([a-z\-]+)/);
+      const meetingId = pathMatch ? pathMatch[1] : null;
+
+      if (meetingId && meetingId !== "new") {
+        if (!state.isActive) {
+          resetState();
+          state.isActive = true;
+          state.meetingId = meetingId;
+          state.meetingUrl = tab.url || null;
+          state.targetTabId = tabId || null;
+          state.startTime = Date.now();
+          state.participants = ["You"];
+          await broadcastStateUpdate();
+        }
+      }
+    } catch {
+      // Ignore invalid or non-standard URLs
     }
   }
 });
@@ -1175,15 +1184,22 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 chrome.tabs.onActivated.addListener(async (activeInfo) => {
   try {
     const tab = await chrome.tabs.get(activeInfo.tabId);
-    if (tab.url?.includes("meet.google.com/")) {
-      const urlMatch = tab.url.match(/meet\.google\.com\/([a-z\-]+)/);
-      const meetingId = urlMatch ? urlMatch[1] : null;
-      if (meetingId && meetingId !== "new" && !state.isActive) {
-        state.meetingId = meetingId;
-        state.meetingUrl = tab.url;
-        state.targetTabId = activeInfo.tabId;
-        await broadcastStateUpdate();
-      }
+    if (!tab.url) {
+      return;
+    }
+
+    const parsedUrl = new URL(tab.url);
+    if (parsedUrl.hostname !== "meet.google.com") {
+      return;
+    }
+
+    const pathMatch = parsedUrl.pathname.match(/^\/([a-z\-]+)/);
+    const meetingId = pathMatch ? pathMatch[1] : null;
+    if (meetingId && meetingId !== "new" && !state.isActive) {
+      state.meetingId = meetingId;
+      state.meetingUrl = tab.url;
+      state.targetTabId = activeInfo.tabId;
+      await broadcastStateUpdate();
     }
   } catch (err) {
     console.debug("[LateMeet] tab activation handler failed:", err);


### PR DESCRIPTION
Potential fix for [https://github.com/shouri123/Late-Meet/security/code-scanning/2](https://github.com/shouri123/Late-Meet/security/code-scanning/2)

Use the built-in `URL` parser and compare `hostname` exactly to `meet.google.com` before extracting the meeting ID from `pathname`. This removes substring ambiguity and keeps behavior aligned with current intent (only true Google Meet pages).

Best single fix in `src/background.ts`:
- In both listeners (`chrome.tabs.onUpdated` around line 1156 and `chrome.tabs.onActivated` around line 1178), replace `includes("meet.google.com/")` plus regex over raw URL with:
  - `if (!tab.url) return;`
  - `const parsed = new URL(tab.url);`
  - `if (parsed.hostname !== "meet.google.com") return;`
  - extract meeting id from `parsed.pathname` using the existing `[a-z\-]+` pattern on the first path segment.
- Wrap parsing in existing `try/catch` (already present in `onActivated`); for `onUpdated`, add a small `try/catch` guard to avoid exceptions on non-standard URLs.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Google Meet session detection with stricter URL validation for improved accuracy
  * Improved handling of tab transitions to prevent incorrect session state initialization
  * Refined meeting identification logic for more reliable tracking across tab switches

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->