### PR TITLE
fix: clear duration timer interval when popup closes

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -652,4 +652,12 @@ document.addEventListener("DOMContentLoaded", async () => {
       el.style.animation = "";
     }, 400);
   }
+
+  // ——— Cleanup on popup close ———
+  window.addEventListener("unload", () => {
+    if (durationInterval) {
+      clearInterval(durationInterval as number);
+      durationInterval = null;
+    }
+  });
 });


### PR DESCRIPTION
## Description

Adds a `window.addEventListener("unload", ...)` handler in `src/popup.ts` to explicitly clear the duration timer `setInterval` when the popup is closed. Previously, the interval would continue running until Chrome garbage-collected the popup's execution context.

Fixes #429

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

- `npm run type-check` — passes
- `npm run lint` — passes
- `npm run build` — passes
- The cleanup handler follows the same pattern used in `content.ts` for its timers