### PR TITLE
fix: remove auto-fire startDashboardAudioCapture that always fails without user gesture

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -134,23 +134,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   initWaveformCanvas();
 
-  try {
-    await startDashboardAudioCapture({
-      resolveMeetTab: resolveManualMeetTab,
-      getMediaStreamId: getDashboardMediaStreamId,
-      requestMicrophonePermission: requestDashboardMicrophonePermission,
-      startAudioCapture: (payload) =>
-        chrome.runtime.sendMessage({
-          type: "MANUAL_START_AUDIO",
-          ...payload,
-        }),
-    });
-
-    await loadActionStatuses();
-  } catch (error) {
-    console.error("Failed to initialize dashboard audio capture:", error);
-  }
-
   // ——— Tab Switching ———
   const tabs = document.querySelectorAll(".dash-tabs .dash-tab");
   const panels = document.querySelectorAll(".tab-panel");


### PR DESCRIPTION
## Description

Removes the `startDashboardAudioCapture()` call that fires automatically on `DOMContentLoaded` in `dashboard.ts`. Chrome's `tabCapture` API requires a user gesture to grant capture permission, so this call **always** throws an error on every dashboard open. The `loadActionStatuses()` call placed after it in the same `try` block was unreachable, but it is already called earlier in the function (line 77), so no functionality is lost.

Fixes #273

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [x] TypeScript type checks pass (`npm run type-check`)
- [x] ESLint checks pass (`npm run lint`)
- [x] Prettier formatting verified (`npm run format:check`)
- [x] All 86 existing tests pass (`npm test`)
- [x] Verified no merge conflicts with upstream main

## Checklist

- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Dashboard initialization behavior updated: automatic audio capture startup has been removed. Audio capture now initiates exclusively when users manually trigger the "Start Audio" button. Status loading for action items continues during page load.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->