### PR TITLE
fix: use nextIndex in pruneSessionsForQuota

### DIFF
--- a/src/sessionStorage.ts
+++ b/src/sessionStorage.ts
@@ -82,7 +82,7 @@ async function pruneSessionsForQuota(
   }
 
   // Measure only session-related keys, not all of chrome.storage.local
-  const sessionKeys = [SAVED_SESSION_INDEX_KEY, ...index.map((s) => getSavedSessionKey(s.id))];
+  const sessionKeys = [SAVED_SESSION_INDEX_KEY, ...nextIndex.map((s) => getSavedSessionKey(s.id))];
   let currentBytes = await getBytesInUse(storage, sessionKeys);
   while (
     currentBytes > 0 &&


### PR DESCRIPTION
Closes #530 

**Description** 

Fixes a stale-reference bug in pruneSessionsForQuota, where the original index
parameter was used to measure current storage bytes instead of the already-trimmed
nextIndex. This caused the quota check to over-count usage (it included sessions
already marked for removal), which triggered unnecessary extra pruning and could
silently discard sessions that were still within the allowed limit.

**Root Cause**

In src/sessionStorage.ts, pruneSessionsForQuota runs two pruning passes:

A count-based pass that trims nextIndex down to MAX_SAVED_SESSIONS - 1.
A byte-based pass that removes sessions until storage fits under STORAGE_SOFT_LIMIT_BYTES.

The byte-based pass measured keys from the original index — not from nextIndex —
so sessions already removed in pass 1 were still included in the byte count.
This inflated currentBytes, making the condition currentBytes + incomingBytes > STORAGE_SOFT_LIMIT_BYTES
true more often than it should be, and causing extra sessions to be pruned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session storage quota management by correcting how storage usage is calculated during session pruning. The system now accurately measures storage consumption after initial session trimming, ensuring sessions are removed properly when approaching storage limits, preventing potential storage overflow issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->