### PR TITLE
fix: add MAX_AUDIO_CHUNK_BYTES guard to prevent OOM on oversized audio chunks

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -19,8 +19,8 @@ export const DEBUG = import.meta.env?.DEV === true;
 /**
  * Maximum permitted size (in bytes) for a single audio chunk blob forwarded
  * from the offscreen document to the background service worker via
- * chrome.runtime.sendMessage. Chrome's IPC message size limit is 64 MB, but
- * blobs larger than this threshold are a symptom of a stalled VAD timer or
+ * chrome.runtime.sendMessage. Chrome's IPC message size limit is implementation-
+ * dependent, but blobs larger than this threshold are a symptom of a stalled VAD timer or
  * MediaRecorder buffering multiple seconds of audio — both of which indicate
  * a problem upstream. Chunks exceeding this limit are discarded with a warning
  * rather than being forwarded, preventing memory exhaustion on long meetings.

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,3 +15,14 @@ export const WHISPER_MODEL = "whisper-1";
  * never accidentally enable debug output by flipping this constant.
  */
 export const DEBUG = import.meta.env?.DEV === true;
+
+/**
+ * Maximum permitted size (in bytes) for a single audio chunk blob forwarded
+ * from the offscreen document to the background service worker via
+ * chrome.runtime.sendMessage. Chrome's IPC message size limit is 64 MB, but
+ * blobs larger than this threshold are a symptom of a stalled VAD timer or
+ * MediaRecorder buffering multiple seconds of audio — both of which indicate
+ * a problem upstream. Chunks exceeding this limit are discarded with a warning
+ * rather than being forwarded, preventing memory exhaustion on long meetings.
+ */
+export const MAX_AUDIO_CHUNK_BYTES = 10 * 1024 * 1024; // 10 MB

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -208,7 +208,7 @@ async function postChunk(blob: Blob) {
 
   if (blob.size > MAX_AUDIO_CHUNK_BYTES) {
     relay(
-      `chunk too large, discarded — ${blob.size} bytes exceeds ${MAX_AUDIO_CHUNK_BYTES} byte limit`,
+      `chunk too large, discarded — ${blob.size} bytes exceeds limit of ${MAX_AUDIO_CHUNK_BYTES} bytes`,
     );
     return;
   }

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,4 +1,5 @@
 import { VoiceActivityTracker, isChunkViable } from "./audioProcessing";
+import { MAX_AUDIO_CHUNK_BYTES } from "./config";
 import {
   connectMicrophoneToOffscreenAudioGraph,
   createOffscreenAudioGraph,
@@ -202,6 +203,13 @@ async function flushAudioChunk(force = false) {
 async function postChunk(blob: Blob) {
   if (!isChunkViable(blob)) {
     relay(`chunk too small, skipped — ${blob?.size ?? 0} bytes (min 5 000)`);
+    return;
+  }
+
+  if (blob.size > MAX_AUDIO_CHUNK_BYTES) {
+    relay(
+      `chunk too large, discarded — ${blob.size} bytes exceeds ${MAX_AUDIO_CHUNK_BYTES} byte limit`,
+    );
     return;
   }
 


### PR DESCRIPTION
## Description

`postChunk()` in `src/offscreen.ts` validated that a blob meets a minimum size via `isChunkViable()` but applied no upper bound. `MediaRecorder.ondataavailable` can produce very large blobs when the VAD timer fires late or the event loop is saturated under CPU pressure (e.g., screen sharing on a slow machine). Forwarding such blobs:

- Encodes them to base64 in memory (expanding size by ~33%)
- Sends them over Chrome's IPC message channel (64 MB hard limit)
- Risks exhausting the offscreen document's memory budget on long meetings

This fix adds `MAX_AUDIO_CHUNK_BYTES = 10 MB` to `src/config.ts` (consistent with the ongoing constant centralization from issue #494) and checks it in `postChunk()` before any encoding or forwarding. Oversized blobs are discarded with a `relay()` warning so the issue is visible in the service worker console.

Fixes #738

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] All 133 existing tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented oversized audio chunks from being transmitted.
  * Improved handling of large audio blobs by discarding them before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->