### PR TITLE
fix: explicitly inject content script styles

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -1,4 +1,3 @@
-import "./content.css";
 import {
   collectParticipantNames,
   participantNameFromCandidate,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -26,6 +26,7 @@
     {
       "matches": ["https://meet.google.com/*"],
       "js": ["src/content.ts"],
+      "css": ["src/content.css"],
       "run_at": "document_idle"
     }
   ],


### PR DESCRIPTION
## Summary
- declare `src/content.css` in the Google Meet content script manifest entry
- remove the JavaScript-side CSS import so the content stylesheet has one explicit injection path

Fixes #557

## Verification
- `npm run build` passed
- `npm run type-check` passed
- `npm test` started successfully after sandbox escalation and many tests passed, but the run was terminated after it hung without new output in `src/utils/credentials.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved styling loading mechanism for better performance and extension compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->