### PR TITLE
fix: preserve session persistence during audio stop

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/background.urlParsing.test.ts",
+    "test": "tsx --test src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/background.urlParsing.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/audioCaptureLifecycle.test.ts
+++ b/src/audioCaptureLifecycle.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createAudioCaptureStopPlan } from "./audioCaptureLifecycle.ts";
+
+test("stop plan preserves finalization after an offscreen acknowledgement clears live state", () => {
+  const state = { audioActive: true };
+  const plan = createAudioCaptureStopPlan(state.audioActive);
+
+  state.audioActive = false;
+
+  assert.equal(plan.shouldSavePendingSession, true);
+  assert.equal(plan.shouldNotifySessionEnded, true);
+});
+
+test("stop plan does not create a pending session when capture was already inactive", () => {
+  const plan = createAudioCaptureStopPlan(false);
+
+  assert.equal(plan.shouldSavePendingSession, false);
+  assert.equal(plan.shouldNotifySessionEnded, false);
+});

--- a/src/audioCaptureLifecycle.ts
+++ b/src/audioCaptureLifecycle.ts
@@ -1,0 +1,11 @@
+export interface AudioCaptureStopPlan {
+  shouldSavePendingSession: boolean;
+  shouldNotifySessionEnded: boolean;
+}
+
+export function createAudioCaptureStopPlan(audioActive: boolean): AudioCaptureStopPlan {
+  return {
+    shouldSavePendingSession: audioActive,
+    shouldNotifySessionEnded: audioActive,
+  };
+}

--- a/src/background.ts
+++ b/src/background.ts
@@ -13,6 +13,7 @@ import {
   StoredSession,
 } from "./sessionStorage";
 import { AudioChunkQueue, AudioChunkQueueItem } from "./audioChunkQueue";
+import { createAudioCaptureStopPlan } from "./audioCaptureLifecycle";
 import { normalizeActiveSpeakerName, resolveTranscriptSpeaker } from "./speakerAttribution";
 import { getMeetingIdFromUrl } from "./meetingTabs";
 import { getOpenAiApiKey, getElevenLabsApiKey } from "./utils/credentials";
@@ -1318,6 +1319,7 @@ async function stopAudioCapture(reason = "Stopped") {
     return;
   }
   isStoppingAudio = true;
+  const stopPlan = createAudioCaptureStopPlan(state.audioActive);
   try {
     try {
       await chrome.runtime.sendMessage({ type: "OFFSCREEN_STOP_CAPTURE" });
@@ -1325,7 +1327,7 @@ async function stopAudioCapture(reason = "Stopped") {
       // Ignore if offscreen not running
     }
 
-    if (state.audioActive) {
+    if (stopPlan.shouldSavePendingSession) {
       addTimeline(`Meeting ended (${reason})`);
       await savePendingSession();
     }
@@ -1336,10 +1338,12 @@ async function stopAudioCapture(reason = "Stopped") {
     await chrome.storage.local.remove("activeMeetingState");
     await broadcastStateUpdate(true);
 
-    try {
-      await chrome.runtime.sendMessage({ type: "SESSION_ENDED" });
-    } catch {
-      // no listeners
+    if (stopPlan.shouldNotifySessionEnded) {
+      try {
+        await chrome.runtime.sendMessage({ type: "SESSION_ENDED" });
+      } catch {
+        // no listeners
+      }
     }
 
     await closeOffscreenDocumentIfPresent();


### PR DESCRIPTION
## Description

Fix the stop-lifecycle race where the offscreen `OFFSCREEN_CAPTURE_STOPPED` acknowledgement cleared `state.audioActive` before `stopAudioCapture()` reached its pending-session persistence guard.

The coordinator now captures a frozen stop-finalization plan before awaiting offscreen shutdown. Completed recordings still write `pendingSession` even when nested acknowledgement messages update live state during recorder cleanup. `SESSION_ENDED` is emitted only for finalized recordings, avoiding misleading Save dialogs for already-inactive sessions.

Fixes #348

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Code refactoring (no functional changes)
- [x] 🧪 Tests

## How Has This Been Tested?

- [x] Built the extension with `npm run build`
- [x] Ran `npm test` (`90/90` tests passed)
- [x] Ran `npm run lint`
- [x] Ran `npm run type-check`
- [x] Ran `npm run format:check`
- [x] Ran `git diff --check`
- [ ] Loaded the extension in Chrome and tested manually
- [ ] Tested on a live Google Meet call
- [ ] Verified no console errors
- [ ] Tested with ElevenLabs API key
- [ ] Tested with OpenAI API key

## Regression Coverage

- Verifies finalization remains enabled after a nested offscreen acknowledgement clears live `audioActive` state.
- Verifies an already-inactive capture does not create a pending session or emit a false session-ended notification.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [ ] I have **starred the repository** ⭐ (helps us grow and show your support!).
- [x] My code follows the project's style guidelines (TypeScript, vanilla CSS, monochrome UI)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My code follows the formatting of this project (run `npm run format`)
- [x] ESLint checks pass locally without any errors (run `npm run lint`)
- [x] TypeScript type checks pass locally (run `npm run type-check`)
- [x] My changes generate no new warnings or errors
- [x] Documentation updates are not required for this internal lifecycle fix
