### PR TITLE
fix(a11y): add focus trap, ARIA roles, and keyboard dismiss to session modal

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -241,11 +241,18 @@
     </div>
 
     <!-- SESSION MODAL (Save/Discard) -->
-    <div id="session-modal" class="session-modal" style="display: none">
+    <div
+      id="session-modal"
+      class="session-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="session-modal-title"
+      style="display: none"
+    >
       <div class="session-modal-backdrop"></div>
       <div class="session-modal-content">
         <div class="session-modal-icon">💾</div>
-        <h2 class="session-modal-title">Meeting Ended</h2>
+        <h2 id="session-modal-title" class="session-modal-title">Meeting Ended</h2>
         <p class="session-modal-text">
           Would you like to save the intelligence and transcript for this session?
         </p>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -331,6 +331,37 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   // ——— Session Save/Discard Modal ———
+  let previouslyFocusedElement: HTMLElement | null = null;
+
+  function trapFocus(e: KeyboardEvent) {
+    if (e.key !== "Tab") return;
+    const focusableEls = sessionModal.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    if (focusableEls.length === 0) return;
+    const firstEl = focusableEls[0];
+    const lastEl = focusableEls[focusableEls.length - 1];
+    if (e.shiftKey) {
+      if (document.activeElement === firstEl) {
+        e.preventDefault();
+        lastEl.focus();
+      }
+    } else {
+      if (document.activeElement === lastEl) {
+        e.preventDefault();
+        firstEl.focus();
+      }
+    }
+  }
+
+  function handleModalKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      hideSessionModal();
+    }
+    trapFocus(e);
+  }
+
   function showSessionModal() {
     const saveBtn = document.getElementById("save-session-btn") as HTMLButtonElement | null;
     const discardBtn = document.getElementById("discard-session-btn") as HTMLButtonElement | null;
@@ -348,16 +379,31 @@ document.addEventListener("DOMContentLoaded", async () => {
       discardBtn.textContent = "Discard";
       discardBtn.classList.remove("loading");
     }
+    previouslyFocusedElement = document.activeElement as HTMLElement | null;
     sessionModal.style.display = "flex";
-    requestAnimationFrame(() => sessionModal.classList.add("visible"));
+    requestAnimationFrame(() => {
+      sessionModal.classList.add("visible");
+      // Move focus into the modal
+      (saveBtn || discardBtn)?.focus();
+    });
+    sessionModal.addEventListener("keydown", handleModalKeydown);
   }
 
   function hideSessionModal() {
     sessionModal.classList.remove("visible");
+    sessionModal.removeEventListener("keydown", handleModalKeydown);
     setTimeout(() => {
       sessionModal.style.display = "none";
+      // Return focus to the previously focused element
+      previouslyFocusedElement?.focus();
+      previouslyFocusedElement = null;
     }, 300);
   }
+
+  // Backdrop click to dismiss
+  sessionModal.querySelector(".session-modal-backdrop")?.addEventListener("click", () => {
+    hideSessionModal();
+  });
 
   document.getElementById("save-session-btn")?.addEventListener("click", async (e) => {
     const btn = e.currentTarget as HTMLButtonElement;


### PR DESCRIPTION
## Description

Adds proper accessibility support to the session save/discard modal in the popup. The modal previously lacked ARIA semantics, focus management, and keyboard interaction — making it unusable for screen reader and keyboard-only users.

**Changes:**

**HTML (`popup.html`):**
- Added `role="dialog"` and `aria-modal="true"` to the modal container
- Added `aria-labelledby="session-modal-title"` linking to the heading
- Added `id="session-modal-title"` to the `<h2>` element

**JavaScript (`popup.ts`):**
- Focus trap: Tab/Shift+Tab cycles between focusable elements within the modal
- Escape key dismisses the modal
- Backdrop click dismisses the modal
- Focus moves to the Save button when the modal opens
- Focus returns to the previously focused element when the modal closes

Fixes #276

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [x] TypeScript type checks pass (`npm run type-check`)
- [x] ESLint checks pass (`npm run lint`)
- [x] Prettier formatting verified on changed files
- [x] All 86 existing tests pass (`npm test`)
- [x] Verified no merge conflicts with upstream main

## Checklist

- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed