### PR TITLE
fix: txt export now outputs plain text instead of markdown

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1115,7 +1115,8 @@ document.addEventListener("DOMContentLoaded", async () => {
     txt += `Key Decisions\n`;
     if (state.decisions?.length) {
       state.decisions.forEach((d: Decision) => {
-        txt += `  • ${d.text}${d.by ? ` — ${d.by}` : ""}\n`;
+        const byStr = d.by ? " — " + d.by : "";
+        txt += `  • ${d.text}${byStr}\n`;
       });
       txt += "\n";
     } else {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1070,6 +1070,86 @@ document.addEventListener("DOMContentLoaded", async () => {
     return md;
   }
 
+  function generatePlainText(state: State): string {
+    const dateVal = state.savedAt || state.startTime || Date.now();
+    const date = new Date(dateVal).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+
+    const duration = (state as State & { duration?: number }).duration || 0;
+    let txt = `Meeting Summary — ${date}\n\n`;
+    txt += `Meeting ID: ${state.meetingId || "N/A"}\n`;
+    txt += `Duration: ${formatDuration(duration)}\n`;
+    txt += `Sentiment: ${state.sentiment || "neutral"}\n\n`;
+
+    txt += `Attendees\n`;
+    if (state.participants?.length) {
+      txt += state.participants.map((p) => `  • ${p}`).join("\n") + "\n\n";
+    } else {
+      txt += `  (No participants detected)\n\n`;
+    }
+
+    txt += `Summary\n`;
+    txt += `  ${state.summary || "(No summary available)"}\n\n`;
+
+    txt += `Action Items\n`;
+    if (state.actionItems?.length) {
+      const sessionMeetingId = state.meetingId || "unknown";
+      state.actionItems.forEach((a: ActionItem) => {
+        const task = resolveActionKey(a);
+        if (!task) return;
+        const statusKey = buildActionStatusKey(sessionMeetingId, task);
+        const done = actionStatuses.get(statusKey) === true;
+        txt += done ? `  [done] ${task}` : `  [ ] ${task}`;
+        if (a.owner) txt += ` — ${a.owner}`;
+        if (a.deadline) txt += ` (due: ${a.deadline})`;
+        txt += "\n";
+      });
+      txt += "\n";
+    } else {
+      txt += `  (No action items)\n\n`;
+    }
+
+    txt += `Key Decisions\n`;
+    if (state.decisions?.length) {
+      state.decisions.forEach((d: Decision) => {
+        txt += `  • ${d.text}${d.by ? ` — ${d.by}` : ""}\n`;
+      });
+      txt += "\n";
+    } else {
+      txt += `  (No decisions recorded)\n\n`;
+    }
+
+    txt += `Topics Covered\n`;
+    if (state.topics?.length) {
+      state.topics.forEach((t: Topic) => {
+        txt += `  • ${t.name} (${t.status})\n`;
+      });
+      txt += "\n";
+    } else {
+      txt += `  (No topics detected)\n\n`;
+    }
+
+    txt += `Key Insights\n`;
+    if (state.keyInsights?.length) {
+      state.keyInsights
+        .filter((i) => i != null)
+        .forEach((insight: KeyInsight | string | null | undefined) => {
+          const text = typeof insight === "string" ? insight : insight?.text || "";
+          if (text) {
+            txt += `  • ${text}\n`;
+          }
+        });
+      txt += "\n";
+    } else {
+      txt += `  (No insights available)\n\n`;
+    }
+
+    return txt;
+  }
+
   let exportToastTimer: number | null = null;
 
   function showToast(message: string, type: "success" | "error" = "success"): void {
@@ -1194,7 +1274,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     try {
       const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
       if (!state) throw new Error("No meeting data available");
-      const textContent = generateMarkdown(state);
+      const textContent = generatePlainText(state);
       const filename = `meeting-summary-${new Date().toISOString().slice(0, 10)}.txt`;
       downloadFile(textContent, filename, "text/plain");
       showToast("Downloaded as .txt file", "success");


### PR DESCRIPTION
## Description

The "Export as TXT" button was calling `generateMarkdown()` which produces markdown syntax (`#`, `**`, `- [ ]`, `_italics_`). When opened in Notepad or TextEdit, these render as formatting noise rather than clean readable text.

Added a dedicated `generatePlainText()` function that produces properly formatted plain text.

Fixes #359

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `src/dashboard.ts`:
  - Added `generatePlainText(state)` function that outputs clean plain text with `•` bullets, indentation, and `[done]/[ ]` status markers
  - Updated the TXT export click handler to use `generatePlainText()` instead of `generateMarkdown()`

## Example Output

```
Meeting Summary — May 31, 2026

Meeting ID: abc-defg-hij
Duration: 00:45:12
Sentiment: positive

Attendees
  • Alice
  • Bob

Summary
  Discussed Q4 roadmap and approved new tooling budget.

Action Items
  [done] Send proposal — Alice
  [ ] Review budget — Bob (due: June 5)

Key Decisions
  • Approved new tooling — CTO
```

## How It Was Tested

- `npm run type-check` — passes
- `npm run lint` — passes
- Verified TXT output contains no markdown syntax

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings