### PR TITLE
fix: add lang="en" attribute to offscreen.html for WCAG 3.1.1 compliance

### DIFF
--- a/src/offscreen.html
+++ b/src/offscreen.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <title>Meeting Copilot Audio Processor</title>
   </head>


### PR DESCRIPTION
## Description

Adds the missing `lang="en"` attribute to `src/offscreen.html`. This was the only HTML file in the project without it — all others (`popup.html`, `dashboard.html`, `options.html`) already include it.

Fixes #424

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

- `npm run build` — passes
- Single-line change, no functional impact