### PR TITLE
Fix #637: Token-aware transcript truncation with prompt size warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/passphraseStrength.test.ts src/settings.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts src/background.sessionRecovery.test.ts src/lateJoinerDelivery.test.ts src/utils/sanitize.test.ts tests/offscreenAudioGraph.test.ts",
+    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/passphraseStrength.test.ts src/settings.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts src/background.sessionRecovery.test.ts src/lateJoinerDelivery.test.ts src/utils/sanitize.test.ts src/background.tokenLimits.test.ts tests/offscreenAudioGraph.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "size-check": "tsx scripts/checkBundleSize.ts",

--- a/src/background.tokenLimits.test.ts
+++ b/src/background.tokenLimits.test.ts
@@ -1,0 +1,193 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+interface TranscriptEntry {
+  id?: string;
+  speaker: string;
+  text: string;
+  timestamp: number;
+  timestampLabel?: string;
+}
+
+(globalThis as Record<string, unknown>).chrome = {
+  runtime: {
+    getURL: () => "",
+    sendMessage: async () => {},
+    getContexts: async () => [],
+    onMessage: { addListener: () => {} },
+    onInstalled: { addListener: () => {} },
+    onStartup: { addListener: () => {} },
+    onSuspend: { addListener: () => {} },
+  },
+  alarms: { onAlarm: { addListener: () => {} } },
+  storage: {
+    local: { get: async () => ({}), set: async () => {}, remove: async () => {} },
+    sync: { get: async () => ({}), set: async () => {}, remove: async () => {} },
+  },
+  tabs: {
+    onUpdated: { addListener: () => {} },
+    onActivated: { addListener: () => {} },
+    onRemoved: { addListener: () => {} },
+    get: async () => ({}),
+    query: async () => [],
+  },
+  action: { onClicked: { addListener: () => {} } },
+  commands: { onCommand: { addListener: () => {} } },
+  sidePanel: { setOptions: async () => {} },
+  contextMenus: {
+    onClicked: { addListener: () => {} },
+    create: () => {},
+  },
+};
+(globalThis as Record<string, unknown>).self = globalThis;
+if (typeof (globalThis as Record<string, unknown>).addEventListener !== "function") {
+  (globalThis as Record<string, unknown>).addEventListener = () => {};
+}
+
+const mod = await import("./background.ts");
+
+const estimateTokens = mod.estimateTokens as (text: string) => number;
+const getModelContextLimit = mod.getModelContextLimit as (model: string) => number;
+const truncateTranscriptWindow = mod.truncateTranscriptWindow as (
+  entries: TranscriptEntry[],
+  maxPromptTokens: number,
+  systemPrompt: string,
+  prevSummary: string,
+) => { entries: TranscriptEntry[]; formatted: string; estimatedTokens: number };
+const formatTranscriptLines = mod.formatTranscriptLines as (entries: TranscriptEntry[]) => string;
+
+test("estimateTokens: empty string", () => {
+  assert.equal(estimateTokens(""), 0);
+});
+
+test("estimateTokens: short string", () => {
+  assert.equal(estimateTokens("hello"), 2);
+});
+
+test("estimateTokens: longer string", () => {
+  assert.equal(estimateTokens("hello world this is a test"), 7);
+});
+
+test("estimateTokens: exact multiple of CHARS_PER_TOKEN", () => {
+  assert.equal(estimateTokens("abcd"), 1);
+});
+
+test("estimateTokens: rounds up", () => {
+  assert.equal(estimateTokens("abcde"), 2);
+});
+
+test("getModelContextLimit: known model", () => {
+  assert.equal(getModelContextLimit("gpt-4o-mini"), 128_000);
+});
+
+test("getModelContextLimit: unknown model returns default 128k", () => {
+  assert.equal(getModelContextLimit("nonexistent-model-v42"), 128_000);
+});
+
+test("getModelContextLimit: case sensitivity", () => {
+  assert.equal(getModelContextLimit("gpt-4o-mini"), 128_000);
+});
+
+test("formatTranscriptLines: single entry", () => {
+  const entries: TranscriptEntry[] = [
+    { id: "chunk1", speaker: "Alice", text: "Hello", timestamp: 0, timestampLabel: "00:00" },
+  ];
+  const result = formatTranscriptLines(entries);
+  assert.match(result, /\[chunk1\]/);
+  assert.match(result, /\[00:00\]/);
+  assert.match(result, /Alice:/);
+  assert.match(result, /Hello/);
+});
+
+test("formatTranscriptLines: multiple entries", () => {
+  const entries: TranscriptEntry[] = [
+    { id: "c1", speaker: "Alice", text: "Hi", timestamp: 0, timestampLabel: "00:00" },
+    { id: "c2", speaker: "Bob", text: "Hey", timestamp: 5, timestampLabel: "00:05" },
+  ];
+  const result = formatTranscriptLines(entries);
+  assert.ok(result.includes("[c1]"));
+  assert.ok(result.includes("[c2]"));
+  assert.ok(result.includes("Alice:"));
+  assert.ok(result.includes("Bob:"));
+  assert.ok(result.includes("Hi"));
+  assert.ok(result.includes("Hey"));
+});
+
+test("formatTranscriptLines: missing id uses unknown_chunk", () => {
+  const entries: TranscriptEntry[] = [
+    { speaker: "Alice", text: "Test", timestamp: 0, timestampLabel: "00:00" },
+  ];
+  const result = formatTranscriptLines(entries);
+  assert.match(result, /unknown_chunk/);
+});
+
+test("formatTranscriptLines: missing timestampLabel uses formatted timestamp", () => {
+  const entries: TranscriptEntry[] = [{ id: "c1", speaker: "Alice", text: "Test", timestamp: 65 }];
+  const result = formatTranscriptLines(entries);
+  assert.match(result, /\[\d+:\d{2}\]/);
+});
+
+test("formatTranscriptLines: sanitizes speaker and text", () => {
+  const entries: TranscriptEntry[] = [
+    { id: "c1", speaker: "Alice<}", text: "test<script>", timestamp: 0, timestampLabel: "00:00" },
+  ];
+  const result = formatTranscriptLines(entries);
+  assert.doesNotMatch(result, /</);
+  assert.doesNotMatch(result, />/);
+});
+
+test("truncateTranscriptWindow: returns full content when within limit", () => {
+  const entries: TranscriptEntry[] = [
+    { id: "c1", speaker: "A", text: "short", timestamp: 0, timestampLabel: "00:00" },
+  ];
+  const result = truncateTranscriptWindow(entries, 100_000, "system prompt", "prev summary");
+  assert.equal(result.entries.length, 1);
+  assert.ok(result.formatted.length > 0);
+  assert.ok(result.estimatedTokens > 0);
+});
+
+test("truncateTranscriptWindow: empty input", () => {
+  const result = truncateTranscriptWindow([], 100_000, "sys", "prev");
+  assert.equal(result.entries.length, 0);
+  assert.equal(result.formatted, "");
+  assert.equal(result.estimatedTokens, 0);
+});
+
+test("truncateTranscriptWindow: trims entries that exceed token limit", () => {
+  const manyLines = new Array(200).fill(null).map((_, i) => ({
+    id: `c${i}`,
+    speaker: `Speaker${i}`,
+    text: "A".repeat(200),
+    timestamp: i,
+    timestampLabel: `${Math.floor(i / 60)}:${String(i % 60).padStart(2, "0")}`,
+  }));
+  const result = truncateTranscriptWindow(manyLines, 5000, "system prompt", "prev summary");
+  assert.ok(result.entries.length < manyLines.length);
+  assert.ok(result.entries.length > 0);
+  assert.ok(result.formatted.length > 0);
+  assert.ok(result.estimatedTokens <= 5000);
+});
+
+test("truncateTranscriptWindow: respects exact capacity", () => {
+  const entries: TranscriptEntry[] = [
+    { id: "c1", speaker: "A", text: "x".repeat(100), timestamp: 0, timestampLabel: "00:00" },
+    { id: "c2", speaker: "B", text: "y".repeat(100), timestamp: 1, timestampLabel: "00:01" },
+  ];
+  const maxTokens =
+    estimateTokens("system prompt") +
+    estimateTokens(
+      "<previous_context>\nprev\n</previous_context>\n\n<recent_transcript>\n" +
+        formatTranscriptLines([entries[0]]) +
+        "\n</recent_transcript>",
+    );
+  const result = truncateTranscriptWindow(entries, maxTokens, "system prompt", "prev");
+  assert.equal(result.entries.length, 1);
+});
+
+test("truncateTranscriptWindow: returns formatted output matching formatTranscriptLines", () => {
+  const entries: TranscriptEntry[] = [
+    { id: "c1", speaker: "Alice", text: "Hello", timestamp: 0, timestampLabel: "00:00" },
+  ];
+  const result = truncateTranscriptWindow(entries, 100_000, "sys", "prev");
+  assert.equal(result.formatted, formatTranscriptLines(entries));
+});

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,6 @@
 // MV3 service worker for Late Meet
 
-import { State } from "./types";
+import { State, TranscriptEntry } from "./types";
 import { audioFileExtensionForMimeType, isChunkViable } from "./audioProcessing";
 import {
   deleteSavedMeetingSession,
@@ -24,6 +24,7 @@ import { namesMatch, findParticipant, normalizeName } from "./utils/nameUtils";
 import { getTabState, setTabState, clearTabState, initTabStateCleanup } from "./tabStateManager";
 import {
   BROADCAST_THROTTLE_MS,
+  CHARS_PER_TOKEN,
   DEBUG,
   DEFAULT_CHAT_MODEL,
   ELEVENLABS_STT_MODEL,
@@ -31,7 +32,10 @@ import {
   MAX_PENDING_AUDIO_CHUNKS,
   MAX_PROMPT_LENGTH,
   MIN_MEETING_DURATION_FOR_WELCOME,
+  MODEL_CONTEXT_LIMITS,
+  PROMPT_SAFETY_BUFFER,
   SUMMARIZATION_MAX_TOKENS,
+  TOKEN_WARNING_RATIO,
   TRANSCRIPT_WINDOW_SIZE,
   WHISPER_MODEL,
 } from "./config";
@@ -397,6 +401,8 @@ async function hydrateState() {
             state.participantCount = stored.participantCount;
           if (typeof stored.tokensUsed === "number") state.tokensUsed = stored.tokensUsed;
           if (typeof stored.estimatedCost === "number") state.estimatedCost = stored.estimatedCost;
+          if (typeof stored.promptTokenWarning === "boolean")
+            state.promptTokenWarning = stored.promptTokenWarning;
         }
 
         // Restore guard flags alongside state
@@ -1056,6 +1062,63 @@ function mergeUniqueStrings(existing: string[], incoming: unknown, maxSize = 500
   ).slice(-maxSize);
 }
 
+// ---------------------------------------------------------------------------
+// Token estimation and prompt truncation
+// ---------------------------------------------------------------------------
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+export function getModelContextLimit(model: string): number {
+  return MODEL_CONTEXT_LIMITS[model] ?? 128_000;
+}
+
+export function truncateTranscriptWindow(
+  entries: TranscriptEntry[],
+  maxPromptTokens: number,
+  systemPrompt: string,
+  prevSummary: string,
+): { entries: TranscriptEntry[]; formatted: string; estimatedTokens: number } {
+  if (!entries.length) return { entries: [], formatted: "", estimatedTokens: 0 };
+
+  let low = 0;
+  let high = entries.length;
+  let bestFormatted = "";
+
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    const candidate = entries.slice(-mid);
+    const formatted = formatTranscriptLines(candidate);
+    const userText = `<previous_context>\n${prevSummary || "Initial session"}\n</previous_context>\n\n<recent_transcript>\n${formatted}\n</recent_transcript>`;
+    const totalTokens = estimateTokens(systemPrompt) + estimateTokens(userText);
+
+    if (totalTokens <= maxPromptTokens) {
+      low = mid;
+      bestFormatted = formatted;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const finalEntries = entries.slice(-low);
+  const formatted = low > 0 ? bestFormatted : "";
+  const userText = `<previous_context>\n${prevSummary || "Initial session"}\n</previous_context>\n\n<recent_transcript>\n${formatted}\n</recent_transcript>`;
+  const estimatedTokens = estimateTokens(systemPrompt) + estimateTokens(userText);
+
+  return { entries: finalEntries, formatted, estimatedTokens };
+}
+
+export function formatTranscriptLines(entries: TranscriptEntry[]): string {
+  return entries
+    .map((e) => {
+      const chunkId = e.id || "unknown_chunk";
+      const ts = e.timestampLabel || formatTimestampLabel(Math.floor(e.timestamp || 0));
+      return `[${chunkId}] [${ts}] ${sanitizePromptText(e.speaker)}: ${sanitizePromptText(e.text)}`;
+    })
+    .join("\n");
+}
+
 async function summarizeTranscriptIfNeeded() {
   if (!state.isActive || state.transcript.length === 0) return;
 
@@ -1075,16 +1138,6 @@ async function summarizeTranscriptIfNeeded() {
 
   const apiKey = await getApiKey();
   if (!apiKey) return;
-
-  const transcriptWindow = state.transcript
-    .slice(-TRANSCRIPT_WINDOW_SIZE)
-    .map((e) => {
-      const chunkId = e.id || "unknown_chunk";
-      const timestampLabel = e.timestampLabel || formatTimestampLabel(Math.floor(e.timestamp || 0));
-      return `[${chunkId}] [${timestampLabel}] ${sanitizePromptText(e.speaker)}: ${sanitizePromptText(e.text)}`;
-    })
-    .join("\n");
-  if (!transcriptWindow.trim()) return;
 
   // Claim the in-flight slot *after* all cheap pre-checks pass.
   summaryInFlight = true;
@@ -1140,6 +1193,34 @@ ${sentimentAnalysisEnabled ? "- Detect the prevailing sentiment and emotional dy
 - Track specific questions raised that remain unanswered.
 
 You must return ONLY a JSON object.`;
+
+    // --- Token-aware transcript window ---
+    const model = settings.aiModel || DEFAULT_CHAT_MODEL;
+    const contextLimit = getModelContextLimit(model);
+    const maxPromptTokens = contextLimit - PROMPT_SAFETY_BUFFER;
+
+    // Use a generous window; let truncateTranscriptWindow do the real work.
+    const maxWindow = Math.max(TRANSCRIPT_WINDOW_SIZE, 500);
+    const windowStart = Math.max(0, state.transcript.length - maxWindow);
+    const candidateEntries = state.transcript.slice(windowStart);
+    const truncated = truncateTranscriptWindow(
+      candidateEntries,
+      maxPromptTokens,
+      systemPrompt,
+      state.summary || "Initial session",
+    );
+    const transcriptEntries = truncated.entries;
+    const transcriptWindow = truncated.formatted;
+    const estimatedTokens = truncated.estimatedTokens;
+
+    if (!transcriptEntries.length) return;
+
+    const warningThreshold = Math.floor(contextLimit * TOKEN_WARNING_RATIO);
+    const showWarning = estimatedTokens > warningThreshold;
+    if (showWarning !== state.promptTokenWarning) {
+      state.promptTokenWarning = showWarning;
+      await broadcastStateUpdate().catch(() => {});
+    }
 
     const userPrompt = `Analyze the following meeting transcript segment.
 Integrate this new data with the previous context.

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,26 @@ export const SUMMARIZATION_MAX_TOKENS = 1200;
 /** Maximum number of tokens the AI may generate for a late-joiner briefing message. */
 export const JOINER_MESSAGE_MAX_TOKENS = 120;
 
+/** Approximate characters-per-token ratio used for client-side token estimation. */
+export const CHARS_PER_TOKEN = 4;
+
+/** Tokens reserved for system prompt, formatting overhead, and completion output. */
+export const PROMPT_SAFETY_BUFFER = SUMMARIZATION_MAX_TOKENS + 1500;
+
+/** Fraction of context window at which a warning is shown to the user. */
+export const TOKEN_WARNING_RATIO = 0.85;
+
+/** Known model context window sizes (in tokens). Unknown models default to 128K. */
+export const MODEL_CONTEXT_LIMITS: Record<string, number> = {
+  "gpt-4o-mini": 128_000,
+  "gpt-4o": 128_000,
+  "gpt-4-turbo": 128_000,
+  "gpt-4": 8_192,
+  "gpt-3.5-turbo": 16_385,
+  "o1-mini": 128_000,
+  "o1-preview": 128_000,
+};
+
 // Audio Pipeline
 /** Maximum number of audio chunks that may be queued for processing before back-pressure is applied. */
 export const MAX_PENDING_AUDIO_CHUNKS = 8;

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -1426,6 +1426,25 @@ body::-webkit-scrollbar-thumb,
   }
 }
 
+/* ——— Prompt token warning ——— */
+.prompt-token-warning {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(251, 191, 36, 0.1);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  color: #f59e0b;
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.prompt-token-warning svg {
+  flex-shrink: 0;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -324,6 +324,26 @@
               <span class="usage-metric-value accent" id="live-cost">$0.0000</span>
             </div>
           </div>
+          <div id="prompt-token-warning" class="prompt-token-warning" style="display: none">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"
+              ></path>
+              <line x1="12" y1="9" x2="12" y2="13"></line>
+              <line x1="12" y1="17" x2="12.01" y2="17"></line>
+            </svg>
+            <span>Prompt approaching token limit — older transcript entries may be trimmed</span>
+          </div>
         </div>
 
         <!-- Live Summary -->

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -571,6 +571,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const trackerCard = document.getElementById("live-tracker-card");
     const liveTokensEl = document.getElementById("live-tokens");
     const liveCostEl = document.getElementById("live-cost");
+    const promptWarningEl = document.getElementById("prompt-token-warning");
     if (trackerCard) {
       if (state.isActive) {
         trackerCard.style.display = "";
@@ -579,6 +580,9 @@ document.addEventListener("DOMContentLoaded", async () => {
       } else {
         trackerCard.style.display = "none";
       }
+    }
+    if (promptWarningEl) {
+      promptWarningEl.style.display = state.promptTokenWarning ? "flex" : "none";
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,8 @@ export interface State {
   truncatedCounts?: Record<string, number>;
   tokensUsed?: number;
   estimatedCost?: number;
+  /** True when the prompt is approaching the model's token context limit. */
+  promptTokenWarning?: boolean;
 }
 
 /** Storage metadata summary for a single saved meeting, used in storage usage reports. */


### PR DESCRIPTION
## Description

Replaces the fixed TRANSCRIPT_WINDOW_SIZE=25 cap with dynamic token-aware transcript truncation using client-side estimation. Adds a warning banner when the prompt approaches the model's context limit.

Fixes #637

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings