### PR TITLE
feat: add opt-in transcript refinement toggle to reduce API costs

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -57,7 +57,8 @@
     "Chakraborty",
     "gantt",
     "glassmorphism",
-    "Supabase"
+    "Supabase",
+    "creds"
   ],
   "ignorePaths": [
     "node_modules",

--- a/src/background.ts
+++ b/src/background.ts
@@ -951,7 +951,8 @@ async function processQueuedAudioChunk({ id, item }: AudioChunkQueueItem<QueuedA
 
   console.log(`[LateMeet] transcript received for chunk ${id} — ${rawText.length} chars`);
   const settings = await getSettings();
-  const refinedText = settings.transcriptRefinement ? await refineTranscription(rawText) : rawText;
+  const refinedText =
+    settings.transcriptRefinement === true ? await refineTranscription(rawText) : rawText;
   if (settings.transcriptRefinement) {
     console.log(`[LateMeet] transcript refined for chunk ${id} — ${refinedText.length} chars`);
   }

--- a/src/background.ts
+++ b/src/background.ts
@@ -479,6 +479,7 @@ interface Settings {
   decisionDetection?: boolean;
   actionExtraction?: boolean;
   sentimentAnalysis?: boolean;
+  transcriptRefinement?: boolean;
 }
 
 async function getSettings(): Promise<Settings> {
@@ -949,8 +950,11 @@ async function processQueuedAudioChunk({ id, item }: AudioChunkQueueItem<QueuedA
   }
 
   console.log(`[LateMeet] transcript received for chunk ${id} — ${rawText.length} chars`);
-  const refinedText = await refineTranscription(rawText);
-  console.log(`[LateMeet] transcript refined for chunk ${id} — ${refinedText.length} chars`);
+  const settings = await getSettings();
+  const refinedText = settings.transcriptRefinement ? await refineTranscription(rawText) : rawText;
+  if (settings.transcriptRefinement) {
+    console.log(`[LateMeet] transcript refined for chunk ${id} — ${refinedText.length} chars`);
+  }
 
   state.transcript.push({
     speaker: resolveTranscriptSpeaker(item.speaker || state.currentSpeaker),

--- a/src/options.html
+++ b/src/options.html
@@ -424,6 +424,20 @@
               <span class="toggle-slider"></span>
             </label>
           </div>
+
+          <div class="toggle-item">
+            <div>
+              <div class="toggle-label">Transcript Refinement</div>
+              <div class="toggle-hint">
+                Use AI to clean up filler words and correct transcription errors (uses an additional
+                API call per audio chunk)
+              </div>
+            </div>
+            <label class="toggle-switch">
+              <input type="checkbox" id="refinement-toggle" />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
         </div>
       </section>
       <!-- Storage Section -->

--- a/src/options.html
+++ b/src/options.html
@@ -434,7 +434,7 @@
               </div>
             </div>
             <label class="toggle-switch">
-              <input type="checkbox" id="refinement-toggle" />
+              <input type="checkbox" id="refinement-toggle" aria-label="Transcript Refinement" />
               <span class="toggle-slider"></span>
             </label>
           </div>

--- a/src/options.ts
+++ b/src/options.ts
@@ -16,6 +16,7 @@ interface Settings {
   decisionDetection?: boolean;
   actionExtraction?: boolean;
   sentimentAnalysis?: boolean;
+  transcriptRefinement?: boolean;
   theme?: "system" | "light" | "dark";
   accent?: string;
   [key: string]: any;
@@ -94,12 +95,16 @@ document.addEventListener("DOMContentLoaded", async () => {
     { id: "decision-toggle", key: "decisionDetection" },
     { id: "action-toggle", key: "actionExtraction" },
     { id: "sentiment-toggle", key: "sentimentAnalysis" },
+    { id: "refinement-toggle", key: "transcriptRefinement" },
   ];
+
+  // Keys that default to off (opt-in features)
+  const defaultOffKeys = new Set(["transcriptRefinement"]);
 
   toggles.forEach((t) => {
     const el = document.getElementById(t.id) as HTMLInputElement | null;
     if (el) {
-      el.checked = settings[t.key] !== false;
+      el.checked = defaultOffKeys.has(t.key) ? settings[t.key] === true : settings[t.key] !== false;
     }
   });
 
@@ -284,6 +289,8 @@ document.addEventListener("DOMContentLoaded", async () => {
           ?.checked,
         actionExtraction: (document.getElementById("action-toggle") as HTMLInputElement)?.checked,
         sentimentAnalysis: (document.getElementById("sentiment-toggle") as HTMLInputElement)
+          ?.checked,
+        transcriptRefinement: (document.getElementById("refinement-toggle") as HTMLInputElement)
           ?.checked,
 
         // Save theme selections into the global config tree bundle block


### PR DESCRIPTION
## Description

Makes the AI transcript refinement step (GPT-4o-mini cleanup of transcribed text) an opt-in feature controlled by a new "Transcript Refinement" toggle in Settings. Previously, every audio chunk triggered a second API call for refinement with no way to disable it, effectively doubling API costs for BYOK users.

The toggle defaults to **off** since modern STT models (Whisper-1, ElevenLabs Scribe v2) already produce clean transcriptions and the summarization step handles noisy input gracefully.

Fixes #305

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [x] Verified no console errors
- [x] ESLint passes (`npm run lint`)
- [x] TypeScript type-check passes (`npm run type-check`)
- [x] Prettier formatting passes (`npm run format:check`)
- [x] All 86 existing tests pass (`npm test`)

## Changes Made

**`src/background.ts`:**
- Added `transcriptRefinement?: boolean` to the `Settings` interface
- Made `refineTranscription()` call conditional on the setting being `true`

**`src/options.ts`:**
- Added `transcriptRefinement` to the Settings interface
- Added `refinement-toggle` to the toggles array
- Added `defaultOffKeys` set to handle opt-in toggles that default to off
- Included the toggle value in the save logic

**`src/options.html`:**
- Added a new toggle UI element for "Transcript Refinement" with a hint explaining the API cost implication

## Checklist

- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional "Transcript Refinement" feature toggle to settings. When enabled, transcripts are refined using an additional API call per audio chunk, providing enhanced quality. The feature is disabled by default for users to opt-in as desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->