### PR TITLE
[BUG]: Prevent partial storage credential saves from silently wiping unspecified keys

### DIFF
--- a/src/utils/credentials.test.ts
+++ b/src/utils/credentials.test.ts
@@ -91,3 +91,19 @@ test("clearing credentials deletes them from both local and session storage", as
   assert.deepEqual(session, {});
   assert.deepEqual(local, {});
 });
+
+test("saving partial credentials does not wipe out omitted keys", async () => {
+  const { session, local } = setupChromeStorage(
+    { openai_api_key: "existing-openai", elevenlabs_api_key: "existing-eleven" },
+    { openai_api_key: "existing-openai", elevenlabs_api_key: "existing-eleven" },
+  );
+
+  // Omit elevenlabs_api_key entirely from the object
+  await saveApiCredentials({ openai_api_key: "new-openai" });
+
+  assert.deepEqual(session, {
+    openai_api_key: "new-openai",
+    elevenlabs_api_key: "existing-eleven",
+  });
+  assert.deepEqual(local, { openai_api_key: "new-openai", elevenlabs_api_key: "existing-eleven" });
+});

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -56,11 +56,14 @@ export async function saveApiCredentials(credentials: ApiCredentials): Promise<v
   const removeKeys: CredentialKey[] = [];
 
   for (const key of CREDENTIAL_KEYS) {
-    const value = normalizedCredential(credentials[key]);
-    if (value) {
-      saveData[key] = value;
-    } else {
-      removeKeys.push(key);
+    // Only process keys that are explicitly present in the input credentials object
+    if (key in credentials) {
+      const value = normalizedCredential(credentials[key]);
+      if (value) {
+        saveData[key] = value;
+      } else {
+        removeKeys.push(key);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #253

### Description
In `src/utils/credentials.ts`, the `saveApiCredentials()` function iterated over all valid credential keys. If a key was missing or empty in the parameter object, it was automatically flagged for deletion (`removeKeys.push(key)`). This design meant that saving a single updated key (such as only `openai_api_key`) would silently wipe out any existing saved key for the other settings (like `elevenlabs_api_key`).

### Proposed Changes
- Modified `saveApiCredentials()` to verify if a key exists in the input object using the `in` operator (`if (key in credentials)`).
- Only delete or clean the key if it was explicitly provided in the input parameter.
- Added a new unit test `saving partial credentials does not wipe out omitted keys` to verify that updates to one credential key preserve existing settings for others.
- All credential tests pass successfully.

---
I am contributing on behalf of GSSoc'26.