### PR TITLE
fix: require vault unlock before saving onboarding API keys

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -136,11 +136,20 @@ export async function renderOnboarding(container: HTMLElement) {
         if (creds.elevenlabs_api_key) elevenInput.value = creds.elevenlabs_api_key;
       })();
 
-      async function ensureUnlocked(): Promise<boolean> {
-        if (isUnlocked()) return true;
+      type UnlockResult = { unlocked: true } | { unlocked: false; reason: "missing" | "wrong" };
+
+      async function ensureUnlocked(): Promise<UnlockResult> {
+        if (isUnlocked()) return { unlocked: true };
         const pass = passInput.value;
-        if (!pass) return false;
-        return await unlockCredentials(pass);
+        if (!pass) return { unlocked: false, reason: "missing" };
+        const ok = await unlockCredentials(pass);
+        return ok ? { unlocked: true } : { unlocked: false, reason: "wrong" };
+      }
+
+      function unlockFailureMessage(reason: "missing" | "wrong"): string {
+        return reason === "missing"
+          ? "Enter an encryption passphrase to save this API key."
+          : "Incorrect passphrase — please try again.";
       }
 
       valOpenBtn.addEventListener("click", async () => {
@@ -149,8 +158,9 @@ export async function renderOnboarding(container: HTMLElement) {
         try {
           const ok = await validateOpenAIKey(key);
           if (ok) {
-            if (!(await ensureUnlocked())) {
-              openaiStatus.textContent = "Enter an encryption passphrase to save this API key.";
+            const result = await ensureUnlocked();
+            if (!result.unlocked) {
+              openaiStatus.textContent = unlockFailureMessage(result.reason);
               return;
             }
             await saveApiCredentials({ openai_api_key: key });
@@ -169,8 +179,9 @@ export async function renderOnboarding(container: HTMLElement) {
         try {
           const ok = await validateElevenLabsKey(key);
           if (ok) {
-            if (!(await ensureUnlocked())) {
-              elevenStatus.textContent = "Enter an encryption passphrase to save this API key.";
+            const result = await ensureUnlocked();
+            if (!result.unlocked) {
+              elevenStatus.textContent = unlockFailureMessage(result.reason);
               return;
             }
             await saveApiCredentials({ elevenlabs_api_key: key });

--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -1,4 +1,9 @@
-import { getApiCredentials, saveApiCredentials } from "./utils/credentials";
+import {
+  getApiCredentials,
+  saveApiCredentials,
+  isUnlocked,
+  unlockCredentials,
+} from "./utils/credentials";
 import { validateOpenAIKey, validateElevenLabsKey } from "./utils/api";
 
 export async function renderOnboarding(container: HTMLElement) {
@@ -51,6 +56,10 @@ export async function renderOnboarding(container: HTMLElement) {
       html: `
         <h2>API Keys</h2>
         <p>Provide your OpenAI API key to enable summarization features. ElevenLabs is optional for TTS.</p>
+        <div class="form-group">
+          <label for="onb-passphrase">Encryption Passphrase</label>
+          <input id="onb-passphrase" type="password" class="form-input" placeholder="Create or enter passphrase..." />
+        </div>
         <div class="form-group">
           <label for="onb-openai">OpenAI API Key</label>
           <input id="onb-openai" class="form-input" placeholder="sk-xxxx" />
@@ -113,6 +122,7 @@ export async function renderOnboarding(container: HTMLElement) {
 
     // Wire validate/save controls if API step
     if (step.id === "api-keys") {
+      const passInput = container.querySelector<HTMLInputElement>("#onb-passphrase")!;
       const openaiInput = container.querySelector<HTMLInputElement>("#onb-openai")!;
       const elevenInput = container.querySelector<HTMLInputElement>("#onb-eleven")!;
       const openaiStatus = container.querySelector<HTMLDivElement>("#onb-openai-status")!;
@@ -126,14 +136,25 @@ export async function renderOnboarding(container: HTMLElement) {
         if (creds.elevenlabs_api_key) elevenInput.value = creds.elevenlabs_api_key;
       })();
 
+      async function ensureUnlocked(): Promise<boolean> {
+        if (isUnlocked()) return true;
+        const pass = passInput.value;
+        if (!pass) return false;
+        return await unlockCredentials(pass);
+      }
+
       valOpenBtn.addEventListener("click", async () => {
         openaiStatus.textContent = "Validating...";
         const key = openaiInput.value.trim();
         try {
           const ok = await validateOpenAIKey(key);
           if (ok) {
-            openaiStatus.textContent = "Valid OpenAI key — saved.";
+            if (!(await ensureUnlocked())) {
+              openaiStatus.textContent = "Enter an encryption passphrase to save this API key.";
+              return;
+            }
             await saveApiCredentials({ openai_api_key: key });
+            openaiStatus.textContent = "Valid OpenAI key — saved.";
           } else {
             openaiStatus.textContent = "Invalid OpenAI key.";
           }
@@ -148,8 +169,12 @@ export async function renderOnboarding(container: HTMLElement) {
         try {
           const ok = await validateElevenLabsKey(key);
           if (ok) {
-            elevenStatus.textContent = "Valid ElevenLabs key — saved.";
+            if (!(await ensureUnlocked())) {
+              elevenStatus.textContent = "Enter an encryption passphrase to save this API key.";
+              return;
+            }
             await saveApiCredentials({ elevenlabs_api_key: key });
+            elevenStatus.textContent = "Valid ElevenLabs key — saved.";
           } else {
             elevenStatus.textContent = "Invalid ElevenLabs key.";
           }


### PR DESCRIPTION
## Description

Fixes #560

During onboarding, OpenAI and ElevenLabs API keys could be validated successfully but fail to save because the credential vault had not yet been initialized or unlocked.

This PR fixes the issue by:

- Adding an encryption passphrase field to the onboarding API Keys step
- Ensuring credentials are unlocked or initialized before calling `saveApiCredentials()`
- Preventing valid API keys from failing to persist during first-time setup
- Reusing the existing credential management flow through `unlockCredentials()` and `isUnlocked()`

The change is limited to the onboarding flow and does not modify the underlying credential encryption or storage implementation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### Testing

- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm test`

Results:
- TypeScript: Passed
- ESLint: Passed (only pre-existing warnings)
- Tests: Passed (99/99)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an encryption passphrase field to API key setup during onboarding.
  * API keys are now saved only after credentials are unlocked with the passphrase.
  * API key validation for OpenAI and ElevenLabs now requires successful passphrase authentication.
  * Improved protection for stored credentials with passphrase-gated saving and clear status messages on failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->