### PR TITLE
[PERF]: Pre-compile regular expressions for participant label extraction in content script

### DIFF
--- a/src/participantDetection.ts
+++ b/src/participantDetection.ts
@@ -21,6 +21,11 @@ export interface ParticipantNameCandidate {
   text?: string | null;
 }
 
+const EXCLUDED_REGEXES = Array.from(EXCLUDED_PARTICIPANT_LABELS).map((label) => {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`\\b${escaped}\\b`, "gi");
+});
+
 function cleanText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
@@ -29,9 +34,7 @@ function stripExcludedLabels(value: string): string {
   let cleaned = cleanText(value);
   if (!cleaned) return "";
 
-  for (const label of EXCLUDED_PARTICIPANT_LABELS) {
-    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const regex = new RegExp(`\\b${escaped}\\b`, "gi");
+  for (const regex of EXCLUDED_REGEXES) {
     cleaned = cleaned.replace(regex, " ");
   }
 


### PR DESCRIPTION
Fixes #250

### Description
In `src/participantDetection.ts`, the `stripExcludedLabels()` function was compiling a new `RegExp` object dynamically for every label in `EXCLUDED_PARTICIPANT_LABELS` on every single call. Since this function runs in a continuously polling content script on the Google Meet DOM, this introduced significant and unnecessary garbage collection pressure and CPU overhead.

### Proposed Changes
- Added a module-level `EXCLUDED_REGEXES` constant that pre-compiles all label regexes once at startup using `Array.from(EXCLUDED_PARTICIPANT_LABELS).map(...)`.
- Updated `stripExcludedLabels()` to iterate over the pre-compiled `EXCLUDED_REGEXES` array instead.
- All 11 existing unit tests in `src/participantDetection.test.ts` still pass without modification.

---
I am contributing on behalf of GSSoc'26.