### PR TITLE
fix: remove redundant nested if (targetId) check in options.ts

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -154,11 +154,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     btn.addEventListener("click", () => {
       const targetId = btn.dataset.target;
       if (targetId) {
-        if (targetId) {
-          const target = document.getElementById(targetId) as HTMLInputElement | null;
-          if (target) {
-            target.type = target.type === "password" ? "text" : "password";
-          }
+        const target = document.getElementById(targetId) as HTMLInputElement | null;
+        if (target) {
+          target.type = target.type === "password" ? "text" : "password";
         }
       }
     });


### PR DESCRIPTION
## Description

Removes a redundant nested `if (targetId)` check inside the `.toggle-vis` click handler in `src/options.ts`. The inner check was always true because it was already guarded by an identical outer `if (targetId)` block — a copy-paste artifact.

Fixes #430

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

- `npm run type-check` — passes
- `npm run lint` — passes
- `npm run build` — passes
- Functionality unchanged — only removed dead logic branch