### PR TITLE
fix: export full saved meeting sessions

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -365,6 +365,7 @@ function snapshot() {
     startTime: state.startTime,
     duration: getDuration(),
     summary: state.summary,
+    summaryItems: state.summaryItems,
     topics: state.topics,
     decisions: state.decisions,
     actionItems: state.actionItems,

--- a/src/background.ts
+++ b/src/background.ts
@@ -6,6 +6,7 @@ import {
   deleteSavedMeetingSession,
   discardPendingMeetingSession,
   getSavedMeetingSessions,
+  getSavedMeetingSession,
   isStorageQuotaError,
   persistMeetingSession,
   persistPendingMeetingSession,
@@ -1617,6 +1618,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       case "GET_SAVED_SESSIONS": {
         const sessions = await getSavedMeetingSessions(chrome.storage.local);
         sendResponse(sessions);
+        return;
+      }
+
+      case "GET_SAVED_SESSION": {
+        const session =
+          typeof message.sessionId === "string"
+            ? await getSavedMeetingSession(chrome.storage.local, message.sessionId)
+            : null;
+        sendResponse(session);
         return;
       }
 

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -5,7 +5,6 @@ import {
   TimelineEvent,
   Decision,
   ActionItem,
-  SummaryItem,
   KeyInsight,
 } from "./types";
 import { initTheme } from "./theme.js";
@@ -920,8 +919,6 @@ document.addEventListener("DOMContentLoaded", async () => {
 
       return;
     }
-
-    const startTime = transcript[0]?.timestamp || Date.now();
 
     transcriptContainer.innerHTML = transcript
       .map((entry) => {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1360,17 +1360,17 @@ document.addEventListener("DOMContentLoaded", async () => {
       container
         .querySelectorAll<HTMLButtonElement>(".session-export-btn:not(.session-download-btn)")
         .forEach((btn) => {
-          btn.addEventListener("click", () => {
+          btn.addEventListener("click", async () => {
             const sessionId = btn.dataset.sessionId;
-            const session = sessions.find((s: State) => (s.id ?? "") === sessionId);
+            const session = sessionId ? await loadFullSavedSession(sessionId) : null;
             if (session) exportSessionMarkdown(session);
           });
         });
 
       container.querySelectorAll<HTMLButtonElement>(".session-download-btn").forEach((btn) => {
-        btn.addEventListener("click", () => {
+        btn.addEventListener("click", async () => {
           const sessionId = btn.dataset.sessionId;
-          const session = sessions.find((s: State) => (s.id ?? "") === sessionId);
+          const session = sessionId ? await loadFullSavedSession(sessionId) : null;
           if (session) downloadSessionMarkdown(session);
         });
       });
@@ -1415,6 +1415,26 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   // ——— HISTORY EXPORT ACTIONS (Now perfectly unified with the dynamic generator!) ———
+  async function loadFullSavedSession(sessionId: string): Promise<State | null> {
+    try {
+      const session: State | null = await chrome.runtime.sendMessage({
+        type: "GET_SAVED_SESSION",
+        sessionId,
+      });
+
+      if (!session) {
+        showToast("Saved session data could not be found", "error");
+        return null;
+      }
+
+      return session;
+    } catch (err) {
+      const e = err as Error;
+      showToast("Failed to load saved session: " + (e.message || String(e)), "error");
+      return null;
+    }
+  }
+
   function exportSessionMarkdown(session: State) {
     const md = generateMarkdown(session);
 

--- a/src/sessionStorage.test.ts
+++ b/src/sessionStorage.test.ts
@@ -21,6 +21,7 @@ function makeSession(id: string, savedAt: number): StoredSession {
     meetingUrl: null,
     startTime: savedAt,
     summary: `Summary ${id}`,
+    summaryItems: [{ text: `Summary item ${id}`, timestamp: "00:10" }],
     topics: [],
     decisions: [],
     actionItems: [],

--- a/src/sessionStorage.test.ts
+++ b/src/sessionStorage.test.ts
@@ -4,8 +4,10 @@ import test from "node:test";
 import {
   createSessionListItem,
   estimateStorageBytes,
+  getSavedMeetingSession,
   getSavedSessionKey,
   isStorageQuotaError,
+  SAVED_SESSIONS_LEGACY_KEY,
   StoredSession,
   upsertSessionIndex,
 } from "./sessionStorage";
@@ -83,4 +85,39 @@ test("quota errors are detected from Chrome storage messages", () => {
 
 test("storage byte estimates increase with payload size", () => {
   assert.ok(estimateStorageBytes({ text: "large payload" }) > estimateStorageBytes({ text: "" }));
+});
+
+test("getSavedMeetingSession loads the full indexed session payload", async () => {
+  const session = makeSession("full", 100);
+  const storage = {
+    get: async () => ({
+      [getSavedSessionKey(session.id)]: session,
+      [SAVED_SESSIONS_LEGACY_KEY]: [],
+    }),
+    set: async () => {},
+    remove: async () => {},
+  };
+
+  const result = await getSavedMeetingSession(storage, session.id);
+
+  assert.equal(result?.id, session.id);
+  assert.deepEqual(result?.transcript, session.transcript);
+  assert.deepEqual(result?.timeline, session.timeline);
+});
+
+test("getSavedMeetingSession falls back to legacy saved sessions", async () => {
+  const session = makeSession("legacy", 200);
+  const storage = {
+    get: async () => ({
+      [SAVED_SESSIONS_LEGACY_KEY]: [session],
+    }),
+    set: async () => {},
+    remove: async () => {},
+  };
+
+  const result = await getSavedMeetingSession(storage, session.id);
+
+  assert.equal(result?.id, session.id);
+  assert.deepEqual(result?.transcript, session.transcript);
+  assert.deepEqual(result?.timeline, session.timeline);
 });

--- a/src/sessionStorage.ts
+++ b/src/sessionStorage.ts
@@ -181,6 +181,22 @@ export async function getSavedMeetingSessions(storage: StorageArea): Promise<Sto
     : [];
 }
 
+export async function getSavedMeetingSession(
+  storage: StorageArea,
+  sessionId: string,
+): Promise<StoredSession | null> {
+  const sessionKey = getSavedSessionKey(sessionId);
+  const values = await storage.get([sessionKey, SAVED_SESSIONS_LEGACY_KEY]);
+  const indexedSession = asStoredSession(values[sessionKey]);
+  if (indexedSession) return indexedSession;
+
+  const legacySessions = Array.isArray(values[SAVED_SESSIONS_LEGACY_KEY])
+    ? (values[SAVED_SESSIONS_LEGACY_KEY].map(asStoredSession).filter(Boolean) as StoredSession[])
+    : [];
+
+  return legacySessions.find((session) => session.id === sessionId) ?? null;
+}
+
 export async function deleteSavedMeetingSession(
   storage: StorageArea,
   sessionId: string,


### PR DESCRIPTION
## Summary

- add a full saved-session lookup for history exports
- fetch the full saved payload before copying or downloading a saved meeting from History
- cover indexed and legacy saved-session lookup paths with regression tests

Fixes #421.

## Verification

- `npm run type-check`
- `npm run lint`
- `npm test`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session export/download reliability by fetching full saved session on demand and handling missing sessions gracefully.

* **Improvements**
  * Live transcript rendering resets search state and avoids unnecessary work when empty.
  * Added a message-based fetch for retrieving a single saved session to support on-demand loads.

* **Tests**
  * Added tests verifying session retrieval and legacy-data fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->