### PR TITLE
fix(a11y): add keyboard navigation to export dropdown menu

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1051,10 +1051,12 @@ document.addEventListener("DOMContentLoaded", async () => {
         break;
       case "End":
         e.preventDefault();
-        items[items.length - 1]?.focus();
+        items.at(-1)?.focus();
         break;
       case "Tab":
         closeExportDropdown(false);
+        break;
+      default:
         break;
     }
   });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -997,22 +997,72 @@ document.addEventListener("DOMContentLoaded", async () => {
   const exportBtn = document.getElementById("export-btn") as HTMLButtonElement;
   const exportDropdown = document.getElementById("export-dropdown") as HTMLDivElement;
 
+  function openExportDropdown() {
+    exportDropdown.removeAttribute("hidden");
+    exportBtn.setAttribute("aria-expanded", "true");
+    const firstItem = exportDropdown.querySelector('[role="menuitem"]') as HTMLElement | null;
+    firstItem?.focus();
+  }
+
+  function closeExportDropdown(returnFocus = true) {
+    exportDropdown.setAttribute("hidden", "");
+    exportBtn.setAttribute("aria-expanded", "false");
+    if (returnFocus) exportBtn.focus();
+  }
+
   exportBtn?.addEventListener("click", () => {
     const isHidden = exportDropdown.hasAttribute("hidden");
     if (isHidden) {
-      exportDropdown.removeAttribute("hidden");
-      exportBtn.setAttribute("aria-expanded", "true");
+      openExportDropdown();
     } else {
-      exportDropdown.setAttribute("hidden", "");
-      exportBtn.setAttribute("aria-expanded", "false");
+      closeExportDropdown(false);
+    }
+  });
+
+  exportBtn?.addEventListener("keydown", (e: KeyboardEvent) => {
+    if (e.key === "ArrowDown" || e.key === "Enter" || e.key === " ") {
+      if (exportDropdown.hasAttribute("hidden")) {
+        e.preventDefault();
+        openExportDropdown();
+      }
+    }
+  });
+
+  exportDropdown?.addEventListener("keydown", (e: KeyboardEvent) => {
+    const items = Array.from(exportDropdown.querySelectorAll('[role="menuitem"]')) as HTMLElement[];
+    const currentIndex = items.indexOf(document.activeElement as HTMLElement);
+
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        closeExportDropdown();
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        items[(currentIndex + 1) % items.length]?.focus();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        items[(currentIndex - 1 + items.length) % items.length]?.focus();
+        break;
+      case "Home":
+        e.preventDefault();
+        items[0]?.focus();
+        break;
+      case "End":
+        e.preventDefault();
+        items[items.length - 1]?.focus();
+        break;
+      case "Tab":
+        closeExportDropdown(false);
+        break;
     }
   });
 
   document.addEventListener("click", (e: MouseEvent) => {
     const wrapper = document.getElementById("export-wrapper");
     if (wrapper && !wrapper.contains(e.target as Node)) {
-      exportDropdown?.setAttribute("hidden", "");
-      exportBtn?.setAttribute("aria-expanded", "false");
+      closeExportDropdown(false);
     }
   });
 


### PR DESCRIPTION
## Description

Implements the WAI-ARIA Menu Button keyboard interaction pattern for the export dropdown in the dashboard side panel. The dropdown had correct ARIA markup (`role="menu"`, `role="menuitem"`) but no corresponding keyboard behavior.

Fixes #358

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `src/dashboard.ts`: Added keyboard event handlers for the export dropdown:
  - **Enter/Space/ArrowDown** on trigger button: opens menu, focuses first item
  - **Escape**: closes menu, returns focus to trigger
  - **ArrowDown/ArrowUp**: cycles through menu items
  - **Home/End**: jumps to first/last item
  - **Tab**: closes menu, allows natural focus flow
- Extracted `openExportDropdown()` and `closeExportDropdown()` helpers for consistent behavior

## How It Was Tested

- `npm run type-check` — passes
- `npm run lint` — passes
- Verified keyboard navigation works: Tab to button → Enter opens → Arrow keys navigate → Escape closes and returns focus
- Verified mouse behavior unchanged

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings