### PR TITLE
fix: persist recording state per tab to survive tab switches

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -2,6 +2,7 @@
 
 import { State } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
+import { getTabState, setTabState, clearTabState, initTabStateCleanup } from "./tabStateManager";
 
 const OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
 const OPENAI_WHISPER_URL = "https://api.openai.com/v1/audio/transcriptions";
@@ -282,7 +283,42 @@ function snapshot() {
   };
 }
 
+async function saveCurrentTabState() {
+  if (state.targetTabId) {
+    const copy = { ...state };
+    delete (copy as any).pendingJoiners;
+    await setTabState(state.targetTabId, copy);
+  }
+}
+
+async function loadTabState(tabId: number) {
+  const tabState = await getTabState(tabId);
+  state.isActive = tabState.isActive ?? false;
+  state.meetingId = tabState.meetingId ?? null;
+  state.meetingUrl = tabState.meetingUrl ?? null;
+  state.startTime = tabState.startTime ?? null;
+  state.summary = tabState.summary ?? "";
+  state.topics = tabState.topics ?? [];
+  state.decisions = tabState.decisions ?? [];
+  state.actionItems = tabState.actionItems ?? [];
+  state.currentTopic = tabState.currentTopic ?? "";
+  state.sentiment = tabState.sentiment ?? "neutral";
+  state.keyInsights = tabState.keyInsights ?? [];
+  state.questionsRaised = tabState.questionsRaised ?? [];
+  state.participants = tabState.participants ?? [];
+  state.initialParticipants = tabState.initialParticipants ?? [];
+  state.lateJoiners = tabState.lateJoiners ?? [];
+  state.timeline = tabState.timeline ?? [];
+  state.transcript = tabState.transcript ?? [];
+  state.audioActive = tabState.audioActive ?? false;
+  state.targetTabId = tabId;
+  state.lastSummarizedAt = tabState.lastSummarizedAt ?? 0;
+  state.participantCount = tabState.participantCount ?? 0;
+  state.pendingJoiners.clear();
+}
+
 async function broadcastStateUpdate() {
+  await saveCurrentTabState();
   const snapshotData = snapshot();
   try {
     // To popup/dashboard
@@ -391,12 +427,12 @@ async function transcribeChunk(base64Audio: string, mimeType = "audio/webm", pro
   // Single declaration — retrieved from session storage with local storage fallback.
   let elevenlabsKey = await chrome.storage.session
     .get("elevenlabs_api_key")
-    .then((r) => r.elevenlabs_api_key);
+    .then((r: any) => r.elevenlabs_api_key as string | undefined);
 
   if (!elevenlabsKey) {
-    const localResult = await chrome.storage.local.get("elevenlabs_api_key");
+    const localResult = (await chrome.storage.local.get("elevenlabs_api_key")) as any;
     if (localResult.elevenlabs_api_key) {
-      elevenlabsKey = localResult.elevenlabs_api_key;
+      elevenlabsKey = localResult.elevenlabs_api_key as string;
       await chrome.storage.session.set({ elevenlabs_api_key: elevenlabsKey });
     }
   }
@@ -853,10 +889,10 @@ async function persistSession() {
   }
   isProcessingSession = true;
   try {
-    const { pendingSession, savedSessions } = await chrome.storage.local.get([
+    const { pendingSession, savedSessions } = (await chrome.storage.local.get([
       "pendingSession",
       "savedSessions",
-    ]);
+    ])) as { pendingSession?: any; savedSessions?: any };
     if (!pendingSession) {
       console.log("[LateMeet] No pending session found to save.");
       return;
@@ -1033,8 +1069,11 @@ async function stopAudioCapture(reason = "Stopped") {
     await savePendingSession();
   }
 
-  state.audioActive = false;
-  state.isActive = false;
+  if (state.targetTabId) {
+    await clearTabState(state.targetTabId);
+  }
+
+  resetState();
 
   await broadcastStateUpdate();
 
@@ -1073,10 +1112,21 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
     if (tab.url?.includes("meet.google.com/")) {
       const urlMatch = tab.url.match(/meet\.google\.com\/([a-z\-]+)/);
       const meetingId = urlMatch ? urlMatch[1] : null;
-      if (meetingId && meetingId !== "new" && !state.isActive) {
-        state.meetingId = meetingId;
-        state.meetingUrl = tab.url;
-        state.targetTabId = activeInfo.tabId;
+      if (meetingId && meetingId !== "new") {
+        if (state.targetTabId && state.targetTabId !== activeInfo.tabId) {
+          await saveCurrentTabState();
+        }
+
+        await loadTabState(activeInfo.tabId);
+
+        if (!state.isActive) {
+          state.isActive = true;
+          state.meetingId = meetingId;
+          state.meetingUrl = tab.url || null;
+          state.targetTabId = activeInfo.tabId;
+          state.startTime = Date.now();
+          state.participants = ["You"];
+        }
         await broadcastStateUpdate();
       }
     }
@@ -1086,6 +1136,8 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
 });
 
 chrome.tabs.onRemoved.addListener(async (tabId) => {
+  await clearTabState(tabId);
+
   if (state.targetTabId && tabId === state.targetTabId) {
     if (state.isActive) {
       await stopAudioCapture("Meeting tab closed");
@@ -1254,3 +1306,4 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 // Proactive scan on startup/load
 scanForMeetTabs();
+initTabStateCleanup();

--- a/src/tabStateManager.ts
+++ b/src/tabStateManager.ts
@@ -1,0 +1,52 @@
+/**
+ * Tab State Manager
+ *
+ * Persists recording/transcription state per Chrome tab.
+ * Prevents state loss when users switch between multiple Meet tabs.
+ */
+
+export interface TabState {
+  tabId: number;
+  isRecording: boolean;
+  startedAt: number | null;
+  transcript: string[];
+  meetingTitle: string;
+}
+
+const defaultState = (): Omit<TabState, "tabId"> => ({
+  isRecording: false,
+  startedAt: null,
+  transcript: [],
+  meetingTitle: "",
+});
+
+/** Get state for a specific tab */
+export async function getTabState(tabId: number): Promise<TabState> {
+  const key = `tab_state_${tabId}`;
+  const result = await chrome.storage.session.get(key);
+  return result[key] ?? { tabId, ...defaultState() };
+}
+
+/** Update state for a specific tab */
+export async function setTabState(
+  tabId: number,
+  updates: Partial<Omit<TabState, "tabId">>
+): Promise<void> {
+  const key = `tab_state_${tabId}`;
+  const current = await getTabState(tabId);
+  await chrome.storage.session.set({
+    [key]: { ...current, ...updates, tabId },
+  });
+}
+
+/** Clear state for a specific tab (e.g., when tab closes) */
+export async function clearTabState(tabId: number): Promise<void> {
+  await chrome.storage.session.remove(`tab_state_${tabId}`);
+}
+
+/** Listen for tab close to clean up state */
+export function initTabStateCleanup(): void {
+  chrome.tabs.onRemoved.addListener((tabId) => {
+    clearTabState(tabId).catch(console.error);
+  });
+}

--- a/src/tabStateManager.ts
+++ b/src/tabStateManager.ts
@@ -21,8 +21,15 @@ const defaultState = (): Omit<TabState, "tabId"> => ({
 /** Get state for a specific tab */
 export async function getTabState(tabId: number): Promise<TabState> {
   const key = `tab_state_${tabId}`;
-  const result = (await chrome.storage.session.get(key)) as any;
-  return result[key] ?? { tabId, ...defaultState() };
+  const result = await chrome.storage.session.get(key);
+  const stored = result[key];
+
+  return {
+    tabId,
+    ...defaultState(),
+    ...(stored && typeof stored === "object" ? stored : {}),
+  } as TabState;
+}
 }
 
 /** Update state for a specific tab */

--- a/src/tabStateManager.ts
+++ b/src/tabStateManager.ts
@@ -1,3 +1,5 @@
+import { State } from "./types";
+
 /**
  * Tab State Manager
  *
@@ -5,32 +7,28 @@
  * Prevents state loss when users switch between multiple Meet tabs.
  */
 
-export interface TabState {
+export interface TabState extends Partial<State> {
   tabId: number;
-  isRecording: boolean;
-  startedAt: number | null;
-  transcript: string[];
-  meetingTitle: string;
 }
 
 const defaultState = (): Omit<TabState, "tabId"> => ({
-  isRecording: false,
-  startedAt: null,
+  audioActive: false,
+  isActive: false,
+  startTime: null,
   transcript: [],
-  meetingTitle: "",
 });
 
 /** Get state for a specific tab */
 export async function getTabState(tabId: number): Promise<TabState> {
   const key = `tab_state_${tabId}`;
-  const result = await chrome.storage.session.get(key);
+  const result = (await chrome.storage.session.get(key)) as any;
   return result[key] ?? { tabId, ...defaultState() };
 }
 
 /** Update state for a specific tab */
 export async function setTabState(
   tabId: number,
-  updates: Partial<Omit<TabState, "tabId">>
+  updates: Partial<Omit<TabState, "tabId">>,
 ): Promise<void> {
   const key = `tab_state_${tabId}`;
   const current = await getTabState(tabId);


### PR DESCRIPTION
## Summary

Adds a `tabStateManager.ts` utility that persists recording state per-tab using the Chrome tab ID. Prevents recording state loss when switching between Google Meet tabs.

cc @shouri123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-tab state persistence to independently maintain recording and transcription state across browser tabs.

* **Bug Fixes**
  * Improved API key retrieval with fallback mechanism for enhanced reliability.
  * Enhanced automatic state cleanup on tab closure and session termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->