### PR TITLE
feat: add local storage usage dashboard to settings page

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -8,6 +8,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="options.css" />
+    <link rel="stylesheet" href="storageDashboard.css" />
   </head>
   <body>
     <div class="options-container">
@@ -361,7 +362,30 @@
           </div>
         </div>
       </section>
-
+      <!-- Storage Section -->
+      <section class="options-section">
+        <h2 class="section-title">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="lucide lucide-database"
+          >
+            <ellipse cx="12" cy="5" rx="9" ry="3" />
+            <path d="M3 5V19A9 3 0 0 0 21 19V5" />
+            <path d="M3 12A9 3 0 0 0 21 12" />
+          </svg>
+          Storage
+        </h2>
+        <p class="form-hint">View and manage local storage used by Late Meet.</p>
+        <div id="storage-dashboard-container"></div>
+      </section>
       <!-- Save Button -->
       <div class="save-section">
         <button id="save-btn" class="save-btn">

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,5 +1,6 @@
 import { getApiCredentials, saveApiCredentials } from "./utils/credentials";
 import { validateOpenAIKey, validateElevenLabsKey } from "./utils/api.js";
+import { renderStorageDashboard } from "./storageDashboard";
 
 interface Settings {
   summarizationInterval?: number;
@@ -239,4 +240,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       saveBtn.textContent = originalText;
     }
   });
+  // ——— Storage Dashboard ———
+  const storageContainer = document.getElementById("storage-dashboard-container");
+  if (storageContainer) {
+    await renderStorageDashboard(storageContainer);
+  }
 });

--- a/src/storageDashboard.css
+++ b/src/storageDashboard.css
@@ -1,0 +1,178 @@
+.storage-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 0;
+}
+
+.storage-warning {
+  padding: 10px 14px;
+  border: 1px solid var(--color-border-danger);
+  border-radius: var(--border-radius-md);
+  color: var(--color-text-danger);
+  font-size: 13px;
+}
+
+.storage-card {
+  padding: 16px;
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: var(--border-radius-lg);
+  background: var(--color-background-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.storage-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.storage-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.storage-value {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+}
+
+.storage-progress-track {
+  height: 8px;
+  background: var(--color-background-tertiary);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.storage-progress-bar {
+  height: 100%;
+  border-radius: 4px;
+  transition: width 0.4s ease;
+}
+
+.storage-percent {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.storage-breakdown {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.storage-breakdown-card {
+  padding: 12px;
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: var(--border-radius-md);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.breakdown-color-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.breakdown-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.breakdown-label {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.breakdown-bytes {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-text-primary);
+}
+
+.breakdown-pct {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.storage-meeting-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.storage-meeting-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--color-border-tertiary);
+}
+
+.storage-meeting-item:last-child {
+  border-bottom: none;
+}
+
+.storage-meeting-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.storage-meeting-title {
+  font-size: 13px;
+  color: var(--color-text-primary);
+}
+
+.storage-meeting-size {
+  font-size: 12px;
+  color: var(--color-text-secondary);
+}
+
+.storage-delete-btn {
+  font-size: 12px;
+  padding: 4px 10px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-md);
+  background: transparent;
+  color: var(--color-text-danger);
+  cursor: pointer;
+}
+
+.storage-delete-btn:hover {
+  background: var(--color-background-danger);
+}
+
+.storage-refresh-btn {
+  align-self: flex-start;
+  font-size: 13px;
+  padding: 6px 14px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.storage-refresh-btn:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-border-primary);
+}
+
+.storage-loading,
+.storage-error {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  padding: 16px 0;
+}

--- a/src/storageDashboard.ts
+++ b/src/storageDashboard.ts
@@ -1,0 +1,110 @@
+import { getStorageStats, formatBytes, deleteSavedMeetingSession } from "./utils/storageUtils";
+import { StorageStats } from "./types";
+
+export async function renderStorageDashboard(container: HTMLElement): Promise<void> {
+  container.innerHTML = '<p class="storage-loading">Loading storage data…</p>';
+
+  try {
+    const stats = await getStorageStats();
+    container.innerHTML = buildDashboardHTML(stats);
+    attachEventListeners(container);
+  } catch (err) {
+    container.innerHTML = '<p class="storage-error">Failed to load storage data.</p>';
+  }
+}
+
+function buildDashboardHTML(stats: StorageStats): string {
+  const isWarning = stats.percentUsed >= stats.warningThreshold;
+  const progressColor = isWarning ? "var(--color-text-danger)" : "var(--color-text-success)";
+
+  return `
+    <div class="storage-dashboard">
+
+      ${
+        isWarning
+          ? `
+        <div class="storage-warning">
+          <span>⚠ Storage usage is above ${stats.warningThreshold}%. Consider removing old meetings.</span>
+        </div>
+      `
+          : ""
+      }
+
+      <div class="storage-card">
+        <div class="storage-card-header">
+          <span class="storage-label">Total storage used</span>
+          <span class="storage-value">${formatBytes(stats.totalBytes)} / ${formatBytes(stats.quotaBytes)}</span>
+        </div>
+        <div class="storage-progress-track">
+          <div class="storage-progress-bar" style="width: ${stats.percentUsed}%; background: ${progressColor}"></div>
+        </div>
+        <div class="storage-percent">${stats.percentUsed}% used • ${stats.meetingCount} meetings stored</div>
+      </div>
+
+      <div class="storage-breakdown">
+        ${buildBreakdownCard("Transcripts", stats.transcriptBytes, stats.totalBytes, "#534AB7")}
+        ${buildBreakdownCard("Summaries", stats.summaryBytes, stats.totalBytes, "#0F6E56")}
+        ${buildBreakdownCard("Action Items", stats.actionItemBytes, stats.totalBytes, "#185FA5")}
+        ${buildBreakdownCard("Settings", stats.settingsBytes, stats.totalBytes, "#5F5E5A")}
+      </div>
+
+      ${
+        stats.largestMeetings.length > 0
+          ? `
+        <div class="storage-card">
+          <div class="storage-card-header">
+            <span class="storage-label">Largest meetings</span>
+          </div>
+          <ul class="storage-meeting-list">
+            ${stats.largestMeetings
+              .map(
+                (m) => `
+              <li class="storage-meeting-item">
+                <div class="storage-meeting-info">
+                  <span class="storage-meeting-title">${m.title}</span>
+                  <span class="storage-meeting-size">${formatBytes(m.totalBytes)}</span>
+                </div>
+                <button class="storage-delete-btn" data-id="${m.id}">Delete</button>
+              </li>
+            `,
+              )
+              .join("")}
+          </ul>
+        </div>
+      `
+          : ""
+      }
+
+      <button class="storage-refresh-btn" id="storage-refresh">Refresh</button>
+    </div>
+  `;
+}
+
+function buildBreakdownCard(label: string, bytes: number, total: number, color: string): string {
+  const pct = total > 0 ? Math.round((bytes / total) * 100) : 0;
+  return `
+    <div class="storage-breakdown-card">
+      <div class="breakdown-color-dot" style="background: ${color}"></div>
+      <div class="breakdown-info">
+        <span class="breakdown-label">${label}</span>
+        <span class="breakdown-bytes">${formatBytes(bytes)}</span>
+      </div>
+      <span class="breakdown-pct">${pct}%</span>
+    </div>
+  `;
+}
+
+function attachEventListeners(container: HTMLElement): void {
+  container.querySelectorAll(".storage-delete-btn").forEach((btn) => {
+    btn.addEventListener("click", async (e) => {
+      const id = (e.target as HTMLElement).dataset.id!;
+      if (confirm("Delete this meeting's stored data?")) {
+        await deleteSavedMeetingSession(chrome.storage.local, id);
+        await renderStorageDashboard(container);
+      }
+    });
+  });
+
+  const refreshBtn = container.querySelector("#storage-refresh");
+  refreshBtn?.addEventListener("click", () => renderStorageDashboard(container));
+}

--- a/src/storageDashboard.ts
+++ b/src/storageDashboard.ts
@@ -1,6 +1,15 @@
 import { getStorageStats, formatBytes, deleteSavedMeetingSession } from "./utils/storageUtils";
 import { StorageStats } from "./types";
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
 export async function renderStorageDashboard(container: HTMLElement): Promise<void> {
   container.innerHTML = '<p class="storage-loading">Loading storage data…</p>';
 
@@ -61,10 +70,10 @@ function buildDashboardHTML(stats: StorageStats): string {
                 (m) => `
               <li class="storage-meeting-item">
                 <div class="storage-meeting-info">
-                  <span class="storage-meeting-title">${m.title}</span>
+                  <span class="storage-meeting-title">${escapeHtml(m.title)}</span>
                   <span class="storage-meeting-size">${formatBytes(m.totalBytes)}</span>
                 </div>
-                <button class="storage-delete-btn" data-id="${m.id}">Delete</button>
+                <button class="storage-delete-btn" data-id="${escapeHtml(m.id)}">Delete</button>
               </li>
             `,
               )

--- a/src/storageDashboard.ts
+++ b/src/storageDashboard.ts
@@ -3,11 +3,11 @@ import { StorageStats } from "./types";
 
 function escapeHtml(value: string): string {
   return value
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
 }
 
 export async function renderStorageDashboard(container: HTMLElement): Promise<void> {
@@ -18,6 +18,7 @@ export async function renderStorageDashboard(container: HTMLElement): Promise<vo
     container.innerHTML = buildDashboardHTML(stats);
     attachEventListeners(container);
   } catch (err) {
+    console.error("[LateMeet] Failed to load storage dashboard:", err);
     container.innerHTML = '<p class="storage-error">Failed to load storage data.</p>';
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,3 +58,26 @@ export interface State {
   id?: string;
   savedAt?: number;
 }
+
+export interface MeetingStorageInfo {
+  id: string;
+  title: string;
+  date: string;
+  totalBytes: number;
+  transcriptBytes: number;
+  summaryBytes: number;
+  actionItemBytes: number;
+}
+
+export interface StorageStats {
+  totalBytes: number;
+  quotaBytes: number;
+  percentUsed: number;
+  transcriptBytes: number;
+  summaryBytes: number;
+  actionItemBytes: number;
+  settingsBytes: number;
+  meetingCount: number;
+  largestMeetings: MeetingStorageInfo[];
+  warningThreshold: number;
+}

--- a/src/utils/storageUtils.ts
+++ b/src/utils/storageUtils.ts
@@ -1,0 +1,102 @@
+import { getSavedMeetingSessions } from "../sessionStorage";
+import { StorageStats, MeetingStorageInfo } from "../types";
+
+const DEFAULT_QUOTA_BYTES = 10 * 1024 * 1024; // 10MB — chrome.storage.local default
+const DEFAULT_WARNING_THRESHOLD = 80;
+
+function roughBytes(value: unknown): number {
+  return new Blob([JSON.stringify(value)]).size;
+}
+
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+export async function getStorageStats(): Promise<StorageStats> {
+  // Reuse the existing helper to get all saved sessions
+  const sessions = await getSavedMeetingSessions(chrome.storage.local);
+
+  // Get everything in local storage to also measure settings + API keys
+  const allItems = await chrome.storage.local.get(null);
+
+  // --- Per-category byte counting ---
+  let transcriptBytes = 0;
+  let summaryBytes = 0;
+  let actionItemBytes = 0;
+  let settingsBytes = 0;
+
+  // Settings keys used in background.ts:
+  //   "settings"         → getSettings()
+  //   "openai_api_key"   → getApiKey()
+  //   "elevenlabs_api_key" → transcribeChunk()
+  const SETTINGS_KEYS = new Set(["settings", "openai_api_key", "elevenlabs_api_key"]);
+
+  for (const [key, value] of Object.entries(allItems)) {
+    if (SETTINGS_KEYS.has(key)) {
+      settingsBytes += roughBytes(value);
+    }
+    // Session-related keys are measured per-session below
+  }
+
+  // Per-session breakdown using the StoredSession shape from sessionStorage.ts
+  const meetingInfos: MeetingStorageInfo[] = sessions.map((session) => {
+    const tBytes = roughBytes(session.transcript ?? []);
+    const sBytes = roughBytes(session.summary ?? "");
+    const aBytes = roughBytes(session.actionItems ?? []);
+    const total = roughBytes(session); // whole session object
+
+    transcriptBytes += tBytes;
+    summaryBytes += sBytes;
+    actionItemBytes += aBytes;
+
+    // Use meetingId or id, and format the date from savedAt
+    const savedAt = session.savedAt ? new Date(session.savedAt) : null;
+    const dateStr = savedAt
+      ? savedAt.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+      : "Unknown date";
+
+    return {
+      id: session.id,
+      title: session.meetingId
+        ? `Meeting — ${session.meetingId}`
+        : `Session ${session.id.slice(0, 8)}`,
+      date: dateStr,
+      totalBytes: total,
+      transcriptBytes: tBytes,
+      summaryBytes: sBytes,
+      actionItemBytes: aBytes,
+    };
+  });
+
+  // Sort largest first, keep top 5 for the dashboard list
+  meetingInfos.sort((a, b) => b.totalBytes - a.totalBytes);
+
+  // Use getBytesInUse for the most accurate total (it measures actual storage overhead)
+  const totalBytes = await new Promise<number>((resolve) => {
+    if (chrome.storage.local.getBytesInUse) {
+      chrome.storage.local.getBytesInUse(null, resolve);
+    } else {
+      resolve(Object.values(allItems).reduce((sum, v) => sum + roughBytes(v), 0));
+    }
+  });
+
+  const quotaBytes = DEFAULT_QUOTA_BYTES;
+
+  return {
+    totalBytes,
+    quotaBytes,
+    percentUsed: Math.min(100, Math.round((totalBytes / quotaBytes) * 100)),
+    transcriptBytes,
+    summaryBytes,
+    actionItemBytes,
+    settingsBytes,
+    meetingCount: sessions.length,
+    largestMeetings: meetingInfos.slice(0, 5),
+    warningThreshold: DEFAULT_WARNING_THRESHOLD,
+  };
+}
+
+// Reuse the existing deleteSavedMeetingSession from sessionStorage.ts
+export { deleteSavedMeetingSession } from "../sessionStorage";

--- a/src/utils/storageUtils.ts
+++ b/src/utils/storageUtils.ts
@@ -78,7 +78,7 @@ export async function getStorageStats(): Promise<StorageStats> {
     if (chrome.storage.local.getBytesInUse) {
       chrome.storage.local.getBytesInUse(null, resolve);
     } else {
-      resolve(Object.values(allItems).reduce((sum, v) => sum + roughBytes(v), 0));
+      resolve(Object.values(allItems).reduce((sum: number, v: unknown) => sum + roughBytes(v), 0));
     }
   });
 


### PR DESCRIPTION
## Description
Adds a Storage Usage Dashboard to the Settings (Options) page. Users can now see how much local storage Late Meet is consuming, broken down by category (Transcripts, Summaries, Action Items, Settings), along with a visual progress bar, total usage vs quota, meeting count, and a list of the largest stored meetings with the ability to delete them individually.

Fixes #177

## Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?
Please describe the tests you ran to verify your changes:
- [x] Built the extension with `npm run build`
- [x] Loaded the extension in Chrome and tested manually
- [ ] Tested on a live Google Meet call
- [x] Verified no console errors
- [ ] Tested with ElevenLabs API key
- [ ] Tested with OpenAI API key

## Screenshots (if applicable)
<img width="847" height="740" alt="image" src="https://github.com/user-attachments/assets/e0eb807b-413f-461f-bb55-e9a37ec9eb69" />

## Checklist
- [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [ ] I have updated the documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Storage Dashboard to the options page showing total usage with a progress bar, per-category breakdown, largest meetings list, delete and refresh actions, and a warning when storage is high.

* **Style**
  * New dashboard styling for layout, progress bar, breakdown cards, lists, and action buttons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/226?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->