### PR TITLE
[BUG]: Case-insensitive participant matching in background service worker join detection

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -792,10 +792,12 @@ function detectNewJoiners(currentList: string[]) {
 
   const normalizedSelf = normalizeParticipantName(selfParticipantName);
   const next = Array.isArray(currentList) ? currentList : [];
+  const normalizedParticipants = state.participants.map(normalizeParticipantName);
+  const normalizedInitial = state.initialParticipants.map(normalizeParticipantName);
   const newJoiners = next.filter(
     (p) =>
-      !state.participants.includes(p) &&
-      !state.initialParticipants.includes(p) &&
+      !normalizedParticipants.includes(normalizeParticipantName(p)) &&
+      !normalizedInitial.includes(normalizeParticipantName(p)) &&
       (!normalizedSelf || normalizeParticipantName(p) !== normalizedSelf),
   );
 


### PR DESCRIPTION
Fixes #252

### Description
In `src/background.ts`, the `detectNewJoiners()` function checks if incoming participant names from the content script are already present in `state.participants` or `state.initialParticipants` using `Array.prototype.includes()`. Since Google Meet or DOM updates might report variations in names or case sensitivity, this strict case-sensitive matching could result in duplicate join entries or missed join notifications.

### Proposed Changes
- Map `state.participants` and `state.initialParticipants` to normalized case-insensitive strings using `normalizeParticipantName` before executing checks.
- Utilize case-insensitive matching when evaluating if a participant has already joined.

---
I am contributing on behalf of GSSoc'26.