### PR TITLE
fix: emit complete WebM files per chunk by restarting recorder on flush (#678)

### DIFF
--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -149,19 +149,43 @@ async function flushAudioChunk(force = false) {
     // recorder is then started so the next segment carries its own header too.
     const previousRecorder = mediaRecorder;
     // Drop the persistent error listener first so a stop-time error is handled
-    // by stopMediaRecorder()'s own listener instead of recursing into stopCapture().
+    // by the wait helper below instead of recursing into stopCapture().
     previousRecorder.removeEventListener("error", handleRecorderError);
 
-    await stopMediaRecorder();
-
-    // dataavailable has now fired with the finished segment; detach the listener.
+    // Wait for the final `dataavailable` so the complete segment is pushed into
+    // pendingChunks before we drain. Per the MediaStream Recording spec the
+    // order is `dataavailable` → `stop`, and on a non-fatal error it is
+    // `error` → `dataavailable` → `stop`, so the final blob always arrives;
+    // a timeout guards against the event never firing.
+    await stopRecorderAndAwaitData(previousRecorder);
     previousRecorder.removeEventListener("dataavailable", handleRecorderDataAvailable);
 
-    // Resume capture before draining so the inter-segment gap stays minimal.
-    if (!isStopping && recorderStream) {
+    if (isStopping || !recorderStream) {
+      await drainWithTimeout();
+      return;
+    }
+
+    // Start a fresh recorder so the next segment carries its own header. Resume
+    // capture before draining so the inter-segment gap stays minimal.
+    // `MediaRecorder` creation/`start()` can throw synchronously (e.g.
+    // NotSupportedError when the stream has gone inactive); if it does, end
+    // capture cleanly instead of leaving the VAD loop spinning on a dead recorder.
+    try {
       mediaRecorder = createRecorder();
       mediaRecorder.start();
       bufferStartTime = Date.now();
+    } catch (err) {
+      console.error("[LateMeet][offscreen] Failed to restart recorder after flush:", err);
+      relay(`recorder restart failed — ${(err as Error)?.message ?? "unknown error"}`);
+      mediaRecorder = null;
+      await stopCapture();
+      await chrome.runtime
+        .sendMessage({
+          type: "UNEXPECTED_TRACK_END",
+          reason: "Recorder failed to restart after flush",
+        })
+        .catch(() => {});
+      return;
     }
 
     await drainWithTimeout();
@@ -353,6 +377,47 @@ async function stopMediaRecorder() {
       recorder.addEventListener("stop", () => clearTimeout(timeout), { once: true });
     });
   }
+}
+
+// Stops a recorder and resolves once its final `dataavailable` has fired (which
+// handleRecorderDataAvailable pushes into pendingChunks), so callers can drain a
+// complete segment. Resolves on `stop` for the no-data case and on a 2 000 ms
+// timeout so a missing event can't wedge the flush loop.
+function stopRecorderAndAwaitData(recorder: MediaRecorder): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (recorder.state === "inactive") {
+      resolve();
+      return;
+    }
+
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeoutId);
+      recorder.removeEventListener("dataavailable", onData);
+      recorder.removeEventListener("stop", onStop);
+      resolve();
+    };
+    // handleRecorderDataAvailable is registered first, so the blob is already in
+    // pendingChunks by the time this listener runs and resolves.
+    const onData = () => finish();
+    const onStop = () => finish();
+    const timeoutId = setTimeout(() => {
+      relay("recorder stop timeout — proceeding with queued chunks");
+      finish();
+    }, 2000);
+
+    recorder.addEventListener("dataavailable", onData, { once: true });
+    recorder.addEventListener("stop", onStop, { once: true });
+
+    try {
+      recorder.stop();
+    } catch (err) {
+      console.error("[LateMeet][offscreen] recorder stop failed:", err);
+      finish();
+    }
+  });
 }
 
 function handleRecorderDataAvailable(event: BlobEvent) {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -32,6 +32,7 @@ let isFlushInProgress = false;
 let isVadBusy = false;
 let silenceTicks = 0;
 let bufferStartTime = 0;
+let recorderMimeType = "";
 let voiceActivity = new VoiceActivityTracker({
   rmsThreshold: rmsThreshold,
 });
@@ -141,33 +142,27 @@ async function flushAudioChunk(force = false) {
       return;
     }
 
-    // In continuous mode, dataavailable only fires on requestData() or stop().
-    // We must wait for the event before draining so the new blob lands in pendingChunks.
-    // A 1 000 ms timeout guards against the event never firing (browser throttling,
-    // system load) which would otherwise leave isFlushInProgress permanently true.
-    await new Promise<void>((resolve) => {
-      const recorder = mediaRecorder!;
-      let settled = false;
-      const finish = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeoutId);
-        recorder.removeEventListener("dataavailable", onData);
-        resolve();
-      };
-      const onData = () => finish();
-      const timeoutId = setTimeout(() => {
-        relay("requestData timeout — resuming with queued chunks");
-        finish();
-      }, 1000);
-      recorder.addEventListener("dataavailable", onData, { once: true });
-      try {
-        recorder.requestData();
-      } catch (err) {
-        console.error("[LateMeet][offscreen] requestData failed:", err);
-        finish();
-      }
-    });
+    // Finalize the current segment by stopping the recorder. Stopping emits a
+    // complete, self-contained file (WebM initialization segment + media) via
+    // `dataavailable` — unlike `requestData()`, whose post-first blobs are
+    // headerless fragments the STT API cannot decode (see issue #678). A fresh
+    // recorder is then started so the next segment carries its own header too.
+    const previousRecorder = mediaRecorder;
+    // Drop the persistent error listener first so a stop-time error is handled
+    // by stopMediaRecorder()'s own listener instead of recursing into stopCapture().
+    previousRecorder.removeEventListener("error", handleRecorderError);
+
+    await stopMediaRecorder();
+
+    // dataavailable has now fired with the finished segment; detach the listener.
+    previousRecorder.removeEventListener("dataavailable", handleRecorderDataAvailable);
+
+    // Resume capture before draining so the inter-segment gap stays minimal.
+    if (!isStopping && recorderStream) {
+      mediaRecorder = createRecorder();
+      mediaRecorder.start();
+      bufferStartTime = Date.now();
+    }
 
     await drainWithTimeout();
   } finally {
@@ -360,6 +355,51 @@ async function stopMediaRecorder() {
   }
 }
 
+function handleRecorderDataAvailable(event: BlobEvent) {
+  console.log("[LateMeet][offscreen] Chunk received:", {
+    type: event.data?.type,
+    size: event.data?.size,
+  });
+
+  if (event.data && event.data.size > 0) {
+    pendingChunks.push(event.data);
+    if (pendingChunks.length >= MAX_PENDING_CHUNKS && mediaRecorder?.state === "recording") {
+      relay(`pendingChunks cap reached (${MAX_PENDING_CHUNKS}), pausing recording`);
+      try {
+        mediaRecorder.pause();
+      } catch (e) {
+        console.warn("[LateMeet][offscreen] Failed to pause recorder:", e);
+      }
+    }
+  }
+}
+
+async function handleRecorderError(err: Event) {
+  console.error("[LateMeet][offscreen] Recorder error:", err);
+
+  if (!isStopping) {
+    await stopCapture();
+  }
+}
+
+// Builds a MediaRecorder bound to the active recorder stream with the shared
+// listeners attached. A new recorder is created per capture and again on every
+// flush so each emitted file is independently decodable (see issue #678).
+function createRecorder(): MediaRecorder {
+  if (!recorderStream) {
+    throw new Error("Cannot create recorder without an active stream");
+  }
+
+  const recorder = recorderMimeType
+    ? new MediaRecorder(recorderStream, { mimeType: recorderMimeType })
+    : new MediaRecorder(recorderStream);
+
+  recorder.addEventListener("dataavailable", handleRecorderDataAvailable);
+  recorder.addEventListener("error", handleRecorderError);
+
+  return recorder;
+}
+
 async function startCapture(
   streamId: string,
   _tabId: number,
@@ -457,40 +497,12 @@ async function startCapture(
 
   recorderStream = destination.stream;
 
-  const mimeType = pickSupportedMimeType();
+  recorderMimeType = pickSupportedMimeType();
+  mediaRecorder = createRecorder();
 
-  mediaRecorder = mimeType
-    ? new MediaRecorder(recorderStream, { mimeType })
-    : new MediaRecorder(recorderStream);
-
-  mediaRecorder.addEventListener("dataavailable", (event: BlobEvent) => {
-    console.log("[LateMeet][offscreen] Chunk received:", {
-      type: event.data?.type,
-      size: event.data?.size,
-    });
-
-    if (event.data && event.data.size > 0) {
-      pendingChunks.push(event.data);
-      if (pendingChunks.length >= MAX_PENDING_CHUNKS && mediaRecorder?.state === "recording") {
-        relay(`pendingChunks cap reached (${MAX_PENDING_CHUNKS}), pausing recording`);
-        try {
-          mediaRecorder.pause();
-        } catch (e) {
-          console.warn("[LateMeet][offscreen] Failed to pause recorder:", e);
-        }
-      }
-    }
-  });
-
-  mediaRecorder.addEventListener("error", async (err) => {
-    console.error("[LateMeet][offscreen] Recorder error:", err);
-
-    if (!isStopping) {
-      await stopCapture();
-    }
-  });
-
-  // Continuous mode: no timeslice argument — we control flush timing via VAD.
+  // No timeslice argument — flush timing is controlled by VAD. Each flush stops
+  // and restarts the recorder so every emitted chunk is a complete file with its
+  // own WebM header (see issue #678).
   mediaRecorder.start();
 
   waveformTimer = setInterval(sampleAndSendWaveform, WAVEFORM_INTERVAL_MS);


### PR DESCRIPTION
## Description

Fixes the bug where only the **first** audio chunk of a meeting was decodable, so most of the transcript was silently dropped.

The offscreen recorder ran a single continuous `MediaRecorder` and flushed via `requestData()`. With WebM/Matroska, the **initialization segment** (EBML header + `Segment`/`Tracks` metadata) is emitted **only in the first `dataavailable` blob**; every later `requestData()` blob is media clusters with no header. Since each chunk is uploaded to the STT API (`transcribeChunk`) as its own standalone `audio.webm` file, only chunk #1 was a valid file — chunks #2..N were headerless fragments that the API rejected or returned empty for, and the failures were swallowed (`transcribeChunk` → `null`).

### Fix

`flushAudioChunk()` now **stops** the recorder (which emits a complete, self-contained file with its own header) and **immediately starts a fresh recorder**, so every emitted chunk is independently decodable. The recorder creation + event listeners are factored into `createRecorder()` and named handlers (`handleRecorderDataAvailable`, `handleRecorderError`) so the same setup is reused on each restart.

Notes:
- The new recorder is started *before* draining so the inter-segment gap stays minimal (and, because flushes are VAD-triggered on silence pauses, gaps usually land in silence).
- The persistent `error` listener is detached before the controlled stop so a stop-time error is handled by `stopMediaRecorder()`'s own listener instead of recursing into `stopCapture()`.
- `stopCapture()` / track-`onended` cleanup paths are unchanged — they already stop the recorder, which now also yields a complete final file.

Fixes #678

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How verified

- `npm run type-check`, `npm run lint`, `npm run build`, and `npm test` (108 passing) all pass; `prettier --check` clean.
- I have **not** been able to run this in a live Meet session, so a maintainer check is appreciated. Suggested manual check: capture for longer than one flush interval (a silence pause, or >25 s to hit the overflow cap) and confirm chunks after the first now transcribe instead of logging `ElevenLabs STT error 4xx` / `Empty ElevenLabs transcript`. Each uploaded chunk should now begin with the EBML magic bytes `0x1A45DFA3` (previously only chunk #1 did).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offscreen audio capture reliability to ensure each audio segment is independently decodable and complete.
  * Reduced gaps between consecutive audio segments for more seamless audio capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
