### PR TITLE
[BUG]: Rejects invalid meeting ID routes such as landing and calling pages under meet.google.com

### DIFF
--- a/src/meetingTabs.test.ts
+++ b/src/meetingTabs.test.ts
@@ -40,17 +40,30 @@ test("meeting id extraction accepts real Meet rooms and rejects non-room URLs", 
   assert.equal(getMeetingIdFromUrl(undefined), null);
 });
 
+test("meeting id extraction rejects non-meeting paths under meet.google.com", () => {
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/landing"), null);
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/calling"), null);
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/support"), null);
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/about"), null);
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/"), null);
+  // Uppercase IDs are not valid (Meet IDs are always lowercase)
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/ABC-DEFG-HIJ"), null);
+  // Too many / too few segments
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/ab-cdef-ghi"), null);
+  assert.equal(getMeetingIdFromUrl("https://meet.google.com/abcd-defg-hijk"), null);
+});
+
 test("manual Meet tab resolution prefers the active meeting tab", async () => {
   const cleanup = mockChromeTabs([
     {
       id: 1,
-      url: "https://meet.google.com/old-room-aaa",
+      url: "https://meet.google.com/old-rmxx-aaa",
       active: false,
       currentWindow: true,
     },
     {
       id: 2,
-      url: "https://meet.google.com/live-room-bbb",
+      url: "https://meet.google.com/liv-room-bbb",
       active: true,
       currentWindow: true,
     },
@@ -59,7 +72,7 @@ test("manual Meet tab resolution prefers the active meeting tab", async () => {
   try {
     const selected = await resolveManualMeetTab();
     assert.equal(selected.tab.id, 2);
-    assert.equal(selected.meetingId, "live-room-bbb");
+    assert.equal(selected.meetingId, "liv-room-bbb");
   } finally {
     cleanup();
   }
@@ -75,7 +88,7 @@ test("manual Meet tab resolution falls back when exactly one meeting tab is open
     },
     {
       id: 4,
-      url: "https://meet.google.com/only-room-ccc",
+      url: "https://meet.google.com/onl-room-ccc",
       active: false,
       currentWindow: true,
     },
@@ -84,7 +97,7 @@ test("manual Meet tab resolution falls back when exactly one meeting tab is open
   try {
     const selected = await resolveManualMeetTab();
     assert.equal(selected.tab.id, 4);
-    assert.equal(selected.meetingUrl, "https://meet.google.com/only-room-ccc");
+    assert.equal(selected.meetingUrl, "https://meet.google.com/onl-room-ccc");
   } finally {
     cleanup();
   }
@@ -100,13 +113,13 @@ test("manual Meet tab resolution rejects ambiguous background meetings", async (
     },
     {
       id: 6,
-      url: "https://meet.google.com/first-room-ddd",
+      url: "https://meet.google.com/fir-stro-ddd",
       active: false,
       currentWindow: true,
     },
     {
       id: 7,
-      url: "https://meet.google.com/second-room-eee",
+      url: "https://meet.google.com/sec-ondo-eee",
       active: false,
       currentWindow: false,
     },

--- a/src/meetingTabs.ts
+++ b/src/meetingTabs.ts
@@ -6,6 +6,9 @@ export interface MeetTabSelection {
 
 const MEET_TAB_URL = "https://meet.google.com/*";
 
+/** Validates the standard Google Meet room ID format: three letters, four letters, three letters separated by dashes. */
+const MEET_ID_REGEX = /^[a-z]{3}-[a-z]{4}-[a-z]{3}$/;
+
 export function getMeetingIdFromUrl(url: string | undefined): string | null {
   if (!url) return null;
 
@@ -15,6 +18,8 @@ export function getMeetingIdFromUrl(url: string | undefined): string | null {
 
     const meetingId = parsed.pathname.split("/").filter(Boolean)[0];
     if (!meetingId || meetingId === "new") return null;
+
+    if (!MEET_ID_REGEX.test(meetingId)) return null;
 
     return meetingId;
   } catch {


### PR DESCRIPTION
Fixes #251

### Description
`getMeetingIdFromUrl` in `src/meetingTabs.ts` was extracting the first path segment from any URL under `meet.google.com`, but only checking for the special case `"new"`. This caused common non-meeting routing pages like `/landing`, `/calling`, `/support`, and `/about` to be treated as valid meeting IDs.

### Proposed Changes
- Added a module-level `MEET_ID_REGEX` constant (`/^[a-z]{3}-[a-z]{4}-[a-z]{3}$/`) that matches the standard Google Meet room ID format.
- Added a `MEET_ID_REGEX.test(meetingId)` check in `getMeetingIdFromUrl` to filter out non-meeting paths.
- Updated existing test fixture meeting IDs to conform to the strict format.
- Added a new dedicated test verifying that common routing paths and non-standard ID formats are rejected.
- All 5 tests pass with the fix.

---
I am contributing on behalf of GSSoc'26.