### PR TITLE
fix: remove misleading Zoom and Teams platform tags from popup UI

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -208,8 +208,6 @@
           </p>
           <div class="supported-platforms">
             <span class="platform-tag active">Google Meet</span>
-            <span class="platform-tag">Zoom (Web)</span>
-            <span class="platform-tag">Teams (Web)</span>
           </div>
           <button id="start-copilot-btn" class="copilot-btn">
             <span class="copilot-btn-icon">


### PR DESCRIPTION
## Description

Removes the "Zoom (Web)" and "Teams (Web)" platform tags from the popup's empty state that falsely imply multi-platform support. Only Google Meet is actually supported — the manifest exclusively targets `https://meet.google.com/*` and there is zero code for Zoom or Teams detection, DOM interaction, or audio capture.

Fixes #340

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes Made

- `src/popup.html`: Removed the two `<span class="platform-tag">` elements for "Zoom (Web)" and "Teams (Web)"
- Kept the "Google Meet" tag with its `active` class (the only actually supported platform)
- No CSS changes needed — existing `.platform-tag` styles still apply to the remaining tag

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

- `npm run type-check` — passes
- `npm run lint` — passes
- `npm run build` — passes
- Visual verification: popup empty state now only shows "Google Meet" as the supported platform