### PR TITLE
fix: measure full sessions in storage dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/background.urlParsing.test.ts",
+    "test": "tsx --test src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/utils/storageUtils.test.ts
+++ b/src/utils/storageUtils.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSessionListItem,
+  getSavedSessionKey,
+  SAVED_SESSION_INDEX_KEY,
+  type StoredSession,
+} from "../sessionStorage";
+import { getStorageStats } from "./storageUtils";
+
+type Store = Record<string, unknown>;
+
+function makeSession(id: string, transcriptLength: number): StoredSession {
+  return {
+    id,
+    savedAt: 1_700_000_000_000,
+    isActive: false,
+    meetingId: `meet-${id}`,
+    meetingUrl: `https://meet.google.com/aaa-bbbb-${id.slice(0, 3).padEnd(3, "x")}`,
+    startTime: 1_700_000_000_000,
+    summary: `Summary ${id}`,
+    summaryItems: [],
+    topics: [],
+    decisions: [],
+    actionItems: [{ task: `Action ${id}` }],
+    currentTopic: "",
+    sentiment: "neutral",
+    keyInsights: [],
+    unresolvedDiscussions: [],
+    contradictions: [],
+    questionsRaised: [],
+    participants: [],
+    initialParticipants: [],
+    lateJoiners: [],
+    timeline: [{ event: "Meeting ended", timestamp: 1_700_000_000_000, elapsed: 60 }],
+    transcript: [
+      {
+        speaker: "Audio",
+        text: "x".repeat(transcriptLength),
+        timestamp: 0,
+      },
+    ],
+    audioActive: false,
+    duration: 60,
+  };
+}
+
+function storageBytes(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value ?? null)).byteLength;
+}
+
+function setupChromeStorage(store: Store) {
+  (globalThis as any).chrome = {
+    storage: {
+      local: {
+        async get(keys: string | string[] | null) {
+          if (keys === null) return { ...store };
+          const keyList = Array.isArray(keys) ? keys : [keys];
+          return keyList.reduce<Store>((result, key) => {
+            result[key] = store[key];
+            return result;
+          }, {});
+        },
+        async set(values: Store) {
+          Object.assign(store, values);
+        },
+        async remove(keys: string | string[]) {
+          const keyList = Array.isArray(keys) ? keys : [keys];
+          keyList.forEach((key) => delete store[key]);
+        },
+        getBytesInUse(keys: string | string[] | null, callback: (bytes: number) => void) {
+          const keyList = keys === null ? Object.keys(store) : Array.isArray(keys) ? keys : [keys];
+          const bytes = keyList.reduce((sum, key) => sum + storageBytes(store[key]), 0);
+          callback(bytes);
+        },
+      },
+    },
+  };
+}
+
+test("getStorageStats measures full indexed session payloads, not lightweight index items", async () => {
+  const smallSession = makeSession("small", 20);
+  const largeSession = makeSession("large", 5_000);
+  const store: Store = {
+    [SAVED_SESSION_INDEX_KEY]: [
+      createSessionListItem(smallSession),
+      createSessionListItem(largeSession),
+    ],
+    [getSavedSessionKey(smallSession.id)]: smallSession,
+    [getSavedSessionKey(largeSession.id)]: largeSession,
+  };
+  setupChromeStorage(store);
+
+  const stats = await getStorageStats();
+
+  assert.equal(stats.meetingCount, 2);
+  assert.equal(stats.largestMeetings[0].id, largeSession.id);
+  assert.ok(stats.transcriptBytes >= storageBytes(largeSession.transcript));
+  assert.ok(stats.largestMeetings[0].transcriptBytes >= storageBytes(largeSession.transcript));
+  assert.ok(stats.largestMeetings[0].totalBytes > stats.largestMeetings[1].totalBytes);
+});

--- a/src/utils/storageUtils.ts
+++ b/src/utils/storageUtils.ts
@@ -1,4 +1,4 @@
-import { getSavedMeetingSessions } from "../sessionStorage";
+import { getSavedMeetingSession, getSavedMeetingSessions } from "../sessionStorage";
 import { StorageStats, MeetingStorageInfo } from "../types";
 
 const DEFAULT_QUOTA_BYTES = 10 * 1024 * 1024; // 10MB — chrome.storage.local default
@@ -15,8 +15,12 @@ export function formatBytes(bytes: number): string {
 }
 
 export async function getStorageStats(): Promise<StorageStats> {
-  // Reuse the existing helper to get all saved sessions
-  const sessions = await getSavedMeetingSessions(chrome.storage.local);
+  const sessionListItems = await getSavedMeetingSessions(chrome.storage.local);
+  const sessions = await Promise.all(
+    sessionListItems.map(async (session) => {
+      return (await getSavedMeetingSession(chrome.storage.local, session.id)) ?? session;
+    }),
+  );
 
   // Get everything in local storage to also measure settings + API keys
   const allItems = await chrome.storage.local.get(null);


### PR DESCRIPTION
## Summary

- Load full saved-session payloads before calculating storage dashboard breakdowns
- Ensure transcript bytes and largest-meeting ordering reflect `savedSession:<id>` data instead of lightweight index entries
- Add regression coverage for indexed sessions with stripped transcript data

## Fixes

Closes #485

## Testing

- `npm run type-check`
- `npm test`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for storage statistics functionality to validate data collection and calculations.

* **Chores**
  * Updated test script configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->