### PR TITLE
fix(a11y): add aria-label to passphrase visibility toggle button

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -165,7 +165,12 @@
               class="form-input"
               placeholder="Enter encryption passphrase..."
             />
-            <button class="toggle-vis" data-target="passphrase-input">
+            <button
+              class="toggle-vis"
+              data-target="passphrase-input"
+              aria-label="Toggle passphrase visibility"
+              title="Show/Hide Passphrase"
+            >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"


### PR DESCRIPTION
## Description

Adds missing `aria-label` and `title` attributes to the passphrase visibility toggle button in the options page. The OpenAI and ElevenLabs API key toggles already have these attributes, but the passphrase toggle was missed.

Fixes #363

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## What Changed

- `src/options.html`: Added `aria-label="Toggle passphrase visibility"` and `title="Show/Hide Passphrase"` to the passphrase toggle button.

## How It Was Tested

- `npm run type-check` — passes
- `npm run lint` — passes
- Verified with VoiceOver that the button is now announced as "Toggle passphrase visibility"

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced the passphrase visibility toggle with improved accessibility features, including better screen reader support and informative tooltips for clearer user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->