### PR TITLE
fix(a11y): add keyboard focus indicator to range slider (#721)

### DIFF
--- a/src/options.css
+++ b/src/options.css
@@ -215,6 +215,11 @@ body {
   gap: 12px;
 }
 
+.form-range:focus-visible {
+  outline: 2px solid hsl(var(--accent-color, 210, 100%, 50%));
+  outline-offset: 2px;
+}
+
 .form-range {
   flex: 1;
   height: 4px;


### PR DESCRIPTION
## Description

Added a `:focus-visible` CSS rule to the `.form-range` audio level slider element in `options.css`. This provides a clear, visible outline when users navigate the Settings page using a keyboard, fixing the accessibility (a11y) issue and ensuring WCAG compliance.

Fixes #721

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced visual focus indicators for range input controls to improve keyboard navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->