### PR TITLE
fix: resolve user gesture loss when opening side panel from popup and onboarding

### DIFF
--- a/src/onboarding.ts
+++ b/src/onboarding.ts
@@ -162,14 +162,8 @@ export async function renderOnboarding(container: HTMLElement) {
     if (step.id === "complete") {
       const openBtn = container.querySelector<HTMLButtonElement>("#onb-open-dashboard");
       const finishBtn = container.querySelector<HTMLButtonElement>("#onb-finish");
-      openBtn?.addEventListener("click", async () => {
-        const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-        const tabId = tabs[0]?.id;
-        if (typeof tabId === "number") {
-          await chrome.sidePanel.open({ tabId });
-        } else {
-          console.warn("Unable to determine current tab id for sidePanel.open");
-        }
+      openBtn?.addEventListener("click", () => {
+        chrome.sidePanel.open({ windowId: chrome.windows.WINDOW_ID_CURRENT });
       });
       finishBtn?.addEventListener("click", async () => {
         await chrome.storage.local.set({ onboardingCompleted: true });

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -153,12 +153,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ——— Open Dashboard ———
   document.getElementById("open-dashboard")?.addEventListener("click", () => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const tabId = tabs[0]?.id;
-      if (tabId !== undefined) {
-        chrome.sidePanel.open({ tabId });
-      }
-    });
+    chrome.sidePanel.open({ windowId: chrome.windows.WINDOW_ID_CURRENT });
   });
 
   // ——— Start Copilot (Audio Capture with User Gesture) ———


### PR DESCRIPTION
Resolves #599

I am contributing on behalf of **GSSoc'26** 🚀

### Proposed Changes:
- Replaced the asynchronous `chrome.tabs.query` queries inside popup and onboarding complete click listeners with synchronous `chrome.sidePanel.open` calls using `chrome.windows.WINDOW_ID_CURRENT`.
- Fully preserves the user gesture token, fixing the runtime exception.