### PR TITLE
feat: add in-session transcript search

### DIFF
--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -1043,14 +1043,18 @@ body::-webkit-scrollbar-thumb,
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   gap: 12px;
+  margin-bottom: 12px;
+  padding: 10px;
+  background: var(--bg-app);
+  border: 1px solid var(--border-main);
+  border-radius: 10px;
 }
 
 .search-input-wrapper {
   position: relative;
   flex: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
 }
@@ -1059,52 +1063,84 @@ body::-webkit-scrollbar-thumb,
   position: absolute;
   left: 10px;
   color: var(--text-muted);
+  pointer-events: none;
 }
 
 .search-input {
   width: 100%;
-  background: rgba(0, 0, 0, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 6px;
-  padding: 8px 30px;
+  height: 36px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-sub);
+  border-radius: 8px;
+  padding: 8px 34px 8px 32px;
   color: var(--text-main);
   font-family: inherit;
   font-size: 13px;
   outline: none;
-  transition: border-color 0.2s;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background 0.2s ease;
+}
+
+.search-input::placeholder {
+  color: var(--text-muted);
 }
 
 .search-input:focus {
-  border-color: rgba(255, 255, 255, 0.25);
+  border-color: var(--border-element);
+  box-shadow: 0 0 0 3px var(--shadow-main);
 }
 
 .search-clear-btn {
   position: absolute;
   right: 8px;
-  background: none;
+  width: 22px;
+  height: 22px;
+  background: transparent;
   border: none;
+  border-radius: 6px;
   color: var(--text-muted);
   cursor: pointer;
   display: none;
   align-items: center;
   justify-content: center;
   padding: 2px;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease,
+    opacity 0.2s ease;
 }
 
-.search-clear-btn:hover {
+.search-clear-btn.visible {
+  display: flex;
+}
+
+.search-clear-btn:hover:not(:disabled) {
   color: var(--text-main);
+  background: var(--bg-card);
+}
+
+.search-clear-btn:disabled {
+  cursor: default;
+  opacity: 0.45;
 }
 
 .search-controls {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-shrink: 0;
 }
 
 .search-counter {
+  min-width: 44px;
   color: var(--text-muted);
   font-size: 12px;
+  font-weight: 600;
+  text-align: center;
   white-space: nowrap;
+  font-variant-numeric: tabular-nums;
 }
 
 .search-nav-buttons {
@@ -1113,38 +1149,63 @@ body::-webkit-scrollbar-thumb,
 }
 
 .search-action-btn {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
+  width: 30px;
+  height: 30px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-sub);
+  border-radius: 7px;
   padding: 4px;
   color: var(--text-main);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background 0.2s;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .search-action-btn:hover:not(:disabled) {
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--bg-card);
+  border-color: var(--border-element);
+  transform: translateY(-1px);
 }
 
 .search-action-btn:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: default;
 }
 
 .search-match {
-  background-color: rgba(255, 255, 255, 0.2);
+  background: rgba(250, 204, 21, 0.5);
   color: inherit;
-  border-radius: 2px;
+  border-radius: 3px;
   padding: 0 2px;
 }
 
 .search-match.active {
-  background-color: #34d399;
+  background: #34d399;
   color: #000000;
+  box-shadow: 0 0 0 1px rgba(52, 211, 153, 0.45);
 }
+
+@media (max-width: 520px) {
+  .transcript-search-header {
+    flex-wrap: wrap;
+  }
+
+  .search-input-wrapper {
+    flex-basis: 100%;
+  }
+
+  .search-controls {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
 /* ——— History Modal & UI ——— */
 .session-item.expanded .session-item-summary {
   display: block;

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -1087,6 +1087,12 @@ body::-webkit-scrollbar-thumb,
   color: var(--text-muted);
 }
 
+.search-input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+  display: none;
+}
+
 .search-input:focus {
   border-color: var(--border-element);
   box-shadow: 0 0 0 3px var(--shadow-main);

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -689,8 +689,8 @@
             <span class="live-indicator"> <span class="live-dot"></span>LIVE </span>
           </div>
 
-          <!-- NEW: Transcript Search Header -->
-          <div class="transcript-search-header">
+          <!-- Transcript Search Header -->
+          <div class="transcript-search-header" id="transcript-search-bar">
             <div class="search-input-wrapper">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -703,18 +703,29 @@
                 stroke-linecap="round"
                 stroke-linejoin="round"
                 class="icon search-icon"
+                aria-hidden="true"
               >
                 <circle cx="11" cy="11" r="8"></circle>
                 <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
               </svg>
+
               <input
-                type="text"
+                type="search"
                 id="transcript-search-input"
                 class="search-input"
                 placeholder="Search transcript..."
                 autocomplete="off"
+                aria-label="Search transcript"
               />
-              <button id="search-clear" class="search-clear-btn" title="Clear search">
+
+              <button
+                id="search-clear"
+                class="search-clear-btn"
+                type="button"
+                title="Clear search"
+                aria-label="Clear transcript search"
+                disabled
+              >
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
                   width="14"
@@ -726,6 +737,7 @@
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   class="icon"
+                  aria-hidden="true"
                 >
                   <line x1="18" y1="6" x2="6" y2="18"></line>
                   <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -734,9 +746,19 @@
             </div>
 
             <div class="search-controls">
-              <span id="transcript-search-counter" class="search-counter"></span>
+              <span id="transcript-search-counter" class="search-counter" aria-live="polite">
+                0/0
+              </span>
+
               <div class="search-nav-buttons">
-                <button id="search-prev" class="search-action-btn" title="Previous match" disabled>
+                <button
+                  id="search-prev"
+                  class="search-action-btn"
+                  type="button"
+                  title="Previous match"
+                  aria-label="Previous transcript match"
+                  disabled
+                >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="14"
@@ -748,11 +770,20 @@
                     stroke-linecap="round"
                     stroke-linejoin="round"
                     class="icon"
+                    aria-hidden="true"
                   >
                     <polyline points="18 15 12 9 6 15"></polyline>
                   </svg>
                 </button>
-                <button id="search-next" class="search-action-btn" title="Next match" disabled>
+
+                <button
+                  id="search-next"
+                  class="search-action-btn"
+                  type="button"
+                  title="Next match"
+                  aria-label="Next transcript match"
+                  disabled
+                >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="14"
@@ -764,6 +795,7 @@
                     stroke-linecap="round"
                     stroke-linejoin="round"
                     class="icon"
+                    aria-hidden="true"
                   >
                     <polyline points="6 9 12 15 18 9"></polyline>
                   </svg>
@@ -771,7 +803,6 @@
               </div>
             </div>
           </div>
-
           <div class="transcript-info">
             Each entry shows who spoke, what was said, and when. Audio entries are from the Whisper
             transcription.

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -823,17 +823,20 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ——— Live Transcript ———
   function updateTranscript(transcript: TranscriptEntry[]) {
-    const container = document.getElementById("dash-transcript-list");
-    if (!container) return;
+    if (!transcriptContainer) return;
+
     if (!transcript || transcript.length === 0) {
-      container.innerHTML =
+      transcriptContainer.innerHTML =
         '<div class="empty-msg">No transcript yet. Start audio to begin capturing speech.</div>';
+
+      resetTranscriptSearchState();
+
       return;
     }
 
     const startTime = transcript[0]?.timestamp || Date.now();
 
-    container.innerHTML = transcript
+    transcriptContainer.innerHTML = transcript
       .map((entry) => {
         const timestamp = entry.timestamp || Date.now();
         const elapsed = Math.round((timestamp - startTime) / 1000);
@@ -841,6 +844,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         const speaker = escapeHtml(entry.speaker || "Unknown");
         const initials = speaker
           .split(" ")
+          .filter(Boolean)
           .map((w) => w[0])
           .join("")
           .toUpperCase()
@@ -861,15 +865,11 @@ document.addEventListener("DOMContentLoaded", async () => {
       })
       .join("");
 
-    // Auto-scroll to bottom if not currently searching
-    const searchInput = document.getElementById(
-      "transcript-search-input",
-    ) as HTMLInputElement | null;
-    if (searchInput && searchInput.value.trim() !== "") {
-      // Re-apply search highlight when new transcript lines arrive
+    if (searchInput?.value.trim()) {
       executeTranscriptSearch(true);
     } else {
-      container.scrollTop = container.scrollHeight;
+      transcriptContainer.scrollTop = transcriptContainer.scrollHeight;
+      updateTranscriptSearchControls();
     }
   }
 
@@ -1275,63 +1275,89 @@ document.addEventListener("DOMContentLoaded", async () => {
     showToast("Downloaded as .md file", "success");
   }
 
-  // ——— Transcript Search Phase 2 ———
+  // ——— Transcript Search ———
   let searchMatches: HTMLElement[] = [];
   let currentMatchIndex = -1;
   let searchDebounceTimer: number | null = null;
 
-  function clearTranscriptSearch() {
-    if (
-      !searchInput ||
-      !searchCounter ||
-      !searchClearBtn ||
-      !searchPrevBtn ||
-      !searchNextBtn ||
-      !transcriptContainer
-    )
-      return;
-
-    // Remove all mark tags cleanly without breaking inner HTML
-    const marks = transcriptContainer.querySelectorAll("mark.search-match");
-    marks.forEach((mark) => {
-      const parent = mark.parentNode;
-      if (parent) {
-        parent.replaceChild(document.createTextNode(mark.textContent || ""), mark);
-        parent.normalize();
-      }
-    });
-
+  function resetTranscriptSearchState(): void {
     searchMatches = [];
     currentMatchIndex = -1;
-    searchInput.value = "";
-    searchCounter.textContent = "";
-    searchClearBtn.style.display = "none";
-    searchPrevBtn.disabled = true;
-    searchNextBtn.disabled = true;
 
-    transcriptContainer.scrollTop = transcriptContainer.scrollHeight;
     if (searchCounter) {
-      searchCounter.style.display = "none";
+      searchCounter.textContent = "0/0";
+    }
+
+    if (searchPrevBtn) {
+      searchPrevBtn.disabled = true;
+    }
+
+    if (searchNextBtn) {
+      searchNextBtn.disabled = true;
+    }
+
+    if (searchClearBtn) {
+      searchClearBtn.disabled = !searchInput?.value.trim();
+      searchClearBtn.classList.toggle("visible", Boolean(searchInput?.value.trim()));
     }
   }
 
-  function updateActiveSearchMatch() {
-    if (searchMatches.length === 0) return;
+  function unwrapTranscriptSearchMarks(): void {
+    if (!transcriptContainer) return;
 
-    searchMatches.forEach((el) => el.classList.remove("active"));
+    transcriptContainer.querySelectorAll("mark.search-match").forEach((mark) => {
+      const parent = mark.parentNode;
 
-    if (currentMatchIndex >= 0 && currentMatchIndex < searchMatches.length) {
-      const activeMatch = searchMatches[currentMatchIndex];
-      activeMatch.classList.add("active");
-      activeMatch.scrollIntoView({ behavior: "smooth", block: "center" });
+      if (!parent) return;
 
-      if (searchCounter) {
-        searchCounter.textContent = `${currentMatchIndex + 1} of ${searchMatches.length}`;
-      }
+      parent.replaceChild(document.createTextNode(mark.textContent || ""), mark);
+      parent.normalize();
+    });
+  }
+
+  function updateTranscriptSearchControls(): void {
+    const hasQuery = Boolean(searchInput?.value.trim());
+    const hasMatches = searchMatches.length > 0;
+
+    if (searchCounter) {
+      searchCounter.textContent = hasMatches
+        ? `${currentMatchIndex + 1}/${searchMatches.length}`
+        : "0/0";
+    }
+
+    if (searchPrevBtn) {
+      searchPrevBtn.disabled = !hasMatches;
+    }
+
+    if (searchNextBtn) {
+      searchNextBtn.disabled = !hasMatches;
+    }
+
+    if (searchClearBtn) {
+      searchClearBtn.disabled = !hasQuery;
+      searchClearBtn.classList.toggle("visible", hasQuery);
     }
   }
 
-  function executeTranscriptSearch(preserveIndex: boolean = false) {
+  function updateActiveSearchMatch(scrollToMatch = true): void {
+    searchMatches.forEach((match, index) => {
+      match.classList.toggle("active", index === currentMatchIndex);
+    });
+
+    updateTranscriptSearchControls();
+
+    if (!scrollToMatch) return;
+
+    const activeMatch = searchMatches[currentMatchIndex];
+
+    activeMatch?.scrollIntoView({
+      behavior: "smooth",
+      block: "center",
+      inline: "nearest",
+    });
+  }
+
+  function executeTranscriptSearch(preserveIndex = false): void {
     if (
       !searchInput ||
       !searchCounter ||
@@ -1343,133 +1369,176 @@ document.addEventListener("DOMContentLoaded", async () => {
       return;
     }
 
-    const query = searchInput.value.toLowerCase().trim();
+    const query = searchInput.value.trim();
+    const normalizedQuery = query.toLowerCase();
+    const previousIndex = currentMatchIndex;
 
-    // Clean existing marks
-    const marks = transcriptContainer.querySelectorAll("mark.search-match");
-    marks.forEach((mark) => {
-      const parent = mark.parentNode;
-      if (parent) {
-        parent.replaceChild(document.createTextNode(mark.textContent || ""), mark);
-        parent.normalize();
-      }
-    });
+    unwrapTranscriptSearchMarks();
 
     searchMatches = [];
-    const previousIndex = currentMatchIndex;
     currentMatchIndex = -1;
 
-    if (!query) {
-      searchCounter.textContent = "";
-      searchClearBtn.style.display = "none";
-      searchPrevBtn.disabled = true;
-      searchNextBtn.disabled = true;
-      if (searchCounter) searchCounter.style.display = "none";
+    if (!normalizedQuery) {
+      updateTranscriptSearchControls();
       return;
     }
 
-    searchClearBtn.style.display = "flex";
+    const textNodes: Text[] = [];
+    const walker = document.createTreeWalker(transcriptContainer, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        const parentElement = node.parentElement;
 
-    // Safely iterate text nodes to avoid mutating DOM structure
-    const textNodes: Node[] = [];
-    const walker = document.createTreeWalker(transcriptContainer, NodeFilter.SHOW_TEXT, null);
-
-    let node;
-    while ((node = walker.nextNode())) {
-      if (node.nodeValue && node.nodeValue.trim() !== "") {
-        // Skip text inside empty-msg
-        const parentEl = node.parentElement as HTMLElement | null;
-        if (parentEl && !parentEl.classList.contains("empty-msg")) {
-          textNodes.push(node);
+        if (!parentElement) {
+          return NodeFilter.FILTER_REJECT;
         }
-      }
+
+        if (parentElement.closest(".empty-msg")) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        if (!parentElement.closest(".transcript-text")) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        if (!node.nodeValue?.trim()) {
+          return NodeFilter.FILTER_REJECT;
+        }
+
+        return NodeFilter.FILTER_ACCEPT;
+      },
+    });
+
+    let node = walker.nextNode();
+
+    while (node) {
+      textNodes.push(node as Text);
+      node = walker.nextNode();
     }
 
     textNodes.forEach((textNode) => {
       const textContent = textNode.nodeValue || "";
-      const lowerText = textContent.toLowerCase();
-      const startIndex = 0;
-      let index = lowerText.indexOf(query, startIndex);
+      const lowerTextContent = textContent.toLowerCase();
 
-      if (index === -1) return;
-
-      const fragment = document.createDocumentFragment();
+      let matchIndex = lowerTextContent.indexOf(normalizedQuery);
       let lastIndex = 0;
 
-      while (index !== -1) {
-        if (index > lastIndex) {
-          fragment.appendChild(document.createTextNode(textContent.substring(lastIndex, index)));
+      if (matchIndex === -1) {
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+
+      while (matchIndex !== -1) {
+        if (matchIndex > lastIndex) {
+          fragment.appendChild(document.createTextNode(textContent.slice(lastIndex, matchIndex)));
         }
 
         const mark = document.createElement("mark");
         mark.className = "search-match";
-        mark.textContent = textContent.substring(index, index + query.length);
+        mark.dataset.transcriptMatch = "true";
+        mark.textContent = textContent.slice(matchIndex, matchIndex + query.length);
+
         fragment.appendChild(mark);
         searchMatches.push(mark);
 
-        lastIndex = index + query.length;
-        index = lowerText.indexOf(query, lastIndex);
+        lastIndex = matchIndex + query.length;
+        matchIndex = lowerTextContent.indexOf(normalizedQuery, lastIndex);
       }
 
       if (lastIndex < textContent.length) {
-        fragment.appendChild(document.createTextNode(textContent.substring(lastIndex)));
+        fragment.appendChild(document.createTextNode(textContent.slice(lastIndex)));
       }
 
-      if (textNode.parentNode) {
-        textNode.parentNode.replaceChild(fragment, textNode);
-      }
+      textNode.parentNode?.replaceChild(fragment, textNode);
     });
 
-    if (searchMatches.length > 0) {
-      if (preserveIndex && previousIndex >= 0 && previousIndex < searchMatches.length) {
-        currentMatchIndex = previousIndex;
-      } else {
-        currentMatchIndex = 0;
-      }
-      searchPrevBtn.disabled = false;
-      searchNextBtn.disabled = false;
-      if (searchCounter) searchCounter.style.display = "inline-flex";
-      updateActiveSearchMatch();
-    } else {
-      if (searchCounter) {
-        searchCounter.textContent = "0 of 0";
-        searchCounter.style.display = "inline-flex";
-      }
-      searchPrevBtn.disabled = true;
-      searchNextBtn.disabled = true;
+    if (searchMatches.length === 0) {
+      updateTranscriptSearchControls();
+      return;
     }
+
+    if (preserveIndex && previousIndex >= 0 && previousIndex < searchMatches.length) {
+      currentMatchIndex = previousIndex;
+    } else {
+      currentMatchIndex = 0;
+    }
+
+    updateActiveSearchMatch(true);
+  }
+
+  function clearTranscriptSearch(): void {
+    if (!searchInput || !transcriptContainer) return;
+
+    searchInput.value = "";
+    unwrapTranscriptSearchMarks();
+
+    searchMatches = [];
+    currentMatchIndex = -1;
+
+    updateTranscriptSearchControls();
+
+    transcriptContainer.scrollTop = transcriptContainer.scrollHeight;
+    searchInput.focus();
+  }
+
+  function navigateTranscriptMatch(direction: 1 | -1): void {
+    if (searchMatches.length === 0) return;
+
+    currentMatchIndex =
+      (currentMatchIndex + direction + searchMatches.length) % searchMatches.length;
+
+    updateActiveSearchMatch(true);
   }
 
   searchInput?.addEventListener("input", () => {
-    if (searchDebounceTimer) window.clearTimeout(searchDebounceTimer);
-    searchDebounceTimer = window.setTimeout(() => executeTranscriptSearch(false), 300);
+    if (searchDebounceTimer) {
+      window.clearTimeout(searchDebounceTimer);
+    }
+
+    searchDebounceTimer = window.setTimeout(() => {
+      executeTranscriptSearch(false);
+    }, 150);
   });
 
-  searchInput?.addEventListener("keydown", (e) => {
-    if (e.key === "Escape") {
+  searchInput?.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      navigateTranscriptMatch(event.shiftKey ? -1 : 1);
+    }
+
+    if (event.key === "Escape") {
+      event.preventDefault();
       clearTranscriptSearch();
-    } else if (e.key === "Enter") {
-      if (e.shiftKey) {
-        searchPrevBtn?.click();
-      } else {
-        searchNextBtn?.click();
-      }
     }
   });
 
   searchClearBtn?.addEventListener("click", clearTranscriptSearch);
 
   searchPrevBtn?.addEventListener("click", () => {
-    if (searchMatches.length === 0) return;
-    currentMatchIndex = (currentMatchIndex - 1 + searchMatches.length) % searchMatches.length;
-    updateActiveSearchMatch();
+    navigateTranscriptMatch(-1);
   });
 
   searchNextBtn?.addEventListener("click", () => {
-    if (searchMatches.length === 0) return;
-    currentMatchIndex = (currentMatchIndex + 1) % searchMatches.length;
-    updateActiveSearchMatch();
+    navigateTranscriptMatch(1);
   });
+
+  document.addEventListener("keydown", (event) => {
+    const isSearchShortcut = (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "f";
+
+    if (!isSearchShortcut) return;
+
+    const transcriptTab = document.querySelector('[data-tab="transcript"]') as HTMLElement | null;
+
+    event.preventDefault();
+    transcriptTab?.click();
+
+    window.setTimeout(() => {
+      searchInput?.focus();
+      searchInput?.select();
+    }, 0);
+  });
+
+  updateTranscriptSearchControls();
 
   // Load sessions on tab switch
   document.querySelector('[data-tab="sessions"]')?.addEventListener("click", loadMeetingHistory);

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1278,7 +1278,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   // ——— Transcript Search ———
   let searchMatches: HTMLElement[] = [];
   let currentMatchIndex = -1;
-  let searchDebounceTimer: number | null = null;
+  let searchDebounceTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
 
   function resetTranscriptSearchState(): void {
     searchMatches = [];
@@ -1492,10 +1492,10 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   searchInput?.addEventListener("input", () => {
     if (searchDebounceTimer) {
-      window.clearTimeout(searchDebounceTimer);
+      globalThis.clearTimeout(searchDebounceTimer);
     }
 
-    searchDebounceTimer = window.setTimeout(() => {
+    searchDebounceTimer = globalThis.setTimeout(() => {
       executeTranscriptSearch(false);
     }, 150);
   });
@@ -1532,7 +1532,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     event.preventDefault();
     transcriptTab?.click();
 
-    window.setTimeout(() => {
+    globalThis.setTimeout(() => {
       searchInput?.focus();
       searchInput?.select();
     }, 0);


### PR DESCRIPTION
## Description
Added an in-session search feature to the Live Transcript tab. Users can now search transcript text in real time, see highlighted matches, view the current match count, navigate between matches using previous/next buttons, and clear the search query.

Fixes #178 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

Please describe the tests you ran to verify your changes:

- [x] Built the extension with `npm run build`
- [x] Loaded the extension in Chrome and tested manually
- [x] Tested on a live Google Meet call
- [ ] Verified no console errors
- [x] Tested with ElevenLabs API key
- [x] Tested with OpenAI API key

Manual testing performed:
- Verified transcript search input appears in the Transcript tab
- Verified case-insensitive search using the keyword project
- Verified 4 matching results were detected
- Verified match counter displays 1/4
- Verified active match and other matches are highlighted correctly
- Verified previous/next navigation buttons are enabled
- Verified clear search button works

Note: Live transcription could not be fully tested locally because the configured OpenAI API key returned `429 insufficient_quota`. The transcript search feature was verified using mock transcript entries in the dashboard.

## Screenshots (if applicable)
**Before: Transcript tab only displayed live transcript content without any in-session search, match counter, or highlighted results.**
<img width="1919" height="937" alt="image" src="https://github.com/user-attachments/assets/682ab5dc-85c0-4034-9f99-596779d928cb" />

**After: Added transcript search with keyword input, highlighted matches, active match indication, match counter (1/4), and previous/next navigation controls.**
<img width="1916" height="954" alt="Screenshot 2026-05-30 170736" src="https://github.com/user-attachments/assets/54bb5d80-82ef-447e-a7ef-a10fd6301926" />

## Checklist

- [x] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut (Ctrl/Cmd+F) to jump to and focus transcript search.

* **Improvements**
  * Restyled transcript search header to match themed card look with improved responsive wrapping.
  * Faster, debounced live search with updated match navigation and visible match counter.
  * Updated match highlighting and clearer action/clear controls with smoother transitions.

* **Accessibility**
  * Improved semantic attributes and labels for search input, controls, and live counter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->