### PR TITLE
[BUG]: Wrap base64 audio decoding in try-catch to avoid pipeline crashes

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -551,7 +551,13 @@ function getTranscriptionPrompt() {
 async function transcribeChunk(base64Audio: string, mimeType = "audio/webm", prompt = "") {
   const elevenlabsKey = await getElevenLabsApiKey();
 
-  const bytes = Uint8Array.from(atob(base64Audio), (c) => c.charCodeAt(0));
+  let bytes: any;
+  try {
+    bytes = Uint8Array.from(atob(base64Audio), (c) => c.charCodeAt(0));
+  } catch (err) {
+    console.error("[LateMeet] Failed to decode base64 audio chunk:", err);
+    return null;
+  }
   const blob = new Blob([bytes], { type: mimeType });
 
   if (!isChunkViable(blob)) {


### PR DESCRIPTION
Fixes #789

Protects the transcribeChunk function against crashes caused by malformed base64 audio inputs.

I am contributing on behalf of GSSoc'26.