### PR TITLE
security: purge plaintext session keys when credentials are locked

### DIFF
--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -109,6 +109,15 @@ export function lockCredentials(): void {
     clearTimeout(autoLockTimer);
     autoLockTimer = null;
   }
+  // Purge plaintext API keys from session storage on lock.
+  // The session store holds decrypted keys for fast access (avoids re-deriving
+  // the PBKDF2 key on every lookup). If we only clear the in-memory derivedKey
+  // but leave the session store intact, an attacker who gains access to
+  // chrome.storage.session after lock expiry can still read the raw keys
+  // without knowing the passphrase.
+  chrome.storage.session.remove(CREDENTIAL_KEYS as unknown as string[]).catch((err) => {
+    console.warn("[LateMeet][credentials] Failed to purge session keys on lock:", err);
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #589

Closes the **credential leak window** created by the 30-minute auto-lock feature: when `lockCredentials()` fires, the in-memory `derivedKey` is cleared but the plaintext API keys in `chrome.storage.session` were previously left untouched.

## Root Cause

`getApiCredentials()` syncs decrypted keys back to `chrome.storage.session` (line 231 in `credentials.ts`) for fast subsequent access. This is correct — but `lockCredentials()` did not clean up those session-stored plaintext values, leaving them accessible after lock.

## Change

### `src/utils/credentials.ts`
- Added `chrome.storage.session.remove(CREDENTIAL_KEYS)` call inside `lockCredentials()`
- The async call is fire-and-catch (errors logged but not re-thrown) — guarantees lock state is always committed
- Added an inline comment explaining the attack surface

## Testing

- [x] `npm run build` — ✅ clean build
- [x] Existing credential tests pass (`npm test`)
- [x] Verified `lockCredentials()` still synchronously clears `derivedKey` before the async remove

## Contribution Note

> I am contributing on behalf of **GSSoc'26** 🚀