### PR TITLE
fix: add focus-visible style and tabindex to floating "Start Copilot" button

### DIFF
--- a/src/content.css
+++ b/src/content.css
@@ -28,7 +28,11 @@
 #mc-float-btn:hover {
   transform: translateY(-2px) scale(1.05);
 }
-
+#mc-float-btn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3.5px #8ec0fe;
+  border-radius: 16px;
+}
 #mc-float-btn:hover .mc-float-label {
   opacity: 1;
   transform: translateX(0);

--- a/src/content.css
+++ b/src/content.css
@@ -29,7 +29,8 @@
   transform: translateY(-2px) scale(1.05);
 }
 #mc-float-btn:focus-visible {
-  outline: none;
+  outline: 2px solid #8ec0fe;
+  outline-offset: 2px;
   box-shadow: 0 0 0 3.5px #8ec0fe;
   border-radius: 16px;
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -535,6 +535,7 @@ initTheme();
     btn.id = "mc-float-btn";
     btn.type = "button";
     btn.setAttribute("aria-label", "Start Late Meet Copilot");
+    btn.setAttribute("tabindex", "0");
 
     const inner = document.createElement("div");
     inner.className = "mc-float-btn-inner";


### PR DESCRIPTION
## Description
Added `:focus-visible` style and explicit `tabindex="0"` to the floating 
"Start Copilot" button (#mc-float-btn) injected into Google Meet pages.

- `src/content.ts`: added `tabindex="0"` alongside the existing `aria-label` 
  assignment so the button has a stable, predictable position in the tab order
- `src/content.css`: added `:focus-visible` rule with a light blue box-shadow 
  ring so keyboard users get a clear visual indicator when the button is focused

## Before

<img width="1568" height="740" alt="image" src="https://github.com/user-attachments/assets/36144425-1749-436f-824e-1b27cf4a929b" />

## After 

<img width="1913" height="913" alt="image" src="https://github.com/user-attachments/assets/5c7df0d9-0b50-4f77-b7ae-9c568071ddd6" />

Fixes #568

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The floating dashboard button is now keyboard-accessible. Users can navigate to and interact with the button using keyboard controls. Visual focus indicators provide clear feedback when the button receives keyboard focus, enhancing accessibility for keyboard users and offering alternative interaction options beyond mouse or touch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->