### PR TITLE
feat: enable markdown, json & txt export in dashboard

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -617,6 +617,30 @@
             </svg>
             Download .md File
           </button>
+          <button class="export-option" id="export-txt-btn" role="menuitem">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="icon"
+              style="margin-right: 8px"
+            >
+              <path
+                d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"
+              ></path>
+              <polyline points="14 2 14 8 20 8"></polyline>
+              <line x1="16" x2="8" y1="13" y2="13"></line>
+              <line x1="16" x2="8" y1="17" y2="17"></line>
+              <line x1="10" x2="8" y1="9" y2="9"></line>
+            </svg>
+            Download .txt File
+          </button>
           <button class="export-option" id="export-json-btn" role="menuitem">
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -881,6 +881,24 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 
+  document.getElementById("export-txt-btn")?.addEventListener("click", async () => {
+    try {
+      const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });
+      if (!state) throw new Error("No meeting data available");
+      const markdown = generateMarkdown(state);
+      // Strip some basic markdown to make it plain text
+      const plainText = markdown.replace(/[*#_]/g, "").trim();
+      const filename = `meeting-summary-${new Date().toISOString().slice(0, 10)}.txt`;
+      downloadFile(plainText, filename, "text/plain");
+      showToast("Downloaded as .txt file", "success");
+    } catch (err) {
+      showToast("Failed to export: " + (err instanceof Error ? err.message : String(err)), "error");
+    } finally {
+      exportDropdown?.setAttribute("hidden", "");
+      exportBtn?.setAttribute("aria-expanded", "false");
+    }
+  });
+
   document.getElementById("export-clipboard-btn")?.addEventListener("click", async () => {
     try {
       const state = await chrome.runtime.sendMessage({ type: "GET_STATE" });


### PR DESCRIPTION
## What changed
Added a plain-text format (`.txt`) export option alongside Markdown and JSON in the dashboard (`dashboard.ts` and `dashboard.html`).

## Why it changed
To provide more versatile backup and export options for users who prefer raw text files.

## How it was tested
Tested locally by running `npm run build` and manually verifying the export buttons in the dashboard.

Fixes #467