### PR TITLE
fix: normalize sentiment values before dashboard mapping

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -506,7 +506,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       neutral: { width: "50%", text: "Neutral 😐", color: "#94A3B8" },
       mixed: { width: "55%", text: "Mixed 🤔", color: "#FBBF24" },
     };
-    const s = map[sentiment] || map.neutral;
+    const normalizedSentiment = (sentiment || "").toLowerCase();
+    const s = map[normalizedSentiment] || map.neutral;
     if (fill) fill.style.width = s.width;
     if (label) {
       label.textContent = s.text;


### PR DESCRIPTION
## 🚀 Description

Fixes sentiment mapping when API responses use capitalized sentiment values.

Previously, the dashboard sentiment mapping relied on lowercase lookup keys. If the API returned values such as `"Positive"` or `"Negative"`, the lookup would fail and incorrectly fall back to the neutral state.

### Root Cause

The dashboard used the raw API sentiment string directly as a lookup key:

```ts
const s = map[sentiment] || map.neutral;
```

Because the mapping keys were lowercase, capitalized responses resulted in lookup failures.

### Changes Made

* Added sentiment normalization before lookup.
* Converted incoming sentiment values to lowercase.
* Preserved existing behavior for lowercase values.
* Kept the fix localized to dashboard sentiment handling.

### Files Changed

* `src/dashboard.ts`

### Before vs After

**Before**

```ts
const s = map[sentiment] || map.neutral;
```

**After**

```ts
const normalizedSentiment = (sentiment || "").toLowerCase();
const s = map[normalizedSentiment] || map.neutral;
```

### Result

* `"Positive"` maps correctly to positive sentiment.
* `"Negative"` maps correctly to negative sentiment.
* Existing lowercase values continue to work.
* Unknown values still safely fall back to neutral.

### Verification

* Ran full test suite (`npm run test`)
* All 88 tests passed
* Verified lowercase and capitalized sentiment values resolve correctly
* Confirmed fallback behavior remains intact

Fixes #386

---

## 🛠️ Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## ✅ Checklist

* [x] Code follows project style guidelines
* [x] Self-review completed
* [x] No new warnings introduced
* [x] Existing tests pass
