### PR TITLE
test: add integration tests for service worker state recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts src/lateJoinerDelivery.test.ts src/utils/sanitize.test.ts",
+    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts src/background.sessionRecovery.test.ts src/lateJoinerDelivery.test.ts src/utils/sanitize.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/src/background.sessionRecovery.test.ts
+++ b/src/background.sessionRecovery.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Integration tests for service-worker state recovery (issue #668).
+ *
+ * Simulates a service-worker restart by pre-seeding persisted state into
+ * chrome.storage before `background.ts` is imported, then verifying that
+ * `hydrateState()` (run on load and awaited by the message handler) restores all
+ * meeting variables. State is read back through a real `GET_STATE` message via
+ * the captured `chrome.runtime.onMessage` listener.
+ *
+ * Node's test runner isolates each test file in its own process, so this file
+ * owns a single fresh import of the background module.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+type AnyRecord = Record<string, unknown>;
+type MessageListener = (
+  message: AnyRecord,
+  sender: AnyRecord,
+  sendResponse: (response?: unknown) => void,
+) => boolean | undefined;
+
+// The state a previous service-worker instance is assumed to have persisted.
+const SEEDED_STATE = {
+  isActive: true,
+  meetingId: "abc-defg-hij",
+  meetingUrl: "https://meet.google.com/abc-defg-hij",
+  startTime: 1_700_000_000_000,
+  summary: "Recovered summary",
+  summaryItems: [{ text: "Discussed roadmap", timestamp: "00:10" }],
+  topics: [{ name: "Roadmap", status: "active" }],
+  decisions: [{ text: "Ship the beta" }],
+  actionItems: [{ task: "Email the team" }],
+  currentTopic: "Roadmap",
+  sentiment: "positive",
+  keyInsights: [{ text: "Strong consensus", confidenceScore: 0.9 }],
+  unresolvedDiscussions: ["Pricing tiers"],
+  contradictions: [{ issue: "Scope vs. deadline", persists: true }],
+  questionsRaised: ["When do we launch?"],
+  participants: ["Alice", "Bob"],
+  initialParticipants: ["Alice"],
+  lateJoiners: ["Bob"],
+  timeline: [{ event: "Meeting started", timestamp: 1_700_000_000_000, elapsed: 0 }],
+  transcript: [{ speaker: "Alice", text: "Hello everyone", timestamp: 1 }],
+  audioActive: true,
+  targetTabId: 42,
+  participantCount: 2,
+};
+
+const SEEDED_GUARDS = {
+  isStartingAudio: false,
+  isStoppingAudio: false,
+  isProcessingSession: false,
+  summaryInFlight: false,
+  selfParticipantName: "Alice",
+};
+
+let messageListener: MessageListener | undefined;
+
+function installChromeMock() {
+  if (typeof (globalThis as AnyRecord).addEventListener !== "function") {
+    (globalThis as AnyRecord).addEventListener = () => {};
+  }
+  (globalThis as AnyRecord).self = globalThis;
+
+  // Persisted store as a prior SW instance would have left it.
+  const localStore: AnyRecord = {
+    activeMeetingState: structuredClone(SEEDED_STATE),
+    activeMeetingGuards: structuredClone(SEEDED_GUARDS),
+  };
+  const sessionStore: AnyRecord = {};
+
+  function createArea(store: AnyRecord) {
+    return {
+      async get(keys: string | string[] | AnyRecord | null) {
+        const list = Array.isArray(keys)
+          ? keys
+          : typeof keys === "string"
+            ? [keys]
+            : Object.keys(keys ?? store);
+        const out: AnyRecord = {};
+        for (const key of list) if (key in store) out[key] = store[key];
+        return out;
+      },
+      async set(values: AnyRecord) {
+        Object.assign(store, values);
+      },
+      async remove(keys: string | string[]) {
+        for (const key of Array.isArray(keys) ? keys : [keys]) delete store[key];
+      },
+    };
+  }
+
+  (globalThis as AnyRecord).chrome = {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://fakeextid/${path}`,
+      sendMessage: async () => {},
+      // A present offscreen context means a restored `audioActive` should be kept.
+      getContexts: async () => [{ contextType: "OFFSCREEN_DOCUMENT" }],
+      onMessage: {
+        addListener: (cb: MessageListener) => {
+          messageListener = cb;
+        },
+      },
+      onInstalled: { addListener: () => {} },
+      onStartup: { addListener: () => {} },
+      onSuspend: { addListener: () => {} },
+    },
+    alarms: {
+      onAlarm: { addListener: () => {} },
+      create: () => {},
+    },
+    tabs: {
+      onUpdated: { addListener: () => {} },
+      onActivated: { addListener: () => {} },
+      onRemoved: { addListener: () => {} },
+      get: async () => ({}),
+      query: async () => [],
+      sendMessage: async () => {},
+    },
+    commands: { onCommand: { addListener: () => {} } },
+    contextMenus: {
+      onClicked: { addListener: () => {} },
+      removeAll: (callback?: () => void) => callback?.(),
+      create: () => {},
+    },
+    sidePanel: { open: async () => {} },
+    storage: {
+      local: createArea(localStore),
+      session: createArea(sessionStore),
+    },
+  };
+}
+
+installChromeMock();
+await import("./background.ts");
+
+/** Sends a message through the captured background listener and awaits the response. */
+function sendMessage(message: AnyRecord): Promise<AnyRecord> {
+  return new Promise((resolve) => {
+    if (!messageListener) {
+      throw new Error("background did not register a chrome.runtime.onMessage listener");
+    }
+    const kept = messageListener(message, {}, (response) => resolve((response ?? {}) as AnyRecord));
+    if (kept !== true) resolve({});
+  });
+}
+
+test("recovers the active meeting identity after a simulated restart", async () => {
+  const state = await sendMessage({ type: "GET_STATE" });
+  assert.equal(state.isActive, true);
+  assert.equal(state.meetingId, "abc-defg-hij");
+  assert.equal(state.meetingUrl, "https://meet.google.com/abc-defg-hij");
+  assert.equal(state.startTime, 1_700_000_000_000);
+  assert.equal(state.targetTabId, 42);
+  assert.equal(state.participantCount, 2);
+});
+
+test("recovers AI-derived meeting content", async () => {
+  const state = await sendMessage({ type: "GET_STATE" });
+  assert.equal(state.summary, "Recovered summary");
+  assert.equal(state.currentTopic, "Roadmap");
+  assert.equal(state.sentiment, "positive");
+  assert.deepEqual(
+    (state.topics as AnyRecord[]).map((t) => t.name),
+    ["Roadmap"],
+  );
+  assert.deepEqual(
+    (state.decisions as AnyRecord[]).map((d) => d.text),
+    ["Ship the beta"],
+  );
+  assert.deepEqual(
+    (state.actionItems as AnyRecord[]).map((a) => a.task),
+    ["Email the team"],
+  );
+  assert.deepEqual(state.unresolvedDiscussions, ["Pricing tiers"]);
+  assert.deepEqual(state.questionsRaised, ["When do we launch?"]);
+});
+
+test("recovers transcript, timeline, and participant lists", async () => {
+  const state = await sendMessage({ type: "GET_STATE" });
+
+  const transcript = state.transcript as AnyRecord[];
+  assert.equal(transcript.length, 1);
+  assert.equal(transcript[0].text, "Hello everyone");
+  assert.equal(transcript[0].speaker, "Alice");
+
+  assert.equal((state.timeline as AnyRecord[]).length, 1);
+  assert.deepEqual(state.participants, ["Alice", "Bob"]);
+  assert.deepEqual(state.initialParticipants, ["Alice"]);
+  assert.deepEqual(state.lateJoiners, ["Bob"]);
+});
+
+test("keeps audioActive when the offscreen document is still present", async () => {
+  const state = await sendMessage({ type: "GET_STATE" });
+  assert.equal(state.audioActive, true);
+});

--- a/src/background.sessionRecovery.test.ts
+++ b/src/background.sessionRecovery.test.ts
@@ -57,6 +57,30 @@ const SEEDED_GUARDS = {
 
 let messageListener: MessageListener | undefined;
 
+/** Resolves a chrome.storage `get` argument to a flat list of keys. */
+function toKeyList(keys: string | string[] | AnyRecord | null, store: AnyRecord): string[] {
+  if (Array.isArray(keys)) return keys;
+  if (typeof keys === "string") return [keys];
+  return Object.keys(keys ?? store);
+}
+
+/** Minimal in-memory chrome.storage area backed by `store`. */
+function createStorageArea(store: AnyRecord) {
+  return {
+    async get(keys: string | string[] | AnyRecord | null) {
+      const out: AnyRecord = {};
+      for (const key of toKeyList(keys, store)) if (key in store) out[key] = store[key];
+      return out;
+    },
+    async set(values: AnyRecord) {
+      Object.assign(store, values);
+    },
+    async remove(keys: string | string[]) {
+      for (const key of Array.isArray(keys) ? keys : [keys]) delete store[key];
+    },
+  };
+}
+
 function installChromeMock() {
   if (typeof (globalThis as AnyRecord).addEventListener !== "function") {
     (globalThis as AnyRecord).addEventListener = () => {};
@@ -68,28 +92,9 @@ function installChromeMock() {
     activeMeetingState: structuredClone(SEEDED_STATE),
     activeMeetingGuards: structuredClone(SEEDED_GUARDS),
   };
-  const sessionStore: AnyRecord = {};
 
-  function createArea(store: AnyRecord) {
-    return {
-      async get(keys: string | string[] | AnyRecord | null) {
-        const list = Array.isArray(keys)
-          ? keys
-          : typeof keys === "string"
-            ? [keys]
-            : Object.keys(keys ?? store);
-        const out: AnyRecord = {};
-        for (const key of list) if (key in store) out[key] = store[key];
-        return out;
-      },
-      async set(values: AnyRecord) {
-        Object.assign(store, values);
-      },
-      async remove(keys: string | string[]) {
-        for (const key of Array.isArray(keys) ? keys : [keys]) delete store[key];
-      },
-    };
-  }
+  const noop = () => {};
+  const ignored = { addListener: noop };
 
   (globalThis as AnyRecord).chrome = {
     runtime: {
@@ -102,32 +107,29 @@ function installChromeMock() {
           messageListener = cb;
         },
       },
-      onInstalled: { addListener: () => {} },
-      onStartup: { addListener: () => {} },
-      onSuspend: { addListener: () => {} },
+      onInstalled: ignored,
+      onStartup: ignored,
+      onSuspend: ignored,
     },
-    alarms: {
-      onAlarm: { addListener: () => {} },
-      create: () => {},
-    },
+    alarms: { onAlarm: ignored, create: noop },
     tabs: {
-      onUpdated: { addListener: () => {} },
-      onActivated: { addListener: () => {} },
-      onRemoved: { addListener: () => {} },
+      onUpdated: ignored,
+      onActivated: ignored,
+      onRemoved: ignored,
       get: async () => ({}),
       query: async () => [],
       sendMessage: async () => {},
     },
-    commands: { onCommand: { addListener: () => {} } },
+    commands: { onCommand: ignored },
     contextMenus: {
-      onClicked: { addListener: () => {} },
+      onClicked: ignored,
       removeAll: (callback?: () => void) => callback?.(),
-      create: () => {},
+      create: noop,
     },
     sidePanel: { open: async () => {} },
     storage: {
-      local: createArea(localStore),
-      session: createArea(sessionStore),
+      local: createStorageArea(localStore),
+      session: createStorageArea({}),
     },
   };
 }


### PR DESCRIPTION
## Description

Adds integration tests that verify the service worker correctly resumes meeting state after a restart, by exercising `background.ts`'s `hydrateState()` recovery path end-to-end.

Fixes #668

## How it works

A service-worker restart is simulated by **pre-seeding persisted state into a stateful `chrome.storage` mock before `background.ts` is imported**. On load (and again when the message handler runs), `hydrateState()` reads `activeMeetingState`/`activeMeetingGuards` and restores the in-memory state. The test then reads the recovered state back through a **real `GET_STATE` message** via the captured `chrome.runtime.onMessage` listener — so it goes through the production hydration + snapshot code, not internals.

Node's test runner isolates each test file in its own process, so this file owns a single fresh import of the background module (the same pattern as `background.urlParsing.test.ts`).

## Coverage (`src/background.sessionRecovery.test.ts`, 4 cases)

- **Meeting identity** restored: `isActive`, `meetingId`, `meetingUrl`, `startTime`, `targetTabId`, `participantCount`.
- **AI-derived content** restored: `summary`, `currentTopic`, `sentiment`, `topics`, `decisions`, `actionItems`, `unresolvedDiscussions`, `questionsRaised`.
- **Transcript / timeline / participant lists** restored (including `participants`, `initialParticipants`, `lateJoiners`).
- **`audioActive` reconciliation**: kept `true` because the mock reports a present `OFFSCREEN_DOCUMENT` context.

## Type of Change

- [x] Tests only (no production code changes)
- [ ] Bug fix
- [ ] New feature

## Verification

`type-check`, `lint`, `format:check`, `build`, and `npm test` (112 passing, +4 new) all pass.

## Note

State recovery is persisted under `activeMeetingState`/`activeMeetingGuards` in `chrome.storage.local` (what `hydrateState()` reads), so the tests target those keys; the mock also provides `chrome.storage.session` for completeness.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
