### PR TITLE
fix(a11y): add keyboard focus indicator to theme selector dropdown (#…

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -166,6 +166,11 @@ body {
   background: var(--bg-element);
 }
 
+.form-select:focus-visible {
+  outline: 2px solid hsl(var(--accent-color, 210, 100%, 50%));
+  outline-offset: 2px;
+}
+
 .form-input::placeholder {
   color: var(--text-muted);
 }


### PR DESCRIPTION
## Description

Added a `:focus-visible` CSS rule to the `.form-select` element in `options.css` to provide a clear visual outline when navigating the Settings page via keyboard. This resolves the missing focus indicator issue and ensures compliance with WCAG keyboard accessibility standards.

Fixes #720

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced focus-visible styling for form select controls to provide a clearer, colored outline and offset when focused.
  * Improves keyboard navigation and accessibility by making focus states more noticeable for users relying on keyboard or assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->