### PR TITLE
fix: replace native confirm() with custom modal in storage dashboard

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -58,7 +58,8 @@
     "gantt",
     "glassmorphism",
     "Supabase",
-    "creds"
+    "creds",
+    "labelledby"
   ],
   "ignorePaths": [
     "node_modules",

--- a/src/storageDashboard.css
+++ b/src/storageDashboard.css
@@ -176,3 +176,87 @@
   color: var(--color-text-secondary);
   padding: 16px 0;
 }
+
+/* Confirmation Modal */
+.storage-confirm-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.storage-confirm-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.storage-confirm-content {
+  position: relative;
+  background: var(--color-background-secondary);
+  border: 1px solid var(--color-border-tertiary);
+  border-radius: var(--border-radius-lg);
+  padding: 24px;
+  max-width: 340px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.storage-confirm-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.storage-confirm-text {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.storage-confirm-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.storage-confirm-cancel {
+  font-size: 13px;
+  padding: 6px 14px;
+  border: 1px solid var(--color-border-secondary);
+  border-radius: var(--border-radius-md);
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+}
+
+.storage-confirm-cancel:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-border-primary);
+}
+
+.storage-confirm-delete {
+  font-size: 13px;
+  padding: 6px 14px;
+  border: 1px solid var(--color-text-danger);
+  border-radius: var(--border-radius-md);
+  background: var(--color-text-danger);
+  color: #fff;
+  cursor: pointer;
+}
+
+.storage-confirm-delete:hover {
+  opacity: 0.9;
+}
+
+.storage-confirm-delete:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/storageDashboard.ts
+++ b/src/storageDashboard.ts
@@ -108,6 +108,8 @@ function showDeleteConfirmModal(container: HTMLElement, sessionId: string): void
   // Remove any existing modal
   container.querySelector(".storage-confirm-modal")?.remove();
 
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
   const modal = document.createElement("div");
   modal.className = "storage-confirm-modal";
   modal.setAttribute("role", "dialog");
@@ -133,7 +135,9 @@ function showDeleteConfirmModal(container: HTMLElement, sessionId: string): void
   const backdrop = modal.querySelector(".storage-confirm-backdrop") as HTMLElement;
 
   function closeModal() {
+    document.removeEventListener("keydown", handleKeydown);
     modal.remove();
+    previouslyFocused?.focus();
   }
 
   function handleKeydown(e: KeyboardEvent) {
@@ -144,7 +148,7 @@ function showDeleteConfirmModal(container: HTMLElement, sessionId: string): void
     if (e.key === "Tab") {
       const focusable = [cancelBtn, deleteBtn];
       const first = focusable[0];
-      const last = focusable[focusable.length - 1];
+      const last = focusable.at(-1)!;
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();
         last.focus();
@@ -157,7 +161,7 @@ function showDeleteConfirmModal(container: HTMLElement, sessionId: string): void
 
   cancelBtn.addEventListener("click", closeModal);
   backdrop.addEventListener("click", closeModal);
-  modal.addEventListener("keydown", handleKeydown);
+  document.addEventListener("keydown", handleKeydown);
 
   deleteBtn.addEventListener("click", async () => {
     deleteBtn.disabled = true;

--- a/src/storageDashboard.ts
+++ b/src/storageDashboard.ts
@@ -104,14 +104,84 @@ function buildBreakdownCard(label: string, bytes: number, total: number, color: 
   `;
 }
 
+function showDeleteConfirmModal(container: HTMLElement, sessionId: string): void {
+  // Remove any existing modal
+  container.querySelector(".storage-confirm-modal")?.remove();
+
+  const modal = document.createElement("div");
+  modal.className = "storage-confirm-modal";
+  modal.setAttribute("role", "dialog");
+  modal.setAttribute("aria-modal", "true");
+  modal.setAttribute("aria-labelledby", "storage-confirm-title");
+
+  modal.innerHTML = `
+    <div class="storage-confirm-backdrop"></div>
+    <div class="storage-confirm-content">
+      <h3 id="storage-confirm-title" class="storage-confirm-title">Delete Meeting Data</h3>
+      <p class="storage-confirm-text">Are you sure you want to delete this meeting's stored data? This action cannot be undone.</p>
+      <div class="storage-confirm-actions">
+        <button class="storage-confirm-cancel" type="button">Cancel</button>
+        <button class="storage-confirm-delete" type="button">Delete</button>
+      </div>
+    </div>
+  `;
+
+  container.appendChild(modal);
+
+  const cancelBtn = modal.querySelector(".storage-confirm-cancel") as HTMLButtonElement;
+  const deleteBtn = modal.querySelector(".storage-confirm-delete") as HTMLButtonElement;
+  const backdrop = modal.querySelector(".storage-confirm-backdrop") as HTMLElement;
+
+  function closeModal() {
+    modal.remove();
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closeModal();
+    }
+    if (e.key === "Tab") {
+      const focusable = [cancelBtn, deleteBtn];
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  cancelBtn.addEventListener("click", closeModal);
+  backdrop.addEventListener("click", closeModal);
+  modal.addEventListener("keydown", handleKeydown);
+
+  deleteBtn.addEventListener("click", async () => {
+    deleteBtn.disabled = true;
+    deleteBtn.textContent = "Deleting...";
+    try {
+      await deleteSavedMeetingSession(chrome.storage.local, sessionId);
+      closeModal();
+      await renderStorageDashboard(container);
+    } catch (err) {
+      console.error("[LateMeet] Failed to delete session:", err);
+      deleteBtn.disabled = false;
+      deleteBtn.textContent = "Delete";
+    }
+  });
+
+  // Focus the cancel button by default (safer action)
+  cancelBtn.focus();
+}
+
 function attachEventListeners(container: HTMLElement): void {
   container.querySelectorAll(".storage-delete-btn").forEach((btn) => {
-    btn.addEventListener("click", async (e) => {
+    btn.addEventListener("click", (e) => {
       const id = (e.target as HTMLElement).dataset.id!;
-      if (confirm("Delete this meeting's stored data?")) {
-        await deleteSavedMeetingSession(chrome.storage.local, id);
-        await renderStorageDashboard(container);
-      }
+      showDeleteConfirmModal(container, id);
     });
   });
 


### PR DESCRIPTION
## Description

Replaces the browser-native `confirm()` dialog in `storageDashboard.ts` with a custom confirmation modal that matches the extension's design system and accessibility standards.

Fixes #353

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- Removed `confirm("Delete this meeting's stored data?")` call
- Added `showDeleteConfirmModal()` function with:
  - ARIA `role="dialog"` and `aria-modal="true"` attributes
  - Focus trap (Tab/Shift+Tab cycles between Cancel and Delete buttons)
  - Escape key dismissal
  - Backdrop click to close
  - Loading state on Delete button during async operation
  - Error handling if deletion fails
- Added corresponding CSS in `storageDashboard.css` using existing design tokens

## How It Was Tested

- `npm run type-check` — passes with no errors
- `npm run lint` — passes with no warnings
- Verified modal renders correctly with themed styling
- Verified keyboard navigation (Tab, Shift+Tab, Escape)
- Verified backdrop click dismisses modal

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced the storage deletion confirmation experience with a custom in-page modal replacing the standard browser dialog. The new modal provides improved visual design, keyboard navigation support (including Escape-to-close and Tab focus wrapping), and real-time feedback showing deletion status during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->