### PR TITLE
[BUG]: Audio chunk queue permanently locks up if onError hook throws an error

### DIFF
--- a/src/audioChunkQueue.test.ts
+++ b/src/audioChunkQueue.test.ts
@@ -104,3 +104,24 @@ test("audio chunk queue rejects new chunks when pending backlog is full", async 
   gate.resolve();
   await waitForDrain();
 });
+
+test("audio chunk queue continues after onError hook failure", async () => {
+  const processed: string[] = [];
+  const queue = new AudioChunkQueue<string>({
+    maxPending: 4,
+    process: async ({ item }) => {
+      if (item === "bad") throw new Error("stt failed");
+      processed.push(item);
+    },
+    onError: () => {
+      throw new Error("onError threw an error");
+    },
+  });
+
+  queue.enqueue("bad");
+  queue.enqueue("next");
+
+  await waitForDrain();
+
+  assert.deepEqual(processed, ["next"]);
+});

--- a/src/audioChunkQueue.ts
+++ b/src/audioChunkQueue.ts
@@ -80,7 +80,11 @@ export class AudioChunkQueue<T> {
         try {
           await this.process(entry);
         } catch (err) {
-          await this.onError?.(err, entry);
+          try {
+            await this.onError?.(err, entry);
+          } catch (handlerErr) {
+            console.error("AudioChunkQueue: onError handler threw an error:", handlerErr);
+          }
         }
       }
     } finally {


### PR DESCRIPTION
Fixes #249

### Description
In `src/audioChunkQueue.ts`, the `drain()` queue loop was vulnerable to failure if the custom `onError` callback threw or rejected an error. Any error originating from `onError` would escape the `try-catch`, stop loop execution, set `this.processing = false`, and permanently freeze all remaining and subsequent queued audio items.

### Proposed Changes
- Wrapped `await this.onError?.(err, entry)` in an inner `try-catch` block to isolate custom error handling crashes.
- Added a robust unit test case verifying that `AudioChunkQueue` survives throws in the `onError` callback and completes queue drainage successfully.
- Verified that all unit tests and logical validation lint checks pass perfectly.

---
I am contributing on behalf of GSSoc'26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in audio chunk queue processing. The queue now continues processing subsequent chunks even when an error handler itself fails, preventing audio processing interruptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->