### PR TITLE
ci: expand PR title lint triggers (#663)

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,7 +1,7 @@
 name: PR Title Lint
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -2,7 +2,7 @@ name: PR Title Lint
 
 on:
   pull_request_target:
-    types: [opened, edited, synchronize]
+    types: [opened, edited, synchronize, reopened, ready_for_review]
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
## Summary\n- extends the existing semantic PR title lint workflow to also run when PRs are reopened or marked ready for review\n- keeps the existing Conventional Commit validation action and configuration unchanged\n\n## Validation\n- git diff --check\n\nCloses #663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request validation to run when pull requests are marked as ready for review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->