### PR TITLE
fix: reject 401 responses in validateElevenLabsKey() instead of accepting missing_permissions

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -254,10 +254,8 @@ export async function validateElevenLabsKey(apiKey: string): Promise<boolean> {
     if (response.ok) {
       return true;
     }
-    if (response.status === 401) {
-      const data = await response.json();
-      return data?.detail?.status === "missing_permissions";
-    }
+    // Any non-OK response (including 401 Unauthorized) means the key is not usable
+    // for this extension's STT functionality — reject it during validation.
     return false;
   } catch (error: any) {
     if (error.name === "AbortError") {


### PR DESCRIPTION
## Description

Fixes a logic error in `validateElevenLabsKey()` that incorrectly returned `true` when ElevenLabs responded with a 401 Unauthorized status containing `missing_permissions` detail. A 401 response means the key cannot authenticate or lacks required permissions for STT operations — it should never be treated as valid.

**Before:** Users could save an API key that passes validation but fails silently during live meetings when actual transcription is attempted.

**After:** Any non-200 response (including 401) correctly returns `false`, giving users immediate feedback that their key is not usable.

Fixes #338

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes Made

- `src/utils/api.ts`: Removed the `if (response.status === 401)` block that incorrectly returned `true` for keys with `missing_permissions` status
- Simplified the logic: any non-OK response now correctly returns `false`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

- `npm run type-check` — passes
- `npm run lint` — passes
- `npm run build` — passes
- `npm test` — all 88 tests pass