### PR TITLE
bug: monitor microphone stream tracks for unexpected track end in offscreen

### DIFF
--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -371,6 +371,14 @@ async function startCapture(
 
     if (microphoneStream) {
       connectSourceToRecorder(microphoneStream, destination);
+
+      microphoneStream.getTracks().forEach((track) => {
+        track.onended = () => {
+          console.warn("[LateMeet][offscreen] Microphone track ended unexpectedly");
+          if (isStopping) return;
+          relay("Microphone track ended unexpectedly (input device disconnected)");
+        };
+      });
     }
   }
 


### PR DESCRIPTION
Resolves #603

I am contributing on behalf of **GSSoc'26** 🚀

### Proposed Changes:
- Added a `track.onended` listener for all microphone track streams inside `startCapture()`.
- Relays a console warning to the service worker if the microphone stream gets unplugged or revoked.