### PR TITLE
fix: unbounded storage growth from legacy data and absent quota enforcement

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1188,9 +1188,23 @@ async function savePendingSession() {
     await savePendingMeetingSession(chrome.storage.local, session);
   } catch (err) {
     console.error("[LateMeet] Failed to save pending session:", err);
+
     if (isStorageQuotaError(err)) {
+      try {
+        const sessions = await getSavedMeetingSessions(chrome.storage.local);
+        if (sessions.length > 0) {
+          const oldest = sessions[sessions.length - 1];
+          await deleteSavedMeetingSession(chrome.storage.local, oldest.id);
+          console.log("[LateMeet] Evicted oldest session to free quota:", oldest.id);
+          await savePendingMeetingSession(chrome.storage.local, session);
+          return;
+        }
+      } catch (recoveryErr) {
+        console.error("[LateMeet] Quota recovery failed:", recoveryErr);
+      }
+
       console.error(
-        "[LateMeet] Storage quota reached while saving pending session. Keep this extension active and export the session before closing Chrome.",
+        "[LateMeet] Storage quota reached while saving pending session and recovery failed.",
       );
     }
   }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,6 +5,7 @@
   "description": "AI meeting copilot for Google Meet with local-first transcription and summaries",
   "permissions": [
     "storage",
+    "unlimitedStorage",
     "tabs",
     "tabCapture",
     "contextMenus",

--- a/src/sessionStorage.ts
+++ b/src/sessionStorage.ts
@@ -81,7 +81,9 @@ async function pruneSessionsForQuota(
     if (session) pruned.push(session);
   }
 
-  let currentBytes = await getBytesInUse(storage, null);
+  // Measure only session-related keys, not all of chrome.storage.local
+  const sessionKeys = [SAVED_SESSION_INDEX_KEY, ...index.map((s) => getSavedSessionKey(s.id))];
+  let currentBytes = await getBytesInUse(storage, sessionKeys);
   while (
     currentBytes > 0 &&
     currentBytes + incomingBytes > STORAGE_SOFT_LIMIT_BYTES &&
@@ -158,6 +160,11 @@ export async function persistMeetingSession(
     [sessionKey]: pendingSession,
     [SAVED_SESSION_INDEX_KEY]: nextIndex,
   });
+
+  // One-time cleanup: remove legacy sessions key after successful migration
+  if (Array.isArray(values[SAVED_SESSIONS_LEGACY_KEY])) {
+    await storage.remove(SAVED_SESSIONS_LEGACY_KEY);
+  }
 
   return pendingSession;
 }


### PR DESCRIPTION
## Description

The session storage system exhibits three independent dimensions of unbounded growth:

1. **Legacy data orphan** — `SAVED_SESSIONS_LEGACY_KEY` is read and converted on every invocation but never deleted after migration, permanently occupying storage with invisible entries.
2. **Inaccurate byte-based pruning** — `pruneSessionsForQuota()` uses `getBytesInUse(storage, null)` measuring all `chrome.storage.local` data (settings, credentials, cached state), not just session data. Non-session data inflates the byte counter, masking true session utilization.
3. **Absent quota error recovery** — `savePendingSession()` catches quota errors but only logs them, permanently losing the current meeting's session data.

**Changes:**
- `persistMeetingSession()` removes `SAVED_SESSIONS_LEGACY_KEY` after successful migration to the indexed format (one-time cleanup).
- `pruneSessionsForQuota()` measures only session-related keys (`SAVED_SESSION_INDEX_KEY` + `savedSession:*` payload keys) instead of the entire storage area.
- `savePendingSession()` recovers from quota errors by evicting the oldest indexed session and retrying the write once before propagating failure.
- Added `"unlimitedStorage"` permission to `manifest.json`.

Fixes #450

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings