### PR TITLE
docs: document extension permissions audit and privacy policy guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,3 +76,90 @@ For Chrome extension-specific vulnerabilities:
 2. Include the Chrome version and extension version
 3. Describe if the vulnerability requires user interaction
 4. Note whether the exploit requires a malicious website
+
+---
+
+## 🔐 Extension Permissions Audit
+
+This section documents every permission declared in [`src/manifest.json`](./src/manifest.json), why it is required, and where the resulting data lives. This audit exists to give users full transparency over what the extension can access.
+
+### Declared Permissions
+
+| Permission | Why It Is Required | Data Stored? |
+| :--- | :--- | :--- |
+| `storage` | Saves meeting transcripts, AI-generated summaries, user preferences (API keys, theme, language), and session history to the browser's local extension storage. | **Yes — locally only.** All data is stored in `chrome.storage.local` on the user's device and never leaves it unless the user explicitly exports a transcript. |
+| `unlimitedStorage` | Meeting transcripts and audio chunks can grow large over long sessions. This permission removes the default 5 MB quota cap so recordings are not silently truncated. | Same as `storage` — all local. |
+| `tabs` | Used to detect which browser tab corresponds to an active Google Meet session, retrieve the tab's URL and title for session metadata, and track tab lifecycle events (focus, close) to correctly start/stop recording. | Tab URL and title are stored transiently in memory; meeting title may be persisted in session metadata in `chrome.storage.local`. |
+| `tabCapture` | Captures the audio stream of the active Google Meet tab so that the extension can transcribe the meeting in real time. Without this permission, no audio can be recorded. | Audio is processed in the offscreen document and discarded after chunked transcription. Raw audio is **never** written to disk or sent to any server other than the configured AI provider. |
+| `contextMenus` | Adds right-click context menu entries that allow users to quickly save or copy a meeting snippet without opening the full panel. | No data stored by this permission itself. |
+| `offscreen` | Chrome Manifest V3 service workers cannot access Web Audio APIs directly. An offscreen document is created solely to host the `AudioContext` / `MediaRecorder` pipeline that processes the captured audio stream. | Audio chunks live in memory inside the offscreen document; they are forwarded to the background service worker and then discarded. |
+| `sidePanel` | Renders the primary Late-Meet UI (transcript, summaries, catch-up view) as a persistent side panel alongside Google Meet without requiring a separate pop-up window. | No additional data is stored by this permission. |
+| `notifications` | Displays browser notifications to alert the user when a recording starts/stops, a summary is ready, or an error occurs (e.g., API key missing). | No user data is stored by notifications. |
+| `alarms` | Schedules periodic background tasks, such as auto-saving the current session and cleaning up stale storage entries, even when the extension pop-up is closed. | No additional data is stored beyond the session data already managed by `storage`. |
+
+### Host Permissions
+
+| Host Pattern | Why It Is Required |
+| :--- | :--- |
+| `https://meet.google.com/*` | Injects the content script (`content.ts`) that attaches to the Google Meet page DOM to detect participant changes, extract the meeting title, and communicate recording state back to the background service worker. |
+| `https://api.openai.com/*` | Sends audio transcription chunks and summarisation prompts to the OpenAI API (Whisper / GPT) **only when the user has provided their own API key**. No requests are made to this host without explicit user configuration. |
+| `https://api.elevenlabs.io/*` | Optionally used for text-to-speech features if the user has configured an ElevenLabs API key. No requests are made to this host without explicit user configuration. |
+
+### Content Security Policy
+
+The extension enforces a strict CSP on all extension pages:
+
+```
+default-src 'none';
+script-src   'self';
+style-src    'self';
+connect-src  https://api.openai.com https://api.elevenlabs.io;
+img-src      'self' data:;
+font-src     'self' data:;
+object-src   'none';
+```
+
+- `'unsafe-eval'` and `'unsafe-inline'` are **never** permitted.
+- Network connections are restricted to the two AI provider domains above; no other outbound requests are possible from extension pages.
+
+---
+
+## 🕵️ Privacy Policy
+
+### What Data Late-Meet Collects
+
+Late-Meet is designed with a **local-first** and **privacy-first** philosophy.
+
+| Data Type | Collected? | Where Stored | When Deleted |
+| :--- | :---: | :--- | :--- |
+| Meeting audio (raw PCM / WebM chunks) | Transiently in memory only | RAM inside the offscreen document | Immediately after transcription chunk is processed |
+| Meeting transcripts (text) | Yes | `chrome.storage.local` on user's device | When user manually clears sessions or uses the storage dashboard |
+| AI summaries & catch-up text | Yes | `chrome.storage.local` on user's device | When user manually clears sessions |
+| User preferences (theme, language) | Yes | `chrome.storage.local` on user's device | When extension is uninstalled or user resets settings |
+| API keys (OpenAI / ElevenLabs) | Yes | `chrome.storage.local` on user's device | When user removes the key or uninstalls the extension |
+| Participant names / speaker labels | Yes (derived from Google Meet DOM) | `chrome.storage.local` as part of session metadata | When user clears the session |
+| Usage analytics or telemetry | **No** | N/A | N/A |
+| Crash reports | **No** | N/A | N/A |
+
+### What Late-Meet Never Does
+
+- ❌ **Does not** transmit meeting transcripts, summaries, or participant names to any Late-Meet server.
+- ❌ **Does not** share any data with third parties beyond the AI provider APIs you explicitly configure.
+- ❌ **Does not** store any data in `chrome.storage.sync` (which syncs across devices via Google Account).
+- ❌ **Does not** access any website other than `meet.google.com` via content scripts.
+- ❌ **Does not** collect analytics, usage metrics, or crash reports.
+
+### Third-Party API Data Handling
+
+When you provide an API key, audio or text data is sent to the respective provider under **your own API account**:
+
+- **OpenAI**: Audio chunks are sent to the Whisper transcription endpoint; meeting text may be sent to a GPT model for summarisation. Refer to [OpenAI's Privacy Policy](https://openai.com/policies/privacy-policy) for how they handle API request data.
+- **ElevenLabs**: Text may be sent for text-to-speech synthesis if you opt in. Refer to [ElevenLabs' Privacy Policy](https://elevenlabs.io/privacy) for details.
+
+You are solely responsible for ensuring your use of third-party APIs complies with your organisation's data-handling policies.
+
+### User Controls
+
+- **View stored data**: Open the extension's Storage Dashboard (`options.html` → Storage) to inspect and delete all locally stored sessions.
+- **Delete all data**: Use the "Clear All Sessions" action in the Storage Dashboard, or uninstall the extension (Chrome automatically purges `chrome.storage.local` on uninstall).
+- **Revoke API keys**: Remove your API key from the Options page at any time. The extension will stop sending data to that provider immediately.


### PR DESCRIPTION
## Description

Closes #660

Documents the full set of Chrome extension permissions and host permissions declared in `src/manifest.json`, explaining why each is required and where any resulting data is stored. Also adds a Privacy Policy section so users have complete transparency over data collection, retention, and deletion.

**Changes made to `SECURITY.md`:**

- Document all 9 manifest permissions (`storage`, `unlimitedStorage`, `tabs`, `tabCapture`, `contextMenus`, `offscreen`, `sidePanel`, `notifications`, `alarms`) with rationale and data-residency notes
- Document all 3 host permissions (`meet.google.com`, `api.openai.com`, `api.elevenlabs.io`) with purpose explanation
- Summarise the enforced Content Security Policy (no `unsafe-eval`, no `unsafe-inline`, restricted `connect-src`)
- Add Privacy Policy section covering data collection table, what the extension never does, third-party API data handling (OpenAI / ElevenLabs under user's own keys), and user controls (Storage Dashboard, uninstall, API key revocation)

Fixes #660

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added comprehensive security documentation detailing extension permissions, data storage, and Content Security Policy.
* Added privacy policy clarifying data collection practices, third-party API handling, and user controls for managing stored data and API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->