### PR TITLE
perf: implement incremental transcript rendering in dashboard

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -908,51 +908,79 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   // ——— Live Transcript ———
+  let renderedTranscriptCount = 0;
+
+  function createTranscriptEntryHTML(entry: TranscriptEntry): string {
+    const timeStr = escapeHtml(entry.timestampLabel || formatDuration(entry.timestamp || 0));
+    const speaker = escapeHtml(entry.speaker || "Unknown");
+    const initials = speaker
+      .split(" ")
+      .filter(Boolean)
+      .map((w) => w[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2);
+    const isAudio = (entry.speaker || "") === "Audio";
+    const text = escapeHtml(entry.text || "");
+    const chunkId = entry.id ? `transcript-${escapeHtml(entry.id)}` : "";
+
+    return `
+      <div id="${chunkId}" class="transcript-entry ${isAudio ? "audio-source" : ""}">
+        <div class="transcript-time">${timeStr}</div>
+        <div class="transcript-avatar">${isAudio ? "🎙" : initials}</div>
+        <div class="transcript-body">
+          <div class="transcript-speaker">${speaker}</div>
+          <div class="transcript-text">${text}</div>
+        </div>
+      </div>
+    `;
+  }
+
   function updateTranscript(transcript: TranscriptEntry[]) {
     if (!transcriptContainer) return;
 
     if (!transcript || transcript.length === 0) {
       transcriptContainer.innerHTML =
         '<div class="empty-msg">No transcript yet. Start audio to begin capturing speech.</div>';
-
+      renderedTranscriptCount = 0;
       resetTranscriptSearchState();
-
       return;
     }
 
-    transcriptContainer.innerHTML = transcript
-      .map((entry) => {
-        const timeStr = escapeHtml(entry.timestampLabel || formatDuration(entry.timestamp || 0));
-        const speaker = escapeHtml(entry.speaker || "Unknown");
-        const initials = speaker
-          .split(" ")
-          .filter(Boolean)
-          .map((w) => w[0])
-          .join("")
-          .toUpperCase()
-          .slice(0, 2);
-        const isAudio = (entry.speaker || "") === "Audio";
-        const text = escapeHtml(entry.text || "");
-        const chunkId = entry.id ? `transcript-${escapeHtml(entry.id)}` : "";
+    // If the transcript shrunk (e.g., session reset), do a full re-render
+    if (transcript.length < renderedTranscriptCount) {
+      renderedTranscriptCount = 0;
+      transcriptContainer.innerHTML = "";
+    }
 
-        return `
-        <div id="${chunkId}" class="transcript-entry ${isAudio ? "audio-source" : ""}">
-          <div class="transcript-time">${timeStr}</div>
-          <div class="transcript-avatar">${isAudio ? "🎙" : initials}</div>
-          <div class="transcript-body">
-            <div class="transcript-speaker">${speaker}</div>
-            <div class="transcript-text">${text}</div>
-          </div>
-        </div>
-      `;
-      })
-      .join("");
+    // Only render new entries that haven't been rendered yet
+    if (transcript.length > renderedTranscriptCount) {
+      // Remove empty message if present
+      const emptyMsg = transcriptContainer.querySelector(".empty-msg");
+      if (emptyMsg) emptyMsg.remove();
 
-    if (searchInput?.value.trim()) {
-      executeTranscriptSearch(true);
-    } else {
-      transcriptContainer.scrollTop = transcriptContainer.scrollHeight;
-      updateTranscriptSearchControls();
+      const newEntries = transcript.slice(renderedTranscriptCount);
+      const fragment = document.createDocumentFragment();
+      const wrapper = document.createElement("div");
+      wrapper.innerHTML = newEntries.map((e) => createTranscriptEntryHTML(e)).join("");
+      while (wrapper.firstChild) {
+        fragment.appendChild(wrapper.firstChild);
+      }
+      transcriptContainer.appendChild(fragment);
+      renderedTranscriptCount = transcript.length;
+
+      if (searchInput?.value.trim()) {
+        executeTranscriptSearch(true);
+      } else {
+        // Auto-scroll only if user is near the bottom
+        const isNearBottom =
+          transcriptContainer.scrollHeight - transcriptContainer.scrollTop <=
+          transcriptContainer.clientHeight + 80;
+        if (isNearBottom) {
+          transcriptContainer.scrollTop = transcriptContainer.scrollHeight;
+        }
+        updateTranscriptSearchControls();
+      }
     }
   }
 


### PR DESCRIPTION
## Description

The `updateTranscript()` function previously replaced the entire transcript container innerHTML on every state update (~every 500ms during active recording). This destroyed search highlights, lost scroll position, and caused unnecessary DOM thrashing for large transcripts.

Now implements incremental rendering that only appends new entries.

Fixes #362

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `src/dashboard.ts`:
  - Added `renderedTranscriptCount` tracker
  - Extracted `createTranscriptEntryHTML()` helper for single-entry rendering
  - `updateTranscript()` now only appends entries beyond the already-rendered count
  - Handles session reset (transcript array shrinks) with a full re-render fallback
  - Auto-scroll only triggers when user is within 80px of the bottom
  - Search re-execution only runs when new entries are actually appended

## Benefits

- Existing DOM nodes (and their `<mark>` search highlights) are preserved
- Scroll position is maintained when user scrolls up to read earlier entries
- Significantly less DOM work for long transcripts (O(new) instead of O(total))
- Search highlights no longer flash/flicker on every state update

## How It Was Tested

- `npm run type-check` — passes
- `npm run lint` — passes
- Verified new entries append correctly without re-rendering existing ones
- Verified scroll position preserved when scrolled up
- Verified search highlights persist across updates
- Verified empty state and session reset handled correctly

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings