### PR TITLE
fix: reset summaryInFlight to false in onSuspend to prevent permanent summarization lock

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -2315,6 +2315,13 @@ chrome.contextMenus.onClicked.addListener(async (info, tab) => {
 // Flush guard flags to storage before service worker is terminated
 // ---------------------------------------------------------------------------
 chrome.runtime.onSuspend.addListener(() => {
+  // An in-flight API call cannot survive service worker suspension — the
+  // promise is abandoned when the worker is killed. Persisting summaryInFlight
+  // as true would cause hydrateState() to restore it on the next wake-up,
+  // permanently blocking summarization for the rest of the session. Always
+  // reset it to false so the next worker instance can summarize normally.
+  summaryInFlight = false;
+
   const guards: HydrationStatus = {
     isStartingAudio,
     isStoppingAudio,


### PR DESCRIPTION
## Description

`summaryInFlight` is a module-level boolean that prevents concurrent summarizations. When the service worker is suspended by Chrome mid-API call, the `onSuspend` handler was persisting `summaryInFlight = true` into `chrome.storage.local`. On the next worker restart, `hydrateState()` restores this value — permanently blocking all future calls to `summarizeTranscriptIfNeeded()` for the rest of the session, since the flag is never reset (the `finally` block that resets it never ran because the worker was killed).

The fix resets `summaryInFlight = false` inside `onSuspend` before persisting the guard state. A suspended worker cannot complete an async API call, so carrying the flag forward serves no purpose and causes the described lock.

Fixes #736

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] All 133 existing tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where summarization could become stuck in a pending state, preventing the feature from functioning in subsequent sessions. The feature will now operate reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->