### PR TITLE
fix: remove dead obscureApiKey/deobscureApiKey functions from credentials.ts

### DIFF
--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -252,11 +252,3 @@ export async function saveApiCredentials(credentials: ApiCredentials): Promise<v
     ]);
   }
 }
-
-// Credentials key encryption/obscurity helpers
-export function obscureApiKey(key: string): string {
-  return btoa(key).split("").reverse().join("");
-}
-export function deobscureApiKey(val: string): string {
-  return atob(val.split("").reverse().join(""));
-}


### PR DESCRIPTION
## Description

Removes two unused exported functions (`obscureApiKey` and `deobscureApiKey`) from `src/utils/credentials.ts`. These functions implemented trivially reversible base64 obfuscation, were never imported anywhere in the codebase, and their presence in a security-critical file was misleading.

Fixes #423

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

- `npm run type-check` — passes
- `npm run lint` — passes
- `npm test` — all 88 tests pass
- Searched codebase: zero imports of these functions exist