### PR TITLE
fix: remove duplicate content.css import in src/content.ts

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -6,7 +6,7 @@ import {
 } from "./participantDetection.ts";
 
 import { initTheme } from "./theme.js";
-import "./content.css";
+
 
 initTheme();
 


### PR DESCRIPTION
Problem
src/content.ts imports ./content.css twice — once at line 1 and again at line 9 — resulting in a redundant stylesheet import.

ts
import "./content.css"; // ✅ line 1 — correct
import { initTheme } from "./theme.js";
import "./content.css"; // ❌ line 9 — duplicate, removed
Why This Matters
Adds unnecessary duplication during module evaluation
Can slightly affect extension startup/loading performance
Makes stylesheet dependencies harder to maintain
May create confusion during future refactors
Changes Made
Removed the duplicate import "./content.css"; from line 9 in src/content.ts
Kept the single correct import at the top of the file (line 1)
How to Verify
Run npm run dev or npm run build
Load the extension in Chrome → open a Google Meet tab
Open DevTools → Network → confirm content.css appears only once
Confirm UI appearance and content script behavior remain unchanged
Related
Closes https://github.com/shouri123/Late-Meet/issues/278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting adjustment to import block spacing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->