### PR TITLE
security: tighten content security policy in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -71,6 +71,6 @@
     }
   },
   "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'self';"
+    "extension_pages": "default-src 'none'; script-src 'self'; style-src 'self'; connect-src https://api.openai.com https://api.elevenlabs.io; img-src 'self' data:; font-src 'self' data:; object-src 'none';"
   }
 }


### PR DESCRIPTION
Resolves #593

I am contributing on behalf of **GSSoc'26** 🚀

### Changes Proposed:
- Restrict Content Security Policy (CSP) in `manifest.json` under `extension_pages` to block unauthorized connections and resource loading.
- Configured:
  - `default-src 'none'`
  - `script-src 'self'`
  - `style-src 'self'`
  - `connect-src https://api.openai.com https://api.elevenlabs.io`
  - `img-src 'self' data:`
  - `font-src 'self' data:`
  - `object-src 'none'`