### PR TITLE
perf: reduce storage read query count from O(N) to O(1) in getStorageStats

### DIFF
--- a/src/utils/storageUtils.ts
+++ b/src/utils/storageUtils.ts
@@ -1,4 +1,3 @@
-import { getSavedMeetingSession, getSavedMeetingSessions } from "../sessionStorage";
 import { StorageStats, MeetingStorageInfo } from "../types";
 
 const DEFAULT_QUOTA_BYTES = 10 * 1024 * 1024; // 10MB — chrome.storage.local default
@@ -15,15 +14,34 @@ export function formatBytes(bytes: number): string {
 }
 
 export async function getStorageStats(): Promise<StorageStats> {
-  const sessionListItems = await getSavedMeetingSessions(chrome.storage.local);
-  const sessions = await Promise.all(
-    sessionListItems.map(async (session) => {
-      return (await getSavedMeetingSession(chrome.storage.local, session.id)) ?? session;
-    }),
-  );
-
-  // Get everything in local storage to also measure settings + API keys
+  // Get everything in local storage in a single query to also measure settings + API keys
   const allItems = await chrome.storage.local.get(null);
+
+  // Extract saved sessions using the index and legacy lists from allItems
+  const SAVED_SESSION_INDEX_KEY = "savedSessionIndex";
+  const SAVED_SESSIONS_LEGACY_KEY = "savedSessions";
+
+  const indexedSessions = Array.isArray(allItems[SAVED_SESSION_INDEX_KEY])
+    ? allItems[SAVED_SESSION_INDEX_KEY]
+    : [];
+
+  const legacySessions = Array.isArray(allItems[SAVED_SESSIONS_LEGACY_KEY])
+    ? allItems[SAVED_SESSIONS_LEGACY_KEY]
+    : [];
+
+  const sessionListItems = indexedSessions.length > 0 ? indexedSessions : legacySessions;
+
+  const sessions = sessionListItems
+    .map((session: any) => {
+      if (!session || !session.id) return session;
+      const key = `savedSession:${session.id}`;
+      const fullSession = allItems[key];
+      if (fullSession && typeof fullSession === "object") {
+        return fullSession;
+      }
+      return session;
+    })
+    .filter(Boolean);
 
   // --- Per-category byte counting ---
   let transcriptBytes = 0;


### PR DESCRIPTION
Resolves #597

I am contributing on behalf of **GSSoc'26** 🚀

### Proposed Changes:
- Modified `getStorageStats()` to execute exactly one `chrome.storage.local.get(null)` call.
- Parsed the indices (`savedSessionIndex`, `savedSessions`) and specific session payloads entirely in-memory from the local dump instead of running concurrent async I/O requests per session.
- Removed unused imports to keep code clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized storage statistics retrieval for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->