### PR TITLE
fix: constrain HSL range in isValidAccent to valid CSS values

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -24,17 +24,25 @@ function resolveTheme(theme: ThemeMode): "light" | "dark" {
   return theme;
 }
 
+function isValidHslComponent(hue: string, sat: string, light: string): boolean {
+  const h = parseInt(hue, 10);
+  const s = parseInt(sat, 10);
+  const l = parseInt(light, 10);
+  return h >= 0 && h <= 360 && s >= 0 && s <= 100 && l >= 0 && l <= 100;
+}
+
 export function isValidAccent(value: string): boolean {
   const accent = value.trim();
-  return (
-    /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(accent) ||
-    /^(360|3[0-5]\d|[12]\d{2}|0*[1-9]\d|0*\d)\s*,\s*(100|0*[1-9]\d|0*\d)%\s*,\s*(100|0*[1-9]\d|0*\d)%$/.test(
-      accent,
-    ) ||
-    /^(360|3[0-5]\d|[12]\d{2}|0*[1-9]\d|0*\d)\s+(100|0*[1-9]\d|0*\d)%\s+(100|0*[1-9]\d|0*\d)%$/.test(
-      accent,
-    )
-  );
+
+  if (/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(accent)) return true;
+
+  const commaMatch = accent.match(/^(\d{1,3})\s*,\s*(\d{1,3})%\s*,\s*(\d{1,3})%$/);
+  if (commaMatch) return isValidHslComponent(commaMatch[1], commaMatch[2], commaMatch[3]);
+
+  const spaceMatch = accent.match(/^(\d{1,3})\s+(\d{1,3})%\s+(\d{1,3})%$/);
+  if (spaceMatch) return isValidHslComponent(spaceMatch[1], spaceMatch[2], spaceMatch[3]);
+
+  return false;
 }
 
 function normalizeSettings(raw: unknown): Settings {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -28,7 +28,9 @@ export function isValidAccent(value: string): boolean {
   const accent = value.trim();
   return (
     /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(accent) ||
-    /^\d{1,3}\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%$/.test(accent) ||
+    /^(360|3[0-5]\d|[12]\d{2}|[1-9]\d|\d)\s*,\s*(100|[1-9]\d|\d)%\s*,\s*(100|[1-9]\d|\d)%$/.test(
+      accent,
+    ) ||
     /^\d{1,3}\s+\d{1,3}%\s+\d{1,3}%$/.test(accent)
   );
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -28,10 +28,12 @@ export function isValidAccent(value: string): boolean {
   const accent = value.trim();
   return (
     /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(accent) ||
-    /^(360|3[0-5]\d|[12]\d{2}|[1-9]\d|\d)\s*,\s*(100|[1-9]\d|\d)%\s*,\s*(100|[1-9]\d|\d)%$/.test(
+    /^(360|3[0-5]\d|[12]\d{2}|0*[1-9]\d|0*\d)\s*,\s*(100|0*[1-9]\d|0*\d)%\s*,\s*(100|0*[1-9]\d|0*\d)%$/.test(
       accent,
     ) ||
-    /^\d{1,3}\s+\d{1,3}%\s+\d{1,3}%$/.test(accent)
+    /^(360|3[0-5]\d|[12]\d{2}|0*[1-9]\d|0*\d)\s+(100|0*[1-9]\d|0*\d)%\s+(100|0*[1-9]\d|0*\d)%$/.test(
+      accent,
+    )
   );
 }
 


### PR DESCRIPTION
Closes #566 

## Description

Fixes isValidAccent in src/theme.ts which accepted out-of-range HSL values like 999, 200%, 300%. The original regex only checked that each component was 1–3 digits — it never constrained hue to 0–360 or saturation/lightness to 0–100. A malformed value passed validation and was injected directly into the --accent-color CSS custom property, silently breaking the theme with no error.

## Root Cause

The original regex used \d{1,3} to match each HSL component, which permits any 1–3 digit number. CSS only accepts hue in 0–360 and saturation/lightness in 0–100. A malformed value passed validation and was injected directly into --accent-color, silently breaking the theme.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accent colors now support comma-separated numeric values (hue and percentage components) in addition to existing formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->