### PR TITLE
fix: add missing viewport meta tags to dashboard and options pages

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Meeting Dashboard — AI Copilot</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap"

--- a/src/options.html
+++ b/src/options.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Settings — AI Meeting Copilot</title>
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"


### PR DESCRIPTION
Fixes #309

## Description
The dashboard.html and options.html pages are missing the viewport meta tag. This causes:
- Dashboard rendered in the side panel does not scale properly on narrow viewports
- Options page does not respect device width on smaller screens
- Poor mobile and side-panel rendering experience

## Changes
- Added viewport meta tag to dashboard.html
- Added viewport meta tag to options.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile responsiveness for the dashboard and options pages by enabling proper viewport scaling on mobile devices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shouri123/Late-Meet/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->