### PR TITLE
fix: claim summaryInFlight before first await to close TOCTOU race in summarization

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1059,37 +1059,38 @@ function mergeUniqueStrings(existing: string[], incoming: unknown, maxSize = 500
 async function summarizeTranscriptIfNeeded() {
   if (!state.isActive || state.transcript.length === 0) return;
 
-  // Bail out immediately if another summarization is already running.
+  // Claim the in-flight slot before the first await so two concurrent callers
+  // that both reach this point before either awaits cannot both pass the guard
+  // and trigger duplicate API calls (TOCTOU). The finally block below always
+  // resets the flag, including all early-return paths.
   if (summaryInFlight) return;
-
-  const settings = await getSettings();
-  const requestedInterval = Number(settings.summarizationInterval);
-  let intervalSeconds =
-    Number.isFinite(requestedInterval) && requestedInterval > 0 ? requestedInterval : 300;
-
-  if (intervalSeconds < 300) intervalSeconds = 300;
-  if (intervalSeconds > 900) intervalSeconds = 900;
-  const lastSum = state.lastSummarizedAt || 0;
-  const elapsed = Math.floor((Date.now() - lastSum) / 1000);
-  if (lastSum > 0 && elapsed < intervalSeconds) return;
-
-  const apiKey = await getApiKey();
-  if (!apiKey) return;
-
-  const transcriptWindow = state.transcript
-    .slice(-TRANSCRIPT_WINDOW_SIZE)
-    .map((e) => {
-      const chunkId = e.id || "unknown_chunk";
-      const timestampLabel = e.timestampLabel || formatTimestampLabel(Math.floor(e.timestamp || 0));
-      return `[${chunkId}] [${timestampLabel}] ${sanitizePromptText(e.speaker)}: ${sanitizePromptText(e.text)}`;
-    })
-    .join("\n");
-  if (!transcriptWindow.trim()) return;
-
-  // Claim the in-flight slot *after* all cheap pre-checks pass.
   summaryInFlight = true;
 
   try {
+    const settings = await getSettings();
+    const requestedInterval = Number(settings.summarizationInterval);
+    let intervalSeconds =
+      Number.isFinite(requestedInterval) && requestedInterval > 0 ? requestedInterval : 300;
+
+    if (intervalSeconds < 300) intervalSeconds = 300;
+    if (intervalSeconds > 900) intervalSeconds = 900;
+    const lastSum = state.lastSummarizedAt || 0;
+    const elapsed = Math.floor((Date.now() - lastSum) / 1000);
+    if (lastSum > 0 && elapsed < intervalSeconds) return;
+
+    const apiKey = await getApiKey();
+    if (!apiKey) return;
+
+    const transcriptWindow = state.transcript
+      .slice(-TRANSCRIPT_WINDOW_SIZE)
+      .map((e) => {
+        const chunkId = e.id || "unknown_chunk";
+        const timestampLabel = e.timestampLabel || formatTimestampLabel(Math.floor(e.timestamp || 0));
+        return `[${chunkId}] [${timestampLabel}] ${sanitizePromptText(e.speaker)}: ${sanitizePromptText(e.text)}`;
+      })
+      .join("\n");
+    if (!transcriptWindow.trim()) return;
+
     const topicDetectionEnabled = isFeatureEnabled(settings, "topicDetection");
     const decisionDetectionEnabled = isFeatureEnabled(settings, "decisionDetection");
     const actionExtractionEnabled = isFeatureEnabled(settings, "actionExtraction");

--- a/src/background.ts
+++ b/src/background.ts
@@ -1085,7 +1085,8 @@ async function summarizeTranscriptIfNeeded() {
       .slice(-TRANSCRIPT_WINDOW_SIZE)
       .map((e) => {
         const chunkId = e.id || "unknown_chunk";
-        const timestampLabel = e.timestampLabel || formatTimestampLabel(Math.floor(e.timestamp || 0));
+        const timestampLabel =
+          e.timestampLabel || formatTimestampLabel(Math.floor(e.timestamp || 0));
         return `[${chunkId}] [${timestampLabel}] ${sanitizePromptText(e.speaker)}: ${sanitizePromptText(e.text)}`;
       })
       .join("\n");


### PR DESCRIPTION
## Description

`summarizeTranscriptIfNeeded()` checked the `summaryInFlight` flag at the top of the function but only set it to `true` after ~26 lines of async code containing multiple `await` calls (`getSettings()`, `getApiKey()`, transcript building). Between the check and the set, the JavaScript event loop can yield — allowing a second concurrent invocation (e.g., a timer tick and a manual trigger arriving in the same turn) to also read `summaryInFlight === false`, pass the guard, and begin a second summarization in parallel.

The result is duplicate OpenAI API calls and two concurrent state writes that silently overwrite each other's results for `summary`, `topics`, `decisions`, `actionItems`, and `keyInsights`.

**Fix:** Move `summaryInFlight = true` to immediately after the synchronous guard check, before any `await`. All code is merged into a single `try/finally` block so the flag is always reset via the `finally` regardless of which return path is taken (interval throttle, missing API key, empty transcript, API error, or success).

Fixes #739

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] All 133 existing tests pass (`npm test`)
- [x] Build succeeds (`npm run build`)