### PR TITLE
perf: optimize tab switching logic in dashboard

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -166,14 +166,24 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   }
 
-  tabs.forEach((tab) => {
-    tab.addEventListener("click", () => {
-      const tabId = (tab as HTMLElement).dataset.tab;
+  const tabContainer = document.querySelector(".dash-tabs");
+  if (tabContainer) {
+    tabContainer.addEventListener("click", (e) => {
+      const target = e.target as HTMLElement;
+      const tab = target.closest(".dash-tab") as HTMLElement | null;
+      if (!tab) return;
+
+      const tabId = tab.dataset.tab;
       if (!tabId) return;
 
-      tabs.forEach((t) => t.classList.remove("active"));
+      tabs.forEach((t) => {
+        t.classList.remove("active");
+        t.setAttribute("aria-selected", "false");
+      });
       panels.forEach((p) => p.classList.remove("active"));
-      (tab as HTMLElement).classList.add("active");
+
+      tab.classList.add("active");
+      tab.setAttribute("aria-selected", "true");
 
       const panel = document.getElementById(`tab-${tabId}`);
       if (panel) {
@@ -195,7 +205,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         }, 150);
       }
     });
-  });
+  }
 
   // ——— State Management ———
   let lastState: State | null = null;


### PR DESCRIPTION
## What changed
Refactored the `dash-tab` click listeners in `dashboard.ts` to use a single event delegation listener on `.dash-tabs`.

## Why it changed
To improve performance by reducing the number of event listeners and to create a cleaner, more maintainable code structure.

## How it was tested
Tested locally by running `npm run build` and verifying that tab switching and ARIA state updates continue to work seamlessly.

Fixes #473