### PR TITLE
fix: correct ElevenLabs API key validation and prevent credential overwrite (#770)

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -426,7 +426,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           return;
         }
 
-       const credentialsToSave: { openai_api_key?: string; elevenlabs_api_key?: string } = {};
+        const credentialsToSave: { openai_api_key?: string; elevenlabs_api_key?: string } = {};
         if (openaiKey) credentialsToSave.openai_api_key = openaiKey;
         if (elevenlabsKey) credentialsToSave.elevenlabs_api_key = elevenlabsKey;
         if (Object.keys(credentialsToSave).length > 0) {

--- a/src/options.ts
+++ b/src/options.ts
@@ -416,15 +416,22 @@ document.addEventListener("DOMContentLoaded", async () => {
           if (status) {
             status.style.color = "red";
             status.textContent = !isOpenAIValid
-              ? "Settings saved, but the OpenAI API key is invalid."
-              : "Settings saved, but the ElevenLabs API key is invalid.";
+              ? "Invalid OpenAI API key. Please check and try again."
+              : "Invalid ElevenLabs API key. Please check and try again.";
             status.classList.add("visible");
             setTimeout(() => status.classList.remove("visible"), 4000);
           }
+          saveBtn.disabled = false;
+          saveBtn.textContent = originalText;
           return;
         }
 
-        await saveApiCredentials({ openai_api_key: openaiKey, elevenlabs_api_key: elevenlabsKey });
+       const credentialsToSave: { openai_api_key?: string; elevenlabs_api_key?: string } = {};
+        if (openaiKey) credentialsToSave.openai_api_key = openaiKey;
+        if (elevenlabsKey) credentialsToSave.elevenlabs_api_key = elevenlabsKey;
+        if (Object.keys(credentialsToSave).length > 0) {
+          await saveApiCredentials(credentialsToSave);
+        }
         credentialsSaved = true;
       }
 


### PR DESCRIPTION
## Summary
Fixes #770

## Root Causes Found & Fixed

### Bug 1: Misleading error message on validation failure
The error message previously said "Settings saved, but the ElevenLabs API key is invalid" — implying settings were saved when credentials were not. Also, the save button remained disabled after the error.

**Fix:** Updated error message to clearly say "Invalid ElevenLabs API key. Please check and try again." and re-enabled the save button on validation failure so the user can correct and retry.

### Bug 2: Credential overwrite on partial save
When only an ElevenLabs key was entered (no OpenAI key), `saveApiCredentials` was called with `openai_api_key: ""` — which deleted the previously saved OpenAI key, and vice versa.

**Fix:** Now only saves credentials that are explicitly provided in the current session, leaving unmodified keys untouched.

## Files Changed
- `src/options.ts`

## Testing
- Enter only ElevenLabs key → OpenAI key is not deleted
- Enter invalid ElevenLabs key → clear error shown, button re-enables
- Enter valid ElevenLabs key → saves successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages to specify which API key (OpenAI or ElevenLabs) is invalid during validation
  * Improved API credential handling to save only provided keys, avoiding unnecessary empty credential storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->