### PR TITLE
fix: respect dashboard microphone permission

### DIFF
--- a/src/dashboardCapture.test.ts
+++ b/src/dashboardCapture.test.ts
@@ -38,6 +38,7 @@ test("dashboard capture gets tab stream id before microphone permission", async 
   });
 
   assert.equal(result.meetingId, "abc-defg-hij");
+  assert.equal(result.microphoneEnabled, true);
   assert.deepEqual(calls, [
     "resolve-meet-tab",
     "get-stream-id:42",
@@ -48,21 +49,59 @@ test("dashboard capture gets tab stream id before microphone permission", async 
 
 test("dashboard capture still starts tab audio when microphone permission fails", async () => {
   const calls: string[] = [];
+  let includeMicrophone: boolean | undefined;
 
-  await startDashboardAudioCapture({
+  const result = await startDashboardAudioCapture({
     resolveMeetTab: async () => meetSelection(),
     getMediaStreamId: async () => "stream-id",
     requestMicrophonePermission: async () => {
       calls.push("request-microphone");
       throw new Error("Permission denied");
     },
-    startAudioCapture: async () => {
+    startAudioCapture: async (payload) => {
       calls.push("start-audio");
+      includeMicrophone = payload.includeMicrophone;
       return { success: true };
     },
   });
 
+  assert.equal(result.microphoneEnabled, false);
+  assert.equal(includeMicrophone, false);
   assert.deepEqual(calls, ["request-microphone", "start-audio"]);
+});
+
+test("dashboard capture disables microphone when permission is denied", async () => {
+  let includeMicrophone: boolean | undefined;
+
+  const result = await startDashboardAudioCapture({
+    resolveMeetTab: async () => meetSelection(),
+    getMediaStreamId: async () => "stream-id",
+    requestMicrophonePermission: async () => false,
+    startAudioCapture: async (payload) => {
+      includeMicrophone = payload.includeMicrophone;
+      return { success: true };
+    },
+  });
+
+  assert.equal(result.microphoneEnabled, false);
+  assert.equal(includeMicrophone, false);
+});
+
+test("dashboard capture includes microphone when permission is granted", async () => {
+  let includeMicrophone: boolean | undefined;
+
+  const result = await startDashboardAudioCapture({
+    resolveMeetTab: async () => meetSelection(),
+    getMediaStreamId: async () => "stream-id",
+    requestMicrophonePermission: async () => true,
+    startAudioCapture: async (payload) => {
+      includeMicrophone = payload.includeMicrophone;
+      return { success: true };
+    },
+  });
+
+  assert.equal(result.microphoneEnabled, true);
+  assert.equal(includeMicrophone, true);
 });
 
 test("dashboard capture does not request microphone when tab capture is denied", async () => {

--- a/src/dashboardCapture.ts
+++ b/src/dashboardCapture.ts
@@ -15,6 +15,7 @@ export interface DashboardCaptureStartResponse {
 
 export interface DashboardCaptureStartResult {
   meetingId: string;
+  microphoneEnabled: boolean;
   response: DashboardCaptureStartResponse;
 }
 
@@ -45,8 +46,9 @@ export async function startDashboardAudioCapture({
     throw new Error('Capture permission denied. Try clicking "Start Audio" again.');
   }
 
+  let microphoneEnabled = false;
   try {
-    await requestMicrophonePermission();
+    microphoneEnabled = await requestMicrophonePermission();
   } catch {
     // Microphone capture is optional; the offscreen document can still record tab audio.
   }
@@ -56,12 +58,12 @@ export async function startDashboardAudioCapture({
     meetingId,
     meetingUrl: meetingUrl || meetTab.url || null,
     streamId,
-    includeMicrophone: true,
+    includeMicrophone: microphoneEnabled,
   });
 
   if (!response?.success) {
     throw new Error(response?.error || "Failed to start audio");
   }
 
-  return { meetingId, response };
+  return { meetingId, microphoneEnabled, response };
 }


### PR DESCRIPTION
## Summary
- store the dashboard microphone permission result and pass it to offscreen capture
- keep dashboard capture tab-only when mic permission is denied or throws
- return microphoneEnabled from dashboard capture and cover granted, denied, and thrown permission paths

## Tests
- npm test -- src/dashboardCapture.test.ts
- npm run type-check
- npm run lint

Closes #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio capture now reports whether the microphone was enabled in its start result.

* **Improvements**
  * Microphone permission is treated as optional and handled gracefully—capture proceeds even if access is denied or fails.

* **Tests**
  * Expanded tests validate microphone permission outcomes and that the reported flags match actual behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->