### PR TITLE
fix: trim whitespace from save button text capture in options.ts

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -234,7 +234,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const elevenlabsKey =
       (document.getElementById("elevenlabs-key") as HTMLInputElement | null)?.value.trim() ?? "";
 
-    const originalText = saveBtn.textContent || "Save Settings";
+    const originalText = saveBtn.textContent?.trim() || "Save Settings";
     if (pendingUnlock) await pendingUnlock;
     if (!isUnlocked()) {
       if (status) {


### PR DESCRIPTION
## Description

Adds `.trim()` to the `saveBtn.textContent` capture in the options page save handler. Since the button contains child `<span>` elements, `textContent` can include extra whitespace from the DOM structure. Trimming ensures the captured text matches what the user sees and is correctly restored after save/validation operations.

Fixes #431

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## Testing

- `npm run type-check` — passes
- `npm run lint` — passes
- `npm run build` — passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the save button label handling to ensure text is properly preserved and restored after settings are saved, with better support for edge cases where button text may be empty or missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->