### PR TITLE
fix(onboarding): correct relative redirect path to options.html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "@elevenlabs/elevenlabs-js": "^2.49.1",
-        "@openrouter/sdk": "^0.12.20"
+        "@elevenlabs/elevenlabs-js": "^2.49.1"
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0-beta.33",
@@ -869,16 +868,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@openrouter/sdk": {
-      "version": "0.12.79",
-      "resolved": "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.12.79.tgz",
-      "integrity": "sha512-0ZpwtnuHh3/B1piW9kHCUIQy6PAsaK/vjFdZuHxmCdAenCyUNsLA2mFpmfHNWRNb+bOO3yBc4IALa264UyzmBA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@oxc-project/types": {
@@ -4469,15 +4458,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -174,7 +174,7 @@ export async function renderOnboarding(container: HTMLElement) {
       finishBtn?.addEventListener("click", async () => {
         await chrome.storage.local.set({ onboardingCompleted: true });
         container.hidden = true;
-        location.href = "src/options.html";
+        location.href = "options.html";
       });
     }
   }
@@ -194,7 +194,7 @@ export async function renderOnboarding(container: HTMLElement) {
       // Finish
       await chrome.storage.local.set({ onboardingCompleted: true });
       container.hidden = true;
-      location.href = "src/options.html";
+      location.href = "options.html";
     }
   });
 
@@ -202,7 +202,7 @@ export async function renderOnboarding(container: HTMLElement) {
     if (confirm("Skip the onboarding? You can always view it later in Settings.")) {
       await chrome.storage.local.set({ onboardingCompleted: true });
       container.hidden = true;
-      location.href = "src/options.html";
+      location.href = "options.html";
     }
   });
 


### PR DESCRIPTION
## Description
Fixes a redirection bug where finishing or skipping the onboarding flow redirects the browser to a non-existent route (`/src/src/options.html`), throwing a 404 error.

## Changes
- Updated relative URLs from `"src/options.html"` to `"options.html"` on lines 177, 197, and 205 in [src/onboarding.ts](file:///d:/GSSOC/Late-Meet/src/onboarding.ts).

closes : #536 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected navigation behavior in the onboarding process. Users completing the onboarding, proceeding through the final step, or skipping the onboarding will now be properly redirected to the options page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->