### PR TITLE
fix: use getMeetingIdFromUrl() in context menu handler

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1643,9 +1643,7 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
   if (!tab?.id) return;
 
   const isMeetTab = isMeetHostname(tab.url);
-  const meetingId = isMeetTab
-    ? (tab.url?.match(/meet\.google\.com\/([a-z-]+)/)?.[1] ?? null)
-    : null;
+  const meetingId = getMeetingIdFromUrl(tab.url);
   const meetingUrl = tab.url || null;
 
   if (!state.audioActive) {


### PR DESCRIPTION
## Description

Replaces the loose inline regex in the `contextMenus.onClicked` handler with the existing strict `getMeetingIdFromUrl()` utility. This was the last remaining code path using a permissive regex for meeting ID extraction — all other handlers were fixed in #303.

Fixes #360

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `src/background.ts`: Replaced inline regex `tab.url?.match(/meet\.google\.com\/([a-z-]+)/)?.[1]` with `getMeetingIdFromUrl(tab.url)` in the context menu click handler.

## Before/After

```typescript
// Before (accepts "landing", "new", "a-b" as valid meeting IDs)
const meetingId = isMeetTab
  ? (tab.url?.match(/meet\.google\.com\/([a-z-]+)/)?.[1] ?? null)
  : null;

// After (only accepts canonical xxx-xxxx-xxx format)
const meetingId = getMeetingIdFromUrl(tab.url);
```

## How It Was Tested

- `npm run type-check` — passes
- `npm run lint` — passes
- Existing `meetingTabs.test.ts` covers `getMeetingIdFromUrl()` validation logic

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings