### PR TITLE
fix: preserve 'unresolved' topic status in popup UI

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -538,6 +538,16 @@ body::-webkit-scrollbar-thumb {
   background: var(--bg-card);
 }
 
+.topic-dot.unresolved {
+  background: #f59e0b;
+  box-shadow: 0 0 6px rgba(245, 158, 11, 0.4);
+}
+
+.topic-status.unresolved {
+  color: #d97706;
+  background: rgba(245, 158, 11, 0.12);
+}
+
 /* ——— Late Joiners ——— */
 .late-joiner-item {
   display: flex;

--- a/src/popup.css
+++ b/src/popup.css
@@ -544,8 +544,8 @@ body::-webkit-scrollbar-thumb {
 }
 
 .topic-status.unresolved {
-  color: #d97706;
-  background: rgba(245, 158, 11, 0.12);
+  color: #fbbf24;
+  background: rgba(245, 158, 11, 0.15);
 }
 
 /* ——— Late Joiners ——— */

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -632,7 +632,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     return map[sentiment] || "—";
   }
 
-  function sanitizeTopicStatus(status: string) {
+  function sanitizeTopicStatus(status: string): string {
     if (status === "completed" || status === "unresolved") return status;
     return "active";
   }

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -633,7 +633,8 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function sanitizeTopicStatus(status: string) {
-    return status === "completed" ? "completed" : "active";
+    if (status === "completed" || status === "unresolved") return status;
+    return "active";
   }
 
   function escapeHtml(value: string | null | undefined) {


### PR DESCRIPTION
## Description

Fixes `sanitizeTopicStatus()` in `popup.ts` which was collapsing the `"unresolved"` topic status into `"active"`, making it impossible for users to distinguish between topics currently being discussed and topics that were abandoned without resolution.

Fixes #355

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `src/popup.ts`: Updated `sanitizeTopicStatus()` to return `"unresolved"` when that status is provided (previously mapped to `"active"`)
- `src/popup.css`: Added `.topic-dot.unresolved` (amber dot) and `.topic-status.unresolved` (amber badge) styles

Note: `dashboard.ts` already handles `"unresolved"` correctly — only the popup needed this fix.

## How It Was Tested

- `npm run type-check` — passes
- `npm run lint` — passes
- Verified that topics with `status: "unresolved"` now render with amber styling distinct from active (blue) and completed (gray)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings