### PR TITLE
fix: change keyboard shortcuts to avoid conflicts with browser Save As and DevTools

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -42,15 +42,15 @@
   "commands": {
     "toggle-recording": {
       "suggested_key": {
-        "default": "Ctrl+Shift+S",
-        "mac": "Command+Shift+S"
+        "default": "Alt+Shift+R",
+        "mac": "MacCtrl+Shift+R"
       },
       "description": "Start/Stop Copilot recording"
     },
     "open-side-panel": {
       "suggested_key": {
-        "default": "Ctrl+Shift+P",
-        "mac": "Command+Shift+P"
+        "default": "Alt+Shift+L",
+        "mac": "MacCtrl+Shift+L"
       },
       "description": "Open the Late-Meet side panel"
     },


### PR DESCRIPTION
## Description

Changes the extension keyboard shortcuts to avoid conflicts with Chrome built-in shortcuts:
- `toggle-recording`: `Ctrl+Shift+S` → `Alt+Shift+R` (R for Record; avoids Save As)
- `open-side-panel`: `Ctrl+Shift+P` → `Alt+Shift+L` (L for Late-Meet; avoids DevTools Command Palette)

Mac shortcuts use `MacCtrl+Shift` instead of `Command+Shift` to avoid conflicts with macOS system shortcuts.

Fixes #425

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

- `npm run type-check` — passes
- `npm run build` — passes
- Shortcuts follow Chrome extension command key requirements (Alt+Shift+key is valid)
- Users can still remap via `chrome://extensions/shortcuts` if preferred

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated extension keyboard shortcuts: Recording toggle now uses Alt+Shift+R (MacCtrl+Shift+R on Mac) and side panel opening now uses Alt+Shift+L (MacCtrl+Shift+L on Mac).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->