### PR TITLE
fix(a11y): sync aria-pressed state on accent color picker buttons

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -125,14 +125,20 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Set the active styling on the matching color dot button
   document.querySelectorAll(".color-dot").forEach((dot) => {
     const dotColor = dot.getAttribute("data-color");
-    if (dotColor === currentAccent) {
+    const isActive = dotColor === currentAccent;
+    if (isActive) {
       dot.classList.add("active");
     }
+    dot.setAttribute("aria-pressed", String(isActive));
 
     // Listen for color grid selections to give instant feedback
     dot.addEventListener("click", () => {
-      document.querySelectorAll(".color-dot").forEach((d) => d.classList.remove("active"));
+      document.querySelectorAll(".color-dot").forEach((d) => {
+        d.classList.remove("active");
+        d.setAttribute("aria-pressed", "false");
+      });
       dot.classList.add("active");
+      dot.setAttribute("aria-pressed", "true");
 
       const selectedTheme = (themeSelect?.value as Settings["theme"]) || "system";
       selectedAccentColor = dot.getAttribute("data-color") || "210, 100%, 50%";


### PR DESCRIPTION
## Description

The accent color picker buttons in the options page have `aria-pressed="false"` in HTML but the JavaScript never updated this attribute when a color was selected. Screen reader users could not determine which color was currently active.

Fixes #361

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `src/options.ts`: Updated the color dot initialization and click handler to sync `aria-pressed` with the visual `.active` class state:
  - On page load: sets `aria-pressed="true"` on the matching color, `"false"` on others
  - On click: resets all to `"false"`, sets clicked dot to `"true"`

## How It Was Tested

- `npm run type-check` — passes
- `npm run lint` — passes
- Verified with VoiceOver that the selected color is announced as "pressed"

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings