### PR TITLE
fix: add cancel() and proper types to debounceSpeakerAttribution

### DIFF
--- a/src/speakerAttribution.ts
+++ b/src/speakerAttribution.ts
@@ -12,11 +12,26 @@ export function resolveTranscriptSpeaker(value: string | null | undefined): stri
   return normalizeActiveSpeakerName(value) || DEFAULT_TRANSCRIPT_SPEAKER;
 }
 
-// Speaker detection debouncing utility
-export function debounceSpeakerAttribution(callback: (...args: any[]) => void, delay: number) {
-  let timer: any = null;
-  return (...args: any[]) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => callback(...args), delay);
+export function debounceSpeakerAttribution<T extends (...args: unknown[]) => void>(
+  callback: T,
+  delay: number,
+): { invoke: (...args: Parameters<T>) => void; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const invoke = (...args: Parameters<T>) => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      callback(...args);
+    }, delay);
   };
+
+  const cancel = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+
+  return { invoke, cancel };
 }


### PR DESCRIPTION
Closes #567  

## Description

Fixes debounceSpeakerAttribution in src/speakerAttribution.ts, which used any types for both the callback and the internal timer, and returned no cancel() method. Without cancel(), callers cannot clear the pending timeout when recording stops, or a component unmounts — the callback fires on stale state, causing incorrect speaker attributions and potential memory leaks.

## Root Cause
The debounce utility lost type safety through any and did not expose a way to cancel the pending timer, which is essential for cleanup in an extension context where recording can stop at any time.

