### PR TITLE
fix: make late-joiner briefings private by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts",
+    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts src/lateJoinerDelivery.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/background.ts
+++ b/src/background.ts
@@ -482,6 +482,7 @@ interface Settings {
   aiModel?: string;
   vadThreshold?: number;
   lateJoinerBriefing?: boolean;
+  publicLateJoinerChat?: boolean;
   topicDetection?: boolean;
   decisionDetection?: boolean;
   actionExtraction?: boolean;
@@ -1131,6 +1132,18 @@ async function sendChatToTab(tabId: number, text: string) {
   }
 }
 
+async function showPrivateBriefToTab(tabId: number, briefContent: string, targetName: string) {
+  try {
+    await chrome.tabs.sendMessage(tabId, {
+      type: "SHOW_BRIEF",
+      briefContent,
+      targetName,
+    });
+  } catch (err) {
+    console.error("[LateMeet] Failed to show private late-joiner brief:", err);
+  }
+}
+
 async function maybeWelcomeJoiners(tabId: number | undefined, joiners: string[]) {
   if (!joiners.length || getDuration() <= MIN_MEETING_DURATION_FOR_WELCOME || !tabId) {
     return;
@@ -1166,7 +1179,10 @@ async function maybeWelcomeJoiners(tabId: number | undefined, joiners: string[])
 
     try {
       const text = await generateLateJoinerMessage(name);
-      await sendChatToTab(tabId, text);
+      await showPrivateBriefToTab(tabId, text, name);
+      if (settings.publicLateJoinerChat === true) {
+        await sendChatToTab(tabId, text);
+      }
     } catch (err) {
       console.error("[LateMeet] Failed to welcome joiner:", err);
     } finally {

--- a/src/lateJoinerDelivery.test.ts
+++ b/src/lateJoinerDelivery.test.ts
@@ -141,38 +141,38 @@ async function sendMessage(message: any) {
 installChromeMock();
 await import("./background.ts");
 
-test("late-joiner briefing uses private overlay by default", async () => {
+test("late-joiner workflow: Bob joins (private-only), then Carol joins (with public chat)", async () => {
+  // Step 1 — Bob joins while public chat is disabled; only private overlay expected.
   tabMessages = [];
   settings = { lateJoinerBriefing: true, publicLateJoinerChat: false };
 
-  const response = await sendMessage({
+  const response1 = await sendMessage({
     type: "PARTICIPANTS_UPDATED",
     participants: ["Alice", "Bob"],
     selfName: "Alice",
   });
 
-  assert.equal(response.success, true);
-  assert.deepEqual(response.joiners, ["Bob"]);
+  assert.equal(response1.success, true);
+  assert.deepEqual(response1.joiners, ["Bob"]);
   assert.equal(tabMessages.length, 1);
   assert.equal(tabMessages[0].tabId, 7);
   assert.equal(tabMessages[0].message.type, "SHOW_BRIEF");
   assert.equal(tabMessages[0].message.targetName, "Bob");
   assert.match(tabMessages[0].message.briefContent, /Bob/i);
-});
 
-test("late-joiner briefing posts to public chat only when explicitly enabled", async () => {
+  // Step 2 — Carol joins after public chat is opted in; both overlay and chat message expected.
+  // Bob is already a known participant from step 1, so only Carol is detected as a new joiner.
   tabMessages = [];
   settings = { lateJoinerBriefing: true, publicLateJoinerChat: true };
 
-  const response = await sendMessage({
+  const response2 = await sendMessage({
     type: "PARTICIPANTS_UPDATED",
     participants: ["Alice", "Bob", "Carol"],
     selfName: "Alice",
   });
 
-  assert.equal(response.success, true);
-  assert.deepEqual(response.joiners, ["Carol"]);
-
+  assert.equal(response2.success, true);
+  assert.deepEqual(response2.joiners, ["Carol"]);
   assert.deepEqual(
     tabMessages.map((entry) => entry.message.type),
     ["SHOW_BRIEF", "SEND_CHAT_MESSAGE"],

--- a/src/lateJoinerDelivery.test.ts
+++ b/src/lateJoinerDelivery.test.ts
@@ -1,0 +1,182 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+type RuntimeMessageCallback = (
+  message: any,
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response?: any) => void,
+) => boolean | void;
+
+const activeMeetingState = {
+  isActive: true,
+  meetingId: "abc-defg-hij",
+  meetingUrl: "https://meet.google.com/abc-defg-hij",
+  startTime: Date.now() - 20_000,
+  summary: "Project status reviewed.",
+  summaryItems: [],
+  topics: [],
+  decisions: [],
+  actionItems: [],
+  currentTopic: "release planning",
+  sentiment: "neutral",
+  keyInsights: [],
+  unresolvedDiscussions: [],
+  contradictions: [],
+  questionsRaised: [],
+  participants: ["Alice"],
+  initialParticipants: ["Alice"],
+  lateJoiners: [],
+  timeline: [],
+  transcript: [],
+  audioActive: true,
+  currentSpeaker: null,
+  targetTabId: 7,
+  lastSummarizedAt: 0,
+  participantCount: 1,
+};
+
+let settings: Record<string, unknown> = {
+  lateJoinerBriefing: true,
+  publicLateJoinerChat: false,
+};
+let onMessage: RuntimeMessageCallback | null = null;
+let tabMessages: Array<{ tabId: number; message: any }> = [];
+
+function installChromeMock() {
+  if (typeof (globalThis as any).addEventListener !== "function") {
+    (globalThis as any).addEventListener = () => {};
+  }
+  (globalThis as any).self = globalThis;
+  (globalThis as any).chrome = {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://late-meet/${path}`,
+      getContexts: async () => [],
+      sendMessage: async () => undefined,
+      onMessage: {
+        addListener: (callback: RuntimeMessageCallback) => {
+          onMessage = callback;
+        },
+      },
+      onInstalled: { addListener: () => {} },
+      onStartup: { addListener: () => {} },
+    },
+    alarms: {
+      onAlarm: { addListener: () => {} },
+      create: () => {},
+    },
+    tabs: {
+      onUpdated: { addListener: () => {} },
+      onActivated: { addListener: () => {} },
+      onRemoved: { addListener: () => {} },
+      query: async () => [],
+      get: async () => ({}),
+      sendMessage: async (tabId: number, message: any) => {
+        tabMessages.push({ tabId, message });
+        return { success: true };
+      },
+    },
+    commands: {
+      onCommand: { addListener: () => {} },
+    },
+    contextMenus: {
+      onClicked: { addListener: () => {} },
+      removeAll: (callback?: () => void) => callback?.(),
+      create: () => {},
+    },
+    sidePanel: {
+      open: async () => {},
+    },
+    offscreen: {
+      createDocument: async () => {},
+      closeDocument: async () => {},
+    },
+    storage: {
+      local: {
+        get: async (key?: string | string[] | null) => {
+          if (key === "activeMeetingState") return { activeMeetingState };
+          if (key === "settings") return { settings };
+          if (Array.isArray(key)) {
+            return Object.fromEntries(
+              key.map((item) => [
+                item,
+                item === "activeMeetingState"
+                  ? activeMeetingState
+                  : item === "settings"
+                    ? settings
+                    : undefined,
+              ]),
+            );
+          }
+          return {};
+        },
+        set: async () => {},
+        remove: async () => {},
+      },
+      session: {
+        get: async () => ({}),
+        set: async () => {},
+        remove: async () => {},
+      },
+    },
+  };
+}
+
+async function sendMessage(message: any) {
+  assert.ok(onMessage, "background onMessage listener should be registered");
+
+  return new Promise<any>((resolve) => {
+    onMessage!(
+      message,
+      {
+        tab: {
+          id: 7,
+          url: "https://meet.google.com/abc-defg-hij",
+        } as chrome.tabs.Tab,
+      },
+      resolve,
+    );
+  });
+}
+
+installChromeMock();
+await import("./background.ts");
+
+test("late-joiner briefing uses private overlay by default", async () => {
+  tabMessages = [];
+  settings = { lateJoinerBriefing: true, publicLateJoinerChat: false };
+
+  const response = await sendMessage({
+    type: "PARTICIPANTS_UPDATED",
+    participants: ["Alice", "Bob"],
+    selfName: "Alice",
+  });
+
+  assert.equal(response.success, true);
+  assert.deepEqual(response.joiners, ["Bob"]);
+  assert.equal(tabMessages.length, 1);
+  assert.equal(tabMessages[0].tabId, 7);
+  assert.equal(tabMessages[0].message.type, "SHOW_BRIEF");
+  assert.equal(tabMessages[0].message.targetName, "Bob");
+  assert.match(tabMessages[0].message.briefContent, /Bob/i);
+});
+
+test("late-joiner briefing posts to public chat only when explicitly enabled", async () => {
+  tabMessages = [];
+  settings = { lateJoinerBriefing: true, publicLateJoinerChat: true };
+
+  const response = await sendMessage({
+    type: "PARTICIPANTS_UPDATED",
+    participants: ["Alice", "Bob", "Carol"],
+    selfName: "Alice",
+  });
+
+  assert.equal(response.success, true);
+  assert.deepEqual(response.joiners, ["Carol"]);
+
+  assert.deepEqual(
+    tabMessages.map((entry) => entry.message.type),
+    ["SHOW_BRIEF", "SEND_CHAT_MESSAGE"],
+  );
+  assert.equal(tabMessages[0].message.targetName, "Carol");
+  assert.match(tabMessages[1].message.text, /Carol/i);
+});

--- a/src/options.html
+++ b/src/options.html
@@ -384,11 +384,28 @@
             <div>
               <div class="toggle-label">Late Joiner Briefing</div>
               <div class="toggle-hint">
-                Automatically generate and send context briefs to late joiners
+                Automatically generate a private local context brief when someone joins late
               </div>
             </div>
             <label class="toggle-switch">
               <input type="checkbox" id="late-joiner-toggle" checked />
+              <span class="toggle-slider"></span>
+            </label>
+          </div>
+
+          <div class="toggle-item">
+            <div>
+              <div class="toggle-label">Public Chat Briefings</div>
+              <div class="toggle-hint">
+                Also post late-joiner briefs into Google Meet chat for everyone to see
+              </div>
+            </div>
+            <label class="toggle-switch">
+              <input
+                type="checkbox"
+                id="public-late-joiner-chat-toggle"
+                aria-label="Public Chat Briefings"
+              />
               <span class="toggle-slider"></span>
             </label>
           </div>

--- a/src/options.ts
+++ b/src/options.ts
@@ -12,6 +12,7 @@ interface Settings {
   vadThreshold?: number;
   aiModel?: string;
   lateJoinerBriefing?: boolean;
+  publicLateJoinerChat?: boolean;
   topicDetection?: boolean;
   decisionDetection?: boolean;
   actionExtraction?: boolean;
@@ -115,6 +116,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   // Feature toggles
   const toggles = [
     { id: "late-joiner-toggle", key: "lateJoinerBriefing" },
+    { id: "public-late-joiner-chat-toggle", key: "publicLateJoinerChat" },
     { id: "topic-toggle", key: "topicDetection" },
     { id: "decision-toggle", key: "decisionDetection" },
     { id: "action-toggle", key: "actionExtraction" },
@@ -123,7 +125,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   ];
 
   // Keys that default to off (opt-in features)
-  const defaultOffKeys = new Set(["transcriptRefinement"]);
+  const defaultOffKeys = new Set(["publicLateJoinerChat", "transcriptRefinement"]);
 
   toggles.forEach((t) => {
     const el = document.getElementById(t.id) as HTMLInputElement | null;
@@ -312,6 +314,9 @@ document.addEventListener("DOMContentLoaded", async () => {
         aiModel: (document.getElementById("ai-model") as HTMLSelectElement)?.value,
         lateJoinerBriefing: (document.getElementById("late-joiner-toggle") as HTMLInputElement)
           ?.checked,
+        publicLateJoinerChat: (
+          document.getElementById("public-late-joiner-chat-toggle") as HTMLInputElement
+        )?.checked,
         topicDetection: (document.getElementById("topic-toggle") as HTMLInputElement)?.checked,
         decisionDetection: (document.getElementById("decision-toggle") as HTMLInputElement)
           ?.checked,


### PR DESCRIPTION
  ## Description  

This PR fixes a real privacy concern that was lurking in the late-joiner briefing feature.

  What was happening: When someone joined a meeting late, the app would automatically generate a briefing with meeting
   context (summaries, decisions, action items) and post it directly into the public Google Meet chat visible to
  every single participant in the room. This happened silently, without any confirmation from the user, even though
  the codebase already had a perfectly good private overlay path (SHOW_BRIEF) that wasn't being used for this flow.

  What this PR does: Routes late-joiner briefings through the private overlay path by default, so the catch-up message
   shows only to the current user as a local overlay not blasted into the public chat. Public chat posting is now a
  separate, explicit opt-in (publicLateJoinerChat: true in settings).

##  Changes in a nutshell:
  - maybeWelcomeJoiners() now calls showPrivateBriefToTab() (new helper) instead of sendChatToTab() by default
  - Added publicLateJoinerChat?: boolean to the Settings interface public posting only happens when this is
  explicitly enabled
  - Added showPrivateBriefToTab() which sends the SHOW_BRIEF message to the content script for private overlay
  rendering
  - Added tests covering both delivery paths: private-only by default, public chat only when opted in

Fixes #558

##  Type of Change

  - Bug fix (non-breaking change which fixes an issue)


##  Checklist:

  - My code follows the style guidelines of this project
  - I have performed a self-review of my own code
  - I have commented my code, particularly in hard-to-understand areas
  - My changes generate no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Late-joiner briefings are now always delivered privately to the meeting tab; posting the briefing into Meet chat is controlled by a new toggle.

* **Documentation**
  * Updated late-joiner briefing description to clarify private local delivery and the new public-chat toggle.

* **Tests**
  * Added end-to-end tests covering private briefing delivery and optional public chat posting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->