### PR TITLE
[BUG]: Make escapeHtml inside dashboard.ts type-safe for non-string values

### DIFF
--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1380,9 +1380,9 @@ document.addEventListener("DOMContentLoaded", async () => {
   });
 
   // ——— Helpers ———
-  function escapeHtml(str: string) {
+  function escapeHtml(str: unknown) {
     const div = document.createElement("div");
-    div.textContent = str;
+    div.textContent = String(str ?? "");
     return div.innerHTML;
   }
 


### PR DESCRIPTION
Fixes #793

Ensures escapeHtml does not throw if passed numbers or nullish values.

I am contributing on behalf of GSSoc'26.