### PR TITLE
perf(#484): reduce waveform sendMessage frequency from 20/s to 10/s

### DIFF
--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -15,7 +15,10 @@ let isStopping = false;
 let isDrainingQueue = false;
 
 const VAD_SAMPLE_MS = 250;
-const WAVEFORM_INTERVAL_MS = 50;
+// Increased from 50ms (20x/sec) to 100ms (10x/sec)
+// to reduce unnecessary service worker wake-ups
+// and chrome.runtime.sendMessage calls
+const WAVEFORM_INTERVAL_MS = 100;
 const WAVEFORM_BUCKETS = 32;
 const WAVEFORM_GAIN = 6;
 const SILENCE_FLUSH_MS = 1500;


### PR DESCRIPTION
Closes #484

## Changes Made
- Increased WAVEFORM_INTERVAL_MS from 50ms to 100ms
- Reduces chrome.runtime.sendMessage calls from 
  20x/sec to 10x/sec
- Reduces unnecessary service worker wake-ups
- No visual impact — waveform still updates smoothly

## File Changed
- src/offscreen.ts — line 18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized waveform sampling frequency to reduce resource consumption and improve application performance and battery efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->