### PR TITLE
perf: throttle broadcastStateUpdate and send minimal state to content scripts

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -316,22 +316,56 @@ function snapshot() {
   };
 }
 
-async function broadcastStateUpdate() {
+async function broadcastStateUpdate(immediate = false) {
+  if (immediate) {
+    pendingBroadcast = false;
+    await executeBroadcast();
+    return;
+  }
+
+  if (pendingBroadcast) return;
+  pendingBroadcast = true;
+
+  const now = Date.now();
+  const elapsed = now - lastBroadcastTime;
+
+  if (elapsed >= BROADCAST_THROTTLE_MS) {
+    pendingBroadcast = false;
+    await executeBroadcast();
+  } else {
+    setTimeout(async () => {
+      if (!pendingBroadcast) return;
+      pendingBroadcast = false;
+      await executeBroadcast();
+    }, BROADCAST_THROTTLE_MS - elapsed);
+  }
+}
+
+const BROADCAST_THROTTLE_MS = 500;
+let lastBroadcastTime = 0;
+let pendingBroadcast = false;
+
+async function executeBroadcast() {
+  lastBroadcastTime = Date.now();
   const snapshotData = snapshot();
   try {
-    // To popup/dashboard
+    // To popup/dashboard — full state
     await chrome.runtime.sendMessage({ type: "STATE_UPDATE", state: snapshotData });
   } catch {
     /* ignore */
   }
 
   try {
-    // To content scripts (floating button)
+    // To content scripts — minimal state (they only need isActive/audioActive for the floating button)
+    const contentState = {
+      isActive: snapshotData.isActive,
+      audioActive: snapshotData.audioActive,
+    };
     const tabs = await chrome.tabs.query({ url: "https://meet.google.com/*" });
     for (const tab of tabs) {
       if (tab.id !== undefined) {
         chrome.tabs
-          .sendMessage(tab.id, { type: "STATE_UPDATE", state: snapshotData })
+          .sendMessage(tab.id, { type: "STATE_UPDATE", state: contentState })
           .catch(() => {});
       }
     }
@@ -1074,12 +1108,12 @@ async function startAudioCapture(
     if (response.microphoneActive === false) {
       addTimeline("Microphone capture unavailable; recording tab audio only");
     }
-    await broadcastStateUpdate();
+    await broadcastStateUpdate(true);
   } catch (err) {
     state.audioActive = false;
     if (createdSession) {
       resetState();
-      await broadcastStateUpdate();
+      await broadcastStateUpdate(true);
     }
     throw err;
   } finally {
@@ -1104,7 +1138,7 @@ async function scanForMeetTabs() {
             state.startTime = Date.now();
             state.participants = ["You"];
             console.log("[LateMeet] Proactively detected meeting:", meetingId);
-            await broadcastStateUpdate();
+            await broadcastStateUpdate(true);
           }
           return;
         }
@@ -1138,7 +1172,7 @@ async function stopAudioCapture(reason = "Stopped") {
     state.audioActive = false;
     state.isActive = false;
 
-    await broadcastStateUpdate();
+    await broadcastStateUpdate(true);
 
     try {
       await chrome.runtime.sendMessage({ type: "SESSION_ENDED" });
@@ -1170,7 +1204,7 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
         state.targetTabId = tabId || null;
         state.startTime = Date.now();
         state.participants = ["You"];
-        await broadcastStateUpdate();
+        await broadcastStateUpdate(true);
       }
     }
   } catch {
@@ -1205,7 +1239,7 @@ chrome.tabs.onRemoved.addListener(async (tabId) => {
     } else {
       state.meetingId = null;
       state.targetTabId = null;
-      await broadcastStateUpdate();
+      await broadcastStateUpdate(true);
     }
   }
 });
@@ -1274,7 +1308,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       case "OFFSCREEN_CAPTURE_STOPPED": {
         state.audioActive = false;
-        await broadcastStateUpdate();
+        await broadcastStateUpdate(true);
         sendResponse({ success: true });
         return;
       }
@@ -1358,14 +1392,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       case "SAVE_SESSION": {
         await persistSession();
-        await broadcastStateUpdate();
+        await broadcastStateUpdate(true);
         sendResponse({ success: true });
         return;
       }
 
       case "DISCARD_SESSION": {
         await discardPendingSession();
-        await broadcastStateUpdate();
+        await broadcastStateUpdate(true);
         sendResponse({ success: true });
         return;
       }

--- a/src/background.ts
+++ b/src/background.ts
@@ -316,8 +316,21 @@ function snapshot() {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Throttled State Broadcast
+// ---------------------------------------------------------------------------
+
+const BROADCAST_THROTTLE_MS = 500;
+let lastBroadcastTime = 0;
+let pendingBroadcast = false;
+let broadcastTimerHandle: ReturnType<typeof setTimeout> | null = null;
+
 async function broadcastStateUpdate(immediate = false) {
   if (immediate) {
+    if (broadcastTimerHandle !== null) {
+      clearTimeout(broadcastTimerHandle);
+      broadcastTimerHandle = null;
+    }
     pendingBroadcast = false;
     await executeBroadcast();
     return;
@@ -333,7 +346,8 @@ async function broadcastStateUpdate(immediate = false) {
     pendingBroadcast = false;
     await executeBroadcast();
   } else {
-    setTimeout(async () => {
+    broadcastTimerHandle = setTimeout(async () => {
+      broadcastTimerHandle = null;
       if (!pendingBroadcast) return;
       pendingBroadcast = false;
       await executeBroadcast();
@@ -341,12 +355,7 @@ async function broadcastStateUpdate(immediate = false) {
   }
 }
 
-const BROADCAST_THROTTLE_MS = 500;
-let lastBroadcastTime = 0;
-let pendingBroadcast = false;
-
 async function executeBroadcast() {
-  lastBroadcastTime = Date.now();
   const snapshotData = snapshot();
   try {
     // To popup/dashboard — full state
@@ -372,6 +381,8 @@ async function executeBroadcast() {
   } catch {
     /* ignore */
   }
+
+  lastBroadcastTime = Date.now();
 }
 
 async function getApiKey() {


### PR DESCRIPTION
## Description

Implements a 500ms throttle on `broadcastStateUpdate()` and reduces the payload sent to content scripts. Previously, every state mutation (speaker change, participant poll, audio chunk processed) triggered a full serialization and broadcast of the entire state object — including the full transcript array — to all listeners. For long meetings this created significant IPC overhead.

**Changes:**
1. **Throttled broadcasts** — Non-critical updates are coalesced within a 500ms window. Rapid-fire events (speaker changes every 250ms, participant polls every 5s) no longer each trigger a full broadcast.
2. **Immediate mode for lifecycle events** — Critical events (audio start/stop, meeting detection, session save/discard) bypass the throttle with `immediate=true` for instant UI feedback.
3. **Minimal content script payload** — Content scripts only use `state.isActive` for the floating button, so they now receive `{ isActive, audioActive }` instead of the full state object with transcript, timeline, topics, etc.

Fixes #275

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [x] TypeScript type checks pass (`npm run type-check`)
- [x] ESLint checks pass (`npm run lint`)
- [x] Prettier formatting verified (`npm run format:check`)
- [x] All 86 existing tests pass (`npm test`)
- [x] Verified no merge conflicts with upstream main
- [x] Verified content script only uses `state.isActive` from STATE_UPDATE messages

## Checklist

- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed