### PR TITLE
fix: isolate content events to the active Meet tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/background.urlParsing.test.ts",
+    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/background.urlParsing.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/activeMeetingMessages.test.ts
+++ b/src/activeMeetingMessages.test.ts
@@ -5,7 +5,7 @@ import { isMessageFromActiveMeeting } from "./activeMeetingMessages.ts";
 
 const ACTIVE_MEETING = {
   targetTabId: 42,
-  meetingId: "abc-defg-hij",
+  meetingId: "cat-room-dog",
 };
 
 test("accepts content-script messages from the active Meet tab", () => {
@@ -13,7 +13,7 @@ test("accepts content-script messages from the active Meet tab", () => {
     isMessageFromActiveMeeting({
       ...ACTIVE_MEETING,
       senderTabId: 42,
-      senderUrl: "https://meet.google.com/abc-defg-hij",
+      senderUrl: "https://meet.google.com/cat-room-dog",
     }),
     true,
   );
@@ -24,7 +24,7 @@ test("rejects messages from another Meet tab", () => {
     isMessageFromActiveMeeting({
       ...ACTIVE_MEETING,
       senderTabId: 99,
-      senderUrl: "https://meet.google.com/other-room",
+      senderUrl: "https://meet.google.com/owl-room-fox",
     }),
     false,
   );
@@ -35,7 +35,7 @@ test("rejects messages when the tab id matches but the Meet room does not", () =
     isMessageFromActiveMeeting({
       ...ACTIVE_MEETING,
       senderTabId: 42,
-      senderUrl: "https://meet.google.com/other-room",
+      senderUrl: "https://meet.google.com/owl-room-fox",
     }),
     false,
   );
@@ -45,9 +45,9 @@ test("rejects messages without an owned target tab or valid Meet URL", () => {
   assert.equal(
     isMessageFromActiveMeeting({
       senderTabId: 42,
-      senderUrl: "https://meet.google.com/abc-defg-hij",
+      senderUrl: "https://meet.google.com/cat-room-dog",
       targetTabId: null,
-      meetingId: "abc-defg-hij",
+      meetingId: "cat-room-dog",
     }),
     false,
   );
@@ -55,7 +55,7 @@ test("rejects messages without an owned target tab or valid Meet URL", () => {
     isMessageFromActiveMeeting({
       ...ACTIVE_MEETING,
       senderTabId: 42,
-      senderUrl: "https://example.com/abc-defg-hij",
+      senderUrl: "https://example.com/cat-room-dog",
     }),
     false,
   );
@@ -65,7 +65,7 @@ test("allows a valid sender URL while the active meeting id is unknown", () => {
   assert.equal(
     isMessageFromActiveMeeting({
       senderTabId: 42,
-      senderUrl: "https://meet.google.com/abc-defg-hij",
+      senderUrl: "https://meet.google.com/cat-room-dog",
       targetTabId: 42,
       meetingId: "unknown",
     }),

--- a/src/activeMeetingMessages.test.ts
+++ b/src/activeMeetingMessages.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { isMessageFromActiveMeeting } from "./activeMeetingMessages.ts";
+
+const ACTIVE_MEETING = {
+  targetTabId: 42,
+  meetingId: "abc-defg-hij",
+};
+
+test("accepts content-script messages from the active Meet tab", () => {
+  assert.equal(
+    isMessageFromActiveMeeting({
+      ...ACTIVE_MEETING,
+      senderTabId: 42,
+      senderUrl: "https://meet.google.com/abc-defg-hij",
+    }),
+    true,
+  );
+});
+
+test("rejects messages from another Meet tab", () => {
+  assert.equal(
+    isMessageFromActiveMeeting({
+      ...ACTIVE_MEETING,
+      senderTabId: 99,
+      senderUrl: "https://meet.google.com/other-room",
+    }),
+    false,
+  );
+});
+
+test("rejects messages when the tab id matches but the Meet room does not", () => {
+  assert.equal(
+    isMessageFromActiveMeeting({
+      ...ACTIVE_MEETING,
+      senderTabId: 42,
+      senderUrl: "https://meet.google.com/other-room",
+    }),
+    false,
+  );
+});
+
+test("rejects messages without an owned target tab or valid Meet URL", () => {
+  assert.equal(
+    isMessageFromActiveMeeting({
+      senderTabId: 42,
+      senderUrl: "https://meet.google.com/abc-defg-hij",
+      targetTabId: null,
+      meetingId: "abc-defg-hij",
+    }),
+    false,
+  );
+  assert.equal(
+    isMessageFromActiveMeeting({
+      ...ACTIVE_MEETING,
+      senderTabId: 42,
+      senderUrl: "https://example.com/abc-defg-hij",
+    }),
+    false,
+  );
+});
+
+test("allows a valid sender URL while the active meeting id is unknown", () => {
+  assert.equal(
+    isMessageFromActiveMeeting({
+      senderTabId: 42,
+      senderUrl: "https://meet.google.com/abc-defg-hij",
+      targetTabId: 42,
+      meetingId: "unknown",
+    }),
+    true,
+  );
+});

--- a/src/activeMeetingMessages.ts
+++ b/src/activeMeetingMessages.ts
@@ -1,0 +1,24 @@
+import { getMeetingIdFromUrl } from "./meetingTabs";
+
+interface ActiveMeetingMessageSource {
+  senderTabId?: number;
+  senderUrl?: string;
+  targetTabId?: number | null;
+  meetingId?: string | null;
+}
+
+export function isMessageFromActiveMeeting({
+  senderTabId,
+  senderUrl,
+  targetTabId,
+  meetingId,
+}: ActiveMeetingMessageSource): boolean {
+  if (senderTabId === undefined || targetTabId == null || senderTabId !== targetTabId) {
+    return false;
+  }
+
+  const senderMeetingId = getMeetingIdFromUrl(senderUrl);
+  if (!senderMeetingId) return false;
+
+  return !meetingId || meetingId === "unknown" || senderMeetingId === meetingId;
+}

--- a/src/background.ts
+++ b/src/background.ts
@@ -18,6 +18,7 @@ import { createAudioCaptureStopPlan } from "./audioCaptureLifecycle";
 import { normalizeActiveSpeakerName, resolveTranscriptSpeaker } from "./speakerAttribution";
 import { getMeetingIdFromUrl } from "./meetingTabs";
 import { getOpenAiApiKey, getElevenLabsApiKey } from "./utils/credentials";
+import { isMessageFromActiveMeeting } from "./activeMeetingMessages";
 
 const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
@@ -1572,6 +1573,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
 
       case "PARTICIPANTS_UPDATED": {
+        if (
+          !isMessageFromActiveMeeting({
+            senderTabId: sender?.tab?.id,
+            senderUrl: sender?.tab?.url || sender?.url,
+            targetTabId: state.targetTabId,
+            meetingId: state.meetingId,
+          })
+        ) {
+          console.warn("[LateMeet] Ignoring participant update from non-active Meet tab");
+          sendResponse({ success: true, ignored: true });
+          return;
+        }
+
         if (!Array.isArray(message.participants)) {
           sendResponse({ success: false, error: "participants must be an array" });
           return;
@@ -1582,13 +1596,26 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         if (incomingSelfName) selfParticipantName = incomingSelfName;
 
         const joiners = detectNewJoiners(message.participants);
-        await maybeWelcomeJoiners(sender?.tab?.id || state.targetTabId || undefined, joiners);
+        await maybeWelcomeJoiners(state.targetTabId || undefined, joiners);
         await broadcastStateUpdate();
         sendResponse({ success: true, joiners });
         return;
       }
 
       case "ACTIVE_SPEAKER_CHANGED": {
+        if (
+          !isMessageFromActiveMeeting({
+            senderTabId: sender?.tab?.id,
+            senderUrl: sender?.tab?.url || sender?.url,
+            targetTabId: state.targetTabId,
+            meetingId: state.meetingId,
+          })
+        ) {
+          console.warn("[LateMeet] Ignoring speaker update from non-active Meet tab");
+          sendResponse({ success: true, ignored: true });
+          return;
+        }
+
         const speaker = normalizeActiveSpeakerName(message.name);
 
         if (!speaker) {


### PR DESCRIPTION
## Description

Fix cross-tab meeting isolation when more than one Google Meet tab is open. Participant and active-speaker events are now accepted only when the sender belongs to the selected active meeting tab and room. Late-joiner chat messages are routed through the owned `state.targetTabId` instead of an arbitrary event sender.

The patch also wires scoped active-speaker updates into transcript attribution and adds focused unit coverage for active-tab acceptance, wrong-tab rejection, wrong-room rejection, invalid sender URLs, and unknown meeting IDs.

Fixes #346

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [x] 🧪 Tests

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [x] Ran `npm test` (`36/36` tests passed)
- [x] Ran `npm run lint`
- [x] Ran `npm run type-check`
- [x] Ran `npm run format:check`
- [x] Ran `git diff --check`
- [ ] Loaded the extension in Chrome and tested manually
- [ ] Tested on a live Google Meet call
- [ ] Verified no console errors
- [ ] Tested with ElevenLabs API key
- [ ] Tested with OpenAI API key

## Screenshots (if applicable)

Not applicable.

## Checklist

- [ ] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] Documentation updates are not required for this internal behavior fix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Participant and active-speaker updates are now validated against the active meeting/tab, preventing stale or cross-tab updates; non-active messages are ignored.
  * Late-join welcome dispatch now targets the stored active meeting tab so welcomes reach the correct session.
* **Tests**
  * Added unit tests covering active-meeting message validation and related edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->