### PR TITLE
fix: clear participant polling and speaker detection on meeting end

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -339,6 +339,13 @@ initTheme();
     }, 5000);
   }
 
+  function stopParticipantPolling() {
+    if (participantPollTimer) {
+      clearInterval(participantPollTimer);
+      participantPollTimer = null;
+    }
+  }
+
   function scheduleActiveSpeakerCheck() {
     if (activeSpeakerCheckTimer) return;
 
@@ -437,6 +444,18 @@ initTheme();
     detectActiveSpeaker();
   }
 
+  function stopActiveSpeakerDetection() {
+    if (activeSpeakerObserver) {
+      activeSpeakerObserver.disconnect();
+      activeSpeakerObserver = null;
+    }
+    if (activeSpeakerCheckTimer) {
+      clearTimeout(activeSpeakerCheckTimer);
+      activeSpeakerCheckTimer = null;
+    }
+    lastActiveSpeakerName = null;
+  }
+
   function injectFloatingButton() {
     const existing = document.getElementById("mc-float-btn");
     if (existing) return;
@@ -516,6 +535,17 @@ initTheme();
         const label = btn.querySelector(".mc-float-label");
         if (label) label.textContent = "Start Copilot";
       }
+
+      // Clean up polling and observers when the meeting session ends
+      if (!isActive) {
+        stopParticipantPolling();
+        stopActiveSpeakerDetection();
+      } else {
+        // Restart polling/detection if a new session begins
+        startParticipantPolling();
+        startActiveSpeakerDetection();
+      }
+
       sendResponse({ success: true });
       return false;
     }


### PR DESCRIPTION
## Description

Adds cleanup functions for the participant polling `setInterval` and active speaker `MutationObserver` in `content.ts`. These resources are now properly released when the meeting session ends (via `STATE_UPDATE` with `isActive === false`), and restarted if a new session begins on the same page.

Previously, the 5-second polling interval and MutationObserver ran indefinitely for the lifetime of the page — even after the user left the meeting — causing unnecessary DOM queries and `chrome.runtime.sendMessage` calls that silently failed.

Fixes #306

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] 🧪 Tests

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [x] Verified no console errors
- [x] ESLint passes (`npm run lint`)
- [x] TypeScript type-check passes (`npm run type-check`)
- [x] Prettier formatting passes (`npm run format:check`)
- [x] All 86 existing tests pass (`npm test`)

## Changes Made

**`src/content.ts`:**
- Added `stopParticipantPolling()` — clears the `setInterval` timer
- Added `stopActiveSpeakerDetection()` — disconnects the `MutationObserver`, clears the debounce timer, and resets the last speaker name
- Updated the `STATE_UPDATE` message handler to call cleanup when `isActive === false` and restart polling/detection when a new session begins

## Note on CI Failures

The Manifest Validation, Bundle Size, and Test Coverage comment failures are pre-existing issues unrelated to this PR:
- Manifest validation fails due to missing fields in `src/manifest.json` (addressed by PR #315)
- The sticky-comment action fails because fork PRs lack write permissions to the upstream repo

## Checklist

- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] I have updated the documentation if needed