### PR TITLE
fix: add ElevenLabs API key validation before starting audio capture

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -210,6 +210,19 @@ document.addEventListener("DOMContentLoaded", async () => {
       return;
     }
 
+    // Check if ElevenLabs API key exists before starting
+    const creds = await getApiCredentials();
+    if (!creds.elevenlabs_api_key) {
+      if (textEl) {
+        textEl.textContent = "⚠️ Missing ElevenLabs Key";
+        setTimeout(() => {
+          if (textEl) textEl.textContent = originalText;
+        }, 2000);
+      }
+      return; // Stop here - don't start recording
+    }
+    // ========== END OF ADDED CODE ==========
+
     try {
       // Show loading state
       btn.disabled = true;


### PR DESCRIPTION
## Description
Added validation in `src/popup.ts` to check for ElevenLabs API key before starting audio recording. If key is missing, shows "⚠️ Missing ElevenLabs Key" warning and prevents recording.

## Type of Change
- [x] Bug fix

## Testing
- Tested with missing ElevenLabs key → warning appears, recording blocked
- Tested with both keys present → recording starts normally

## Related Issue
Fixes #564 

## Checklist
- [x] My code follows the project style
- [x] I have tested my changes

## GSSoC 2026
This PR is submitted under GSSoC 2026. Please add the `gssoc` label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced audio capture with a preflight validation check for the ElevenLabs API key. When the key is missing, users receive clear feedback via a temporary message. This prevents recording from starting without proper configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->