### PR TITLE
bug: fix offscreen initialization race condition using a ping-pong handshake

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -523,8 +523,16 @@ async function ensureOffscreenDocument() {
 
   // createDocument resolves when the document is created, but the offscreen JS
   // still needs a moment to execute and register its chrome.runtime.onMessage
-  // listener. Without this delay the first OFFSCREEN_START_CAPTURE is lost.
-  await new Promise((resolve) => setTimeout(resolve, 200));
+  // listener. Ping the document to establish a handshake before resolving.
+  for (let i = 0; i < 20; i++) {
+    try {
+      const res = await chrome.runtime.sendMessage({ type: "OFFSCREEN_PING" });
+      if (res?.success) return;
+    } catch {
+      // ignore "Receiving end does not exist" message errors during early load
+    }
+    await new Promise((resolve) => setTimeout(resolve, 30));
+  }
 }
 
 async function closeOffscreenDocumentIfPresent() {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -511,6 +511,11 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   }
 
   (async () => {
+    if (message.type === "OFFSCREEN_PING") {
+      sendResponse({ success: true });
+      return;
+    }
+
     if (message.type === "OFFSCREEN_START_CAPTURE") {
       try {
         const captureInfo = await startCapture(


### PR DESCRIPTION
Resolves #605

I am contributing on behalf of **GSSoc'26** 🚀

### Proposed Changes:
- Added a simple handshake response for `OFFSCREEN_PING` in `offscreen.ts`.
- Replaced the hardcoded `setTimeout(200)` in `ensureOffscreenDocument` with a retry ping loop that polls `OFFSCREEN_PING` every 30ms until a success response is obtained.