### PR TITLE
fix: support active speaker detection in localized Meet UIs

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -47,7 +47,21 @@ initTheme();
     ],
     activeSpeakerIndicators: [
       '[aria-label*="speaking" i]',
+      '[aria-label*="hablando" i]',
+      '[aria-label*="parle" i]',
+      '[aria-label*="spricht" i]',
+      '[aria-label*="falando" i]',
+      '[aria-label*="parlando" i]',
+      '[aria-label*="говорит" i]',
+      '[aria-label*="正在讲话" i]',
+      '[aria-label*="話しています" i]',
       '[data-tooltip*="speaking" i]',
+      '[data-tooltip*="hablando" i]',
+      '[data-tooltip*="parle" i]',
+      '[data-tooltip*="spricht" i]',
+      '[data-tooltip*="falando" i]',
+      '[data-tooltip*="parlando" i]',
+      '[data-tooltip*="говорит" i]',
       '[data-is-speaking="true"]',
       '[data-speaking="true"]',
       '[data-active-speaker="true"]',
@@ -90,7 +104,12 @@ initTheme();
 
   function hasActiveSpeakerCue(el: Element): boolean {
     const ariaLabel = String(el.getAttribute("aria-label") || "");
-    if (/\bspeaking\b/i.test(ariaLabel)) return true;
+    if (
+      /(speaking|hablando|parle|spricht|falando|parlando|говорит|正在讲话|話しています)/i.test(
+        ariaLabel,
+      )
+    )
+      return true;
 
     if (
       el.getAttribute("data-is-speaking") === "true" ||

--- a/src/content.ts
+++ b/src/content.ts
@@ -62,6 +62,8 @@ initTheme();
       '[data-tooltip*="falando" i]',
       '[data-tooltip*="parlando" i]',
       '[data-tooltip*="говорит" i]',
+      '[data-tooltip*="正在讲话" i]',
+      '[data-tooltip*="話しています" i]',
       '[data-is-speaking="true"]',
       '[data-speaking="true"]',
       '[data-active-speaker="true"]',


### PR DESCRIPTION
## 🚀 Description

Fixes active speaker detection for users running Google Meet in non-English languages.

Previously, active speaker detection relied on matching the English word "speaking" in accessibility labels and tooltips. Since Google Meet localizes these labels, speaker detection would fail in many languages, preventing Late Meet from correctly identifying active speakers.

### Changes Made

* Added support for common localized equivalents of "speaking" in active speaker detection selectors.
* Updated validation logic to recognize multiple language variants.
* Preserved existing English behavior.
* Kept the fix focused on speaker detection only.

### Files Changed

* `src/content.ts`

### Verification

* Installed dependencies (`npm install`)
* Ran test suite (`npm run test`)
* All tests passed (88/88)
* Confirmed existing English behavior remains unchanged

Fixes #385

---

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## ✅ Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [x] No new warnings introduced
* [x] Existing tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded active speaker detection to recognize multilingual UI cues, ensuring the active speaker indicator functions correctly across multiple language settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->