### PR TITLE
perf: disconnect MutationObserver after floating button injection

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -556,6 +556,12 @@ initTheme();
   const observer = new MutationObserver(() => {
     if (window.location.pathname.length > 5 && !window.location.pathname.includes("/_")) {
       injectFloatingButton();
+      // Disconnect once the button is successfully injected. Re-injection after
+      // copilot stops is handled by the STATE_UPDATE message listener, so this
+      // observer is no longer needed.
+      if (document.getElementById("mc-float-btn")) {
+        observer.disconnect();
+      }
     }
   });
 


### PR DESCRIPTION
## Description

Disconnects the body-wide `MutationObserver` in `content.ts` after the floating "Start Copilot" button is successfully injected into the DOM. Previously, this observer continued firing on every DOM mutation in Google Meet indefinitely, causing unnecessary CPU overhead during active video calls.

Fixes #357

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `src/content.ts`: After `injectFloatingButton()` is called and the button is confirmed in the DOM via `getElementById`, the observer disconnects itself.

## Why This Is Safe

The observer's only purpose is to detect when the user navigates from the Meet lobby to a meeting room (URL path changes). Once the button is injected:
- If the user clicks it → copilot starts, button is removed programmatically
- If copilot stops → the `STATE_UPDATE` message handler calls `injectFloatingButton()` directly (no observer needed)
- The `visibilitychange` handler also re-injects on tab resume

So the observer is only needed for the initial injection.

## How It Was Tested

- `npm run type-check` — passes
- `npm run lint` — passes
- Verified button still appears when navigating to a meeting room
- Verified button re-appears after copilot stops (via STATE_UPDATE handler)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings