### PR TITLE
feat: add copy-to-clipboard buttons with toast feedbacks for transcript segments

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1127,6 +1127,26 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
   }
 
+  // ——— Transcript Copy Listener ———
+  if (transcriptContainer) {
+    transcriptContainer.addEventListener("click", (e) => {
+      const btn = (e.target as Element).closest(".copy-transcript-btn") as HTMLButtonElement | null;
+      if (!btn) return;
+      const speaker = btn.dataset.speaker || "Unknown";
+      const time = btn.dataset.time || "00:00";
+      const message = btn.dataset.message || "";
+      const copyText = `[${time}] ${speaker}: ${message}`;
+      
+      navigator.clipboard
+        .writeText(copyText)
+        .then(() => showToast("Copied to clipboard!", "success"))
+        .catch((err) => {
+          console.error("Failed to copy transcript:", err);
+          showToast("Failed to copy!", "error");
+        });
+    });
+  }
+
   // ——— Unified Export Helper (Handles both Live & History) ———
   function generateMarkdown(state: State): string {
     const dateVal = state.savedAt || state.startTime || Date.now();


### PR DESCRIPTION
## Description

This PR implements the functionality to copy specific transcript segments to the clipboard from the dashboard view. A click event listener has been added to the transcript container via event delegation to handle the pre-existing copy buttons. When a user clicks the tiny hover-action copy button on a transcript item, the `[time] Speaker: message` text is copied to their clipboard and a success toast notification is shown for immediate visual feedback. 

Fixes #649

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
```