### PR TITLE
fix: pause VAD and waveform timers during MediaRecorder pause (#622)

### DIFF
--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -127,8 +127,65 @@ function sampleAndSendWaveform() {
   chrome.runtime.sendMessage({ type: "WAVEFORM_DATA", buckets }).catch(() => {});
 }
 
+function pauseTimers() {
+  if (vadTimer) {
+    clearInterval(vadTimer);
+    vadTimer = null;
+  }
+  if (waveformTimer) {
+    clearInterval(waveformTimer);
+    waveformTimer = null;
+  }
+  bufferStartTime = 0;
+  silenceTicks = 0;
+}
+
+function resumeTimers() {
+  bufferStartTime = Date.now();
+  silenceTicks = 0;
+  waveformTimer = setInterval(sampleAndSendWaveform, WAVEFORM_INTERVAL_MS);
+  vadTimer = setInterval(vadLoop, VAD_SAMPLE_MS);
+}
+
+async function vadLoop() {
+  if (isStopping || isVadBusy || isDrainingQueue || mediaRecorder?.state !== "recording") return;
+
+  isVadBusy = true;
+
+  try {
+    const rms = getCurrentRms();
+    voiceActivity.observe(rms);
+
+    if (rms < rmsThreshold) {
+      silenceTicks++;
+    } else {
+      silenceTicks = 0;
+    }
+
+    const naturalPause = silenceTicks >= SILENCE_FLUSH_TICKS;
+    const overflowReached = Date.now() - bufferStartTime >= MAX_BUFFER_MS;
+
+    if (naturalPause || overflowReached) {
+      const reason = naturalPause ? "silence-pause" : "overflow-cap";
+      relay(
+        `flush triggered — reason=${reason} rms=${rms.toFixed(4)} silenceTicks=${silenceTicks}`,
+      );
+      silenceTicks = 0;
+      bufferStartTime = Date.now();
+      // Force-flush on overflow so silent audio doesn't block the buffer cap.
+      await flushAudioChunk(overflowReached && !naturalPause);
+    }
+  } catch (err) {
+    console.error("[LateMeet][offscreen] VAD loop error:", err);
+  } finally {
+    isVadBusy = false;
+  }
+}
+
 async function flushAudioChunk(force = false) {
-  if (isFlushInProgress || !mediaRecorder || mediaRecorder.state !== "recording") {
+  if (isFlushInProgress) return;
+  if (!mediaRecorder || mediaRecorder.state !== "recording") {
+    bufferStartTime = Date.now();
     return;
   }
 
@@ -248,6 +305,7 @@ async function drainPendingChunks() {
       } catch (e) {
         console.warn("[LateMeet][offscreen] Failed to resume recorder:", e);
       }
+      resumeTimers();
     }
   }
 }
@@ -473,6 +531,7 @@ async function startCapture(
       pendingChunks.push(event.data);
       if (pendingChunks.length >= MAX_PENDING_CHUNKS && mediaRecorder?.state === "recording") {
         relay(`pendingChunks cap reached (${MAX_PENDING_CHUNKS}), pausing recording`);
+        pauseTimers();
         try {
           mediaRecorder.pause();
         } catch (e) {
@@ -502,40 +561,7 @@ async function startCapture(
   silenceTicks = 0;
   bufferStartTime = Date.now();
 
-  vadTimer = setInterval(async () => {
-    if (isStopping || isVadBusy || isDrainingQueue) return;
-
-    isVadBusy = true;
-
-    try {
-      const rms = getCurrentRms();
-      voiceActivity.observe(rms);
-
-      if (rms < rmsThreshold) {
-        silenceTicks++;
-      } else {
-        silenceTicks = 0;
-      }
-
-      const naturalPause = silenceTicks >= SILENCE_FLUSH_TICKS;
-      const overflowReached = Date.now() - bufferStartTime >= MAX_BUFFER_MS;
-
-      if (naturalPause || overflowReached) {
-        const reason = naturalPause ? "silence-pause" : "overflow-cap";
-        relay(
-          `flush triggered — reason=${reason} rms=${rms.toFixed(4)} silenceTicks=${silenceTicks}`,
-        );
-        silenceTicks = 0;
-        bufferStartTime = Date.now();
-        // Force-flush on overflow so silent audio doesn't block the buffer cap.
-        await flushAudioChunk(overflowReached && !naturalPause);
-      }
-    } catch (err) {
-      console.error("[LateMeet][offscreen] VAD loop error:", err);
-    } finally {
-      isVadBusy = false;
-    }
-  }, VAD_SAMPLE_MS);
+  vadTimer = setInterval(vadLoop, VAD_SAMPLE_MS);
 
   relay(`capture started — mic=${Boolean(microphoneStream)} rmsThreshold=${rmsThreshold}`);
 

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -184,7 +184,7 @@ async function vadLoop() {
 
 async function flushAudioChunk(force = false) {
   if (isFlushInProgress) return;
-  if (!mediaRecorder || mediaRecorder.state !== "recording") {
+  if (mediaRecorder?.state !== "recording") {
     bufferStartTime = Date.now();
     return;
   }
@@ -315,6 +315,8 @@ function stopTracks(stream: MediaStream | null) {
 }
 
 async function cleanupResources() {
+  pauseTimers();
+
   stopTracks(mediaStream);
   stopTracks(microphoneStream);
   stopTracks(recorderStream);
@@ -322,11 +324,6 @@ async function cleanupResources() {
   mediaStream = null;
   microphoneStream = null;
   recorderStream = null;
-
-  if (waveformTimer) {
-    clearInterval(waveformTimer);
-    waveformTimer = null;
-  }
 
   if (audioContext) {
     try {


### PR DESCRIPTION
## Summary

Fixes #622 — when the offscreen document's `MediaRecorder` is paused (due to `pendingChunks` hitting `MAX_PENDING_CHUNKS`), the VAD timer and waveform timer continued running unconditionally. The `bufferStartTime` timestamp was never adjusted for the paused period, causing an immediate overflow flush on resume that split speech segments mid-sentence.

## Root Cause

1. **VAD and waveform timers were not gated on recorder state** — both timers started once in `startCapture()` and were never stopped or adjusted when the recorder paused
2. **`bufferStartTime` not reset in early-return path** — when `flushAudioChunk()` returned early because `mediaRecorder.state !== "recording"`, `bufferStartTime` remained frozen at the pre-pause value
3. **`silenceTicks` accumulation during pause** — the VAD timer observed near-zero RMS during pause, incrementing `silenceTicks` and potentially triggering false `naturalPause` flushes

## Changes

### Phase 1: Pause/resume timer lifecycle (`src/offscreen.ts`)

- **`pauseTimers()`** — clears both `vadTimer` and `waveformTimer`, resets `bufferStartTime` and `silenceTicks`
- **`resumeTimers()`** — reinitializes `bufferStartTime` to `Date.now()`, resets `silenceTicks`, restarts both timers

### Phase 2: Wired to pause/resume points

- **`dataavailable` handler** — `pauseTimers()` is called **before** `mediaRecorder.pause()`, so no VAD tick fires during pause
- **`drainPendingChunks()`** — `resumeTimers()` is called **after** `mediaRecorder.resume()`, so timers restart with fresh `bufferStartTime`

### Phase 3: `flushAudioChunk()` early-return fix

When `flushAudioChunk()` returns early because the recorder is not recording:
- **`bufferStartTime` is now reset to `Date.now()`** — prevents overflow accumulation across pause/resume cycles

### Phase 4: Named `vadLoop()` function + recorder state guard

- Extracted the anonymous VAD interval callback into a named `vadLoop()` function
- Added `mediaRecorder?.state !== "recording"` check at the top of `vadLoop()` so all VAD logic is skipped when the recorder is paused/dormant

## Testing

- [x] Compiles without new TypeScript errors
- [x] ESLint passes cleanly
- [x] When `pendingChunks >= MAX_PENDING_CHUNKS`, timers pause before `mediaRecorder.pause()`
- [x] When queue drains, timers resume after `mediaRecorder.resume()` with fresh `bufferStartTime`
- [x] `flushAudioChunk()` early-return no longer freezes `bufferStartTime`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved audio recording internals to make voice-activity detection and timer handling more reliable.
  * Reduced missed or delayed audio flushes and better handling when buffers fill or drain, improving recording stability and responsiveness.
  * More consistent pause/resume behavior for background sampling and waveform updates, conserving resources during long recordings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->