### PR TITLE
feat: add configurable summarization interval

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1035,9 +1035,10 @@ async function summarizeTranscriptIfNeeded() {
   const settings = await getSettings();
   const requestedInterval = Number(settings.summarizationInterval);
   let intervalSeconds =
-    Number.isFinite(requestedInterval) && requestedInterval > 0 ? requestedInterval : 30;
-  if (intervalSeconds < 10) intervalSeconds = 10;
-  if (intervalSeconds > 300) intervalSeconds = 300;
+    Number.isFinite(requestedInterval) && requestedInterval > 0 ? requestedInterval : 300;
+
+  if (intervalSeconds < 300) intervalSeconds = 300;
+  if (intervalSeconds > 900) intervalSeconds = 900;
   const lastSum = state.lastSummarizedAt || 0;
   const elapsed = Math.floor((Date.now() - lastSum) / 1000);
   if (lastSum > 0 && elapsed < intervalSeconds) return;

--- a/src/options.html
+++ b/src/options.html
@@ -314,18 +314,21 @@
 
         <div class="form-group">
           <label class="form-label">Summarization Interval</label>
-          <p class="form-hint">How often AI processes the transcript (in seconds)</p>
+          <p class="form-hint">
+            Choose how often AI summarizes the meeting transcript (5–15 minutes)
+          </p>
           <div class="slider-row">
             <input
               type="range"
               id="summary-interval"
               class="form-range"
-              min="15"
-              max="120"
-              step="5"
-              value="30"
+              min="300"
+              max="900"
+              step="300"
+              value="300"
             />
-            <span id="interval-value" class="range-value">30s</span>
+
+            <span id="interval-value" class="range-value">5 min</span>
           </div>
         </div>
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -104,10 +104,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   const intervalSlider = document.getElementById("summary-interval") as HTMLInputElement | null;
   const intervalValue = document.getElementById("interval-value");
   if (intervalSlider && intervalValue) {
-    intervalSlider.value = String(settings.summarizationInterval || 30);
-    intervalValue.textContent = `${intervalSlider.value}s`;
+    intervalSlider.value = String(settings.summarizationInterval || 300);
+    intervalValue.textContent = `${Number(intervalSlider.value) / 60} min`;
+
     intervalSlider.addEventListener("input", () => {
-      intervalValue.textContent = `${intervalSlider.value}s`;
+      intervalValue.textContent = `${Number(intervalSlider.value) / 60} min`;
     });
   }
 
@@ -362,11 +363,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     const originalText = saveBtn.textContent?.trim() || "Save Settings";
     saveBtn.disabled = true;
     try {
-      const parsedInterval = intervalSlider ? parseInt(intervalSlider.value, 10) : 30;
+      const parsedInterval = intervalSlider ? parseInt(intervalSlider.value, 10) : 300;
       let validatedInterval =
-        Number.isNaN(parsedInterval) || !Number.isFinite(parsedInterval) ? 30 : parsedInterval;
-      if (validatedInterval < 10) validatedInterval = 10;
-      if (validatedInterval > 300) validatedInterval = 300;
+        Number.isNaN(parsedInterval) || !Number.isFinite(parsedInterval) ? 300 : parsedInterval;
+      if (validatedInterval < 300) validatedInterval = 300;
+      if (validatedInterval > 900) validatedInterval = 900;
 
       const parsedVadThreshold = vadSlider ? parseFloat(vadSlider.value) : 0.012;
       let validatedVadThreshold =


### PR DESCRIPTION
## Description

Adds a configurable summarization interval setting for AI transcript summaries.

Changes made
- Updated summarization interval slider range from seconds-based values to 5–15 minutes (300–900 seconds)
- Updated helper text and UI labels to display minutes instead of seconds
- Added validation to enforce the allowed interval range
- Persisted selected interval value in extension settings storage
- Verified settings persist correctly after page reload

Fixes #642 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Updated the “Summarization Interval” setting to use minute-based increments (5–15 minutes) with a default of 5 minutes, improving clarity and consistency between the UI and scheduling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->