### PR TITLE
Fix #623: Adaptive noise gate with dynamic noise floor estimation

### DIFF
--- a/src/audioProcessing.test.ts
+++ b/src/audioProcessing.test.ts
@@ -217,15 +217,15 @@ test("noise gate: default initial threshold", () => {
   assert.equal(gate.getThreshold(), 0.024); // 0.012 * 2.0
 });
 
-test("noise gate: process returns current threshold", () => {
+test("noise gate: analyze returns current threshold", () => {
   const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01 });
-  const threshold = gate.process(0.005);
+  const threshold = gate.analyze(0.005);
   assert.equal(threshold, 0.02);
 });
 
 test("noise gate: speech keeps gate open via hold counter", () => {
   const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01, holdFrames: 3 });
-  gate.process(0.03); // speech (above 0.02 threshold)
+  gate.analyze(0.03); // speech (above 0.02 threshold)
   assert.ok(gate.isOpen, "gate should open after speech");
   gate.tick();
   assert.ok(gate.isOpen, "gate should stay open after 1 tick");
@@ -237,10 +237,10 @@ test("noise gate: speech keeps gate open via hold counter", () => {
 
 test("noise gate: hold counter resets on repeated speech", () => {
   const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01, holdFrames: 2 });
-  gate.process(0.03); // speech
+  gate.analyze(0.03); // speech
   gate.tick();
   assert.ok(gate.isOpen);
-  gate.process(0.03); // speech again — resets hold
+  gate.analyze(0.03); // speech again — resets hold
   gate.tick();
   assert.ok(gate.isOpen, "hold should reset");
   gate.tick();
@@ -249,7 +249,7 @@ test("noise gate: hold counter resets on repeated speech", () => {
 
 test("noise gate: tick returns true while hold active", () => {
   const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01, holdFrames: 2 });
-  gate.process(0.03);
+  gate.analyze(0.03);
   assert.equal(gate.tick(), true);
   assert.equal(gate.tick(), true);
   assert.equal(gate.tick(), false);
@@ -264,7 +264,7 @@ test("noise gate: noise floor adapts upward during silence", () => {
 
   // Feed silent RMS values (below threshold)
   for (let i = 0; i < 10; i++) {
-    gate.process(0.015);
+    gate.analyze(0.015);
   }
 
   assert.ok(
@@ -273,7 +273,7 @@ test("noise gate: noise floor adapts upward during silence", () => {
   );
 });
 
-test("noise gate: noise floor decays slowly during speech", () => {
+test("noise gate: noise floor is unchanged during speech (long-meeting stability)", () => {
   const gate = new AdaptiveNoiseGate({
     initialThreshold: 0.01,
     adaptationRate: 0.5,
@@ -281,13 +281,15 @@ test("noise gate: noise floor decays slowly during speech", () => {
   const initialFloor = gate.getNoiseFloor();
 
   // Feed speech RMS values (above threshold)
-  for (let i = 0; i < 100; i++) {
-    gate.process(0.05);
+  for (let i = 0; i < 1000; i++) {
+    gate.analyze(0.05);
   }
 
-  assert.ok(
-    gate.getNoiseFloor() < initialFloor,
-    "noise floor should decay during sustained speech with no noise",
+  assert.equal(
+    gate.getNoiseFloor(),
+    initialFloor,
+    "noise floor must not decay toward zero during sustained speech — " +
+      "that would classify everything as speech over a long meeting",
   );
 });
 
@@ -316,21 +318,30 @@ test("noise gate: getNoiseFloor returns current floor", () => {
 
 test("noise gate: reset restores initial state", () => {
   const gate = new AdaptiveNoiseGate({ initialThreshold: 0.02, holdFrames: 3 });
-  gate.process(0.05); // speech
+  gate.analyze(0.05); // speech — noise floor stays unchanged by design
   gate.tick();
+
   assert.ok(gate.isOpen);
-  assert.ok(gate.getNoiseFloor() < 0.02);
+  assert.equal(
+    gate.getNoiseFloor(),
+    0.02,
+    "noise floor should remain at initialThreshold during speech",
+  );
 
   gate.reset();
 
-  assert.equal(gate.getNoiseFloor(), 0.012);
+  assert.equal(
+    gate.getNoiseFloor(),
+    0.02,
+    "reset should restore the initialThreshold from constructor options",
+  );
   assert.equal(gate.isOpen, false);
 });
 
 test("noise gate: non-finite RMS does not trigger speech", () => {
   const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01 });
-  gate.process(NaN);
+  gate.analyze(NaN);
   assert.equal(gate.isOpen, false);
-  gate.process(Infinity);
+  gate.analyze(Infinity);
   assert.equal(gate.isOpen, false);
 });

--- a/src/audioProcessing.test.ts
+++ b/src/audioProcessing.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  AdaptiveNoiseGate,
   VoiceActivityTracker,
   audioFileExtensionForMimeType,
   isChunkViable,
@@ -202,4 +203,134 @@ test("custom minimum chunk size is respected", () => {
     true,
     "custom minimum size must override the default threshold",
   );
+});
+
+// ─── Adaptive noise gate ─────────────────────────────────────────────────────
+
+test("noise gate: initial threshold matches constructor arg", () => {
+  const gate = new AdaptiveNoiseGate({ initialThreshold: 0.02 });
+  assert.equal(gate.getThreshold(), 0.04); // 0.02 * 2.0
+});
+
+test("noise gate: default initial threshold", () => {
+  const gate = new AdaptiveNoiseGate();
+  assert.equal(gate.getThreshold(), 0.024); // 0.012 * 2.0
+});
+
+test("noise gate: process returns current threshold", () => {
+  const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01 });
+  const threshold = gate.process(0.005);
+  assert.equal(threshold, 0.02);
+});
+
+test("noise gate: speech keeps gate open via hold counter", () => {
+  const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01, holdFrames: 3 });
+  gate.process(0.03); // speech (above 0.02 threshold)
+  assert.ok(gate.isOpen, "gate should open after speech");
+  gate.tick();
+  assert.ok(gate.isOpen, "gate should stay open after 1 tick");
+  gate.tick();
+  assert.ok(gate.isOpen, "gate should stay open after 2 ticks");
+  gate.tick();
+  assert.equal(gate.isOpen, false, "gate should close after hold expires");
+});
+
+test("noise gate: hold counter resets on repeated speech", () => {
+  const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01, holdFrames: 2 });
+  gate.process(0.03); // speech
+  gate.tick();
+  assert.ok(gate.isOpen);
+  gate.process(0.03); // speech again — resets hold
+  gate.tick();
+  assert.ok(gate.isOpen, "hold should reset");
+  gate.tick();
+  assert.equal(gate.isOpen, false);
+});
+
+test("noise gate: tick returns true while hold active", () => {
+  const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01, holdFrames: 2 });
+  gate.process(0.03);
+  assert.equal(gate.tick(), true);
+  assert.equal(gate.tick(), true);
+  assert.equal(gate.tick(), false);
+});
+
+test("noise gate: noise floor adapts upward during silence", () => {
+  const gate = new AdaptiveNoiseGate({
+    initialThreshold: 0.01,
+    adaptationRate: 0.5,
+  });
+  const initialFloor = gate.getNoiseFloor();
+
+  // Feed silent RMS values (below threshold)
+  for (let i = 0; i < 10; i++) {
+    gate.process(0.015);
+  }
+
+  assert.ok(
+    gate.getNoiseFloor() > initialFloor,
+    "noise floor should rise during sustained silence at a higher RMS",
+  );
+});
+
+test("noise gate: noise floor decays slowly during speech", () => {
+  const gate = new AdaptiveNoiseGate({
+    initialThreshold: 0.01,
+    adaptationRate: 0.5,
+  });
+  const initialFloor = gate.getNoiseFloor();
+
+  // Feed speech RMS values (above threshold)
+  for (let i = 0; i < 100; i++) {
+    gate.process(0.05);
+  }
+
+  assert.ok(
+    gate.getNoiseFloor() < initialFloor,
+    "noise floor should decay during sustained speech with no noise",
+  );
+});
+
+test("noise gate: threshold clamped to min", () => {
+  const gate = new AdaptiveNoiseGate({
+    initialThreshold: 0.001,
+    minThreshold: 0.005,
+    thresholdMultiplier: 1.0,
+  });
+  assert.equal(gate.getThreshold(), 0.005);
+});
+
+test("noise gate: threshold clamped to max", () => {
+  const gate = new AdaptiveNoiseGate({
+    initialThreshold: 0.1,
+    maxThreshold: 0.05,
+    thresholdMultiplier: 1.0,
+  });
+  assert.equal(gate.getThreshold(), 0.05);
+});
+
+test("noise gate: getNoiseFloor returns current floor", () => {
+  const gate = new AdaptiveNoiseGate({ initialThreshold: 0.015 });
+  assert.equal(gate.getNoiseFloor(), 0.015);
+});
+
+test("noise gate: reset restores initial state", () => {
+  const gate = new AdaptiveNoiseGate({ initialThreshold: 0.02, holdFrames: 3 });
+  gate.process(0.05); // speech
+  gate.tick();
+  assert.ok(gate.isOpen);
+  assert.ok(gate.getNoiseFloor() < 0.02);
+
+  gate.reset();
+
+  assert.equal(gate.getNoiseFloor(), 0.012);
+  assert.equal(gate.isOpen, false);
+});
+
+test("noise gate: non-finite RMS does not trigger speech", () => {
+  const gate = new AdaptiveNoiseGate({ initialThreshold: 0.01 });
+  gate.process(NaN);
+  assert.equal(gate.isOpen, false);
+  gate.process(Infinity);
+  assert.equal(gate.isOpen, false);
 });

--- a/src/audioProcessing.ts
+++ b/src/audioProcessing.ts
@@ -62,7 +62,7 @@ export interface NoiseGateOptions {
  *
  * @example
  *   const gate = new AdaptiveNoiseGate({ initialThreshold: 0.012 });
- *   gate.process(0.008); // returns adaptive threshold (~0.012)
+ *   gate.analyze(0.008); // returns adaptive threshold (~0.012)
  *   gate.tick();         // returns true (gate still held open)
  */
 export class AdaptiveNoiseGate {
@@ -72,35 +72,36 @@ export class AdaptiveNoiseGate {
   private readonly minThreshold: number;
   private readonly maxThreshold: number;
   private readonly holdFrames: number;
+  private readonly initialThreshold: number;
   private holdCounter: number;
-  private frameCount: number;
 
   constructor(options: NoiseGateOptions = {}) {
-    this.noiseFloor = options.initialThreshold ?? 0.012;
+    this.initialThreshold = options.initialThreshold ?? 0.012;
+    this.noiseFloor = this.initialThreshold;
     this.adaptationRate = options.adaptationRate ?? 0.01;
     this.thresholdMultiplier = options.thresholdMultiplier ?? 2.0;
     this.minThreshold = options.minThreshold ?? 0.003;
     this.maxThreshold = options.maxThreshold ?? 0.05;
     this.holdFrames = options.holdFrames ?? 2;
     this.holdCounter = 0;
-    this.frameCount = 0;
   }
 
   /**
-   * Feed an RMS sample to the estimator. The noise floor is adapted upward
-   * during silence frames and decays slowly during speech.
+   * Feed an RMS sample to the estimator and receive the current adaptive
+   * threshold. The noise floor is adapted upward during silence frames and
+   * left unchanged during speech so it cannot asymptotically drift toward
+   * zero over a long meeting.
    *
    * @returns The current adaptive threshold.
    */
-  process(rms: number): number {
-    this.frameCount++;
+  analyze(rms: number): number {
     const threshold = this.getThreshold();
     const isSpeech = Number.isFinite(rms) && rms >= threshold;
 
     if (isSpeech) {
       this.holdCounter = this.holdFrames;
-      // Slow decay during speech in case ambient noise drops
-      this.noiseFloor *= 1 - this.adaptationRate * 0.1;
+      // Noise floor is untouched during speech — it stays at the last
+      // silence estimate so it cannot decay toward zero over long meetings.
     } else {
       // Adapt noise floor toward observed RMS during silence
       this.noiseFloor += this.adaptationRate * (rms - this.noiseFloor);
@@ -138,11 +139,10 @@ export class AdaptiveNoiseGate {
     return this.noiseFloor;
   }
 
-  /** Reset the estimator to its initial state. */
+  /** Reset the estimator to its initial state (same constructor options). */
   reset(): void {
-    this.noiseFloor = 0.012;
+    this.noiseFloor = this.initialThreshold;
     this.holdCounter = 0;
-    this.frameCount = 0;
   }
 }
 

--- a/src/audioProcessing.ts
+++ b/src/audioProcessing.ts
@@ -35,6 +35,122 @@ export class VoiceActivityTracker {
 }
 
 /**
+ * @description Options for configuring the AdaptiveNoiseGate
+ * @property {number} initialThreshold - Starting noise floor estimate (default 0.012)
+ * @property {number} adaptationRate - How fast the noise floor adapts during silence (0-1, default 0.01)
+ * @property {number} thresholdMultiplier - Multiplier from noise floor to gate threshold (default 2.0)
+ * @property {number} minThreshold - Minimum gate threshold (default 0.003)
+ * @property {number} maxThreshold - Maximum gate threshold (default 0.05)
+ * @property {number} holdFrames - Frames to keep gate open after last speech frame (default 2)
+ */
+export interface NoiseGateOptions {
+  initialThreshold?: number;
+  adaptationRate?: number;
+  thresholdMultiplier?: number;
+  minThreshold?: number;
+  maxThreshold?: number;
+  holdFrames?: number;
+}
+
+/**
+ * @description Dynamically estimates the background noise floor from incoming RMS
+ * samples and computes an adaptive gate threshold. During silence the noise floor
+ * slowly tracks the observed RMS; during speech it decays very gradually so the
+ * gate stays responsive when ambient noise drops.
+ *
+ * A hold counter prevents the gate from chattering during short inter-word pauses.
+ *
+ * @example
+ *   const gate = new AdaptiveNoiseGate({ initialThreshold: 0.012 });
+ *   gate.process(0.008); // returns adaptive threshold (~0.012)
+ *   gate.tick();         // returns true (gate still held open)
+ */
+export class AdaptiveNoiseGate {
+  private noiseFloor: number;
+  private readonly adaptationRate: number;
+  private readonly thresholdMultiplier: number;
+  private readonly minThreshold: number;
+  private readonly maxThreshold: number;
+  private readonly holdFrames: number;
+  private holdCounter: number;
+  private frameCount: number;
+
+  constructor(options: NoiseGateOptions = {}) {
+    this.noiseFloor = options.initialThreshold ?? 0.012;
+    this.adaptationRate = options.adaptationRate ?? 0.01;
+    this.thresholdMultiplier = options.thresholdMultiplier ?? 2.0;
+    this.minThreshold = options.minThreshold ?? 0.003;
+    this.maxThreshold = options.maxThreshold ?? 0.05;
+    this.holdFrames = options.holdFrames ?? 2;
+    this.holdCounter = 0;
+    this.frameCount = 0;
+  }
+
+  /**
+   * Feed an RMS sample to the estimator. The noise floor is adapted upward
+   * during silence frames and decays slowly during speech.
+   *
+   * @returns The current adaptive threshold.
+   */
+  process(rms: number): number {
+    this.frameCount++;
+    const threshold = this.getThreshold();
+    const isSpeech = Number.isFinite(rms) && rms >= threshold;
+
+    if (isSpeech) {
+      this.holdCounter = this.holdFrames;
+      // Slow decay during speech in case ambient noise drops
+      this.noiseFloor *= 1 - this.adaptationRate * 0.1;
+    } else {
+      // Adapt noise floor toward observed RMS during silence
+      this.noiseFloor += this.adaptationRate * (rms - this.noiseFloor);
+    }
+
+    return threshold;
+  }
+
+  /**
+   * Decrement the hold counter by one frame. Call this on every VAD tick
+   * (even when analysis is throttled) so the hold timer progresses correctly.
+   *
+   * @returns True while the gate should remain open (hold active).
+   */
+  tick(): boolean {
+    if (this.holdCounter > 0) {
+      this.holdCounter--;
+      return true;
+    }
+    return false;
+  }
+
+  /** Whether the gate is currently held open after recent speech. */
+  get isOpen(): boolean {
+    return this.holdCounter > 0;
+  }
+
+  /** Returns the current adaptive gate threshold. */
+  getThreshold(): number {
+    return clamp(this.noiseFloor * this.thresholdMultiplier, this.minThreshold, this.maxThreshold);
+  }
+
+  /** Returns the estimated noise floor. */
+  getNoiseFloor(): number {
+    return this.noiseFloor;
+  }
+
+  /** Reset the estimator to its initial state. */
+  reset(): void {
+    this.noiseFloor = 0.012;
+    this.holdCounter = 0;
+    this.frameCount = 0;
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
  * @description Determines the appropriate file extension for an audio MIME type
  * @param {string} mimeType - The MIME type of the audio (e.g., "audio/webm", "audio/mp3")
  * @returns {string} The file extension without the dot (e.g., "webm", "mp3", "ogg")

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,7 +24,27 @@ export const SUMMARIZATION_MAX_TOKENS = 1200;
 export const JOINER_MESSAGE_MAX_TOKENS = 120;
 
 // Audio Pipeline
-/** Maximum number of audio chunks that may be queued for processing before back-pressure is applied. */
+/** Default RMS threshold for voice activity detection when no adaptive noise gate is used. */
+export const DEFAULT_VAD_THRESHOLD = 0.012;
+
+/** How fast the adaptive noise gate's noise floor tracks during silence (0-1). */
+export const NOISE_GATE_ADAPTATION_RATE = 0.01;
+
+/** Multiplier applied to the noise floor to derive the gate threshold. */
+export const NOISE_GATE_THRESHOLD_MULTIPLIER = 2.0;
+
+/** Minimum gate threshold to prevent the gate from staying wide open. */
+export const NOISE_GATE_MIN_THRESHOLD = 0.003;
+
+/** Maximum gate threshold to prevent the gate from silencing normal speech. */
+export const NOISE_GATE_MAX_THRESHOLD = 0.05;
+
+/** Number of VAD frames the gate stays open after the last speech frame. */
+export const NOISE_GATE_HOLD_FRAMES = 2;
+
+/** Time constant (seconds) for gain ramp smoothing when the gate opens/closes. */
+export const NOISE_GATE_RAMP_TIME = 0.01;
+
 export const MAX_PENDING_AUDIO_CHUNKS = 8;
 
 /** Interval in milliseconds at which voice-activity detection (VAD) samples audio energy. */

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -619,7 +619,7 @@ async function startCapture(
         voiceActivity.observe(rms);
 
         // Use adaptive threshold when noise gate is available
-        const adaptiveThreshold = noiseGate?.process(rms) ?? rmsThreshold;
+        const adaptiveThreshold = noiseGate?.analyze(rms) ?? rmsThreshold;
         speechActive = Number.isFinite(rms) && rms >= adaptiveThreshold;
 
         if (speechActive) {
@@ -636,15 +636,14 @@ async function startCapture(
       const gainOpen = speechActive || gateHolding;
 
       // Smoothly ramp the noise gain node to avoid audible clicks.
+      // setTargetAtTime is idempotent when the target is already reached,
+      // so we skip the guard entirely rather than carry a magic tolerance.
       if (noiseGateGainNode && audioContext) {
-        const targetGain = gainOpen ? 1 : 0;
-        if (Math.abs(noiseGateGainNode.gain.value - targetGain) > 0.01) {
-          noiseGateGainNode.gain.setTargetAtTime(
-            targetGain,
-            audioContext.currentTime,
-            NOISE_GATE_RAMP_TIME,
-          );
-        }
+        noiseGateGainNode.gain.setTargetAtTime(
+          gainOpen ? 1 : 0,
+          audioContext.currentTime,
+          NOISE_GATE_RAMP_TIME,
+        );
       }
 
       if (naturalPause || overflowReached) {

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -1,9 +1,15 @@
-import { VoiceActivityTracker, isChunkViable } from "./audioProcessing";
+import { AdaptiveNoiseGate, VoiceActivityTracker, isChunkViable } from "./audioProcessing";
 import { computeRms, shouldRunVadAnalysis } from "./vadTuning";
 import {
   DRAIN_TIMEOUT_MS,
   MAX_BUFFER_MS,
   MAX_PENDING_CHUNKS,
+  NOISE_GATE_ADAPTATION_RATE,
+  NOISE_GATE_HOLD_FRAMES,
+  NOISE_GATE_MAX_THRESHOLD,
+  NOISE_GATE_MIN_THRESHOLD,
+  NOISE_GATE_RAMP_TIME,
+  NOISE_GATE_THRESHOLD_MULTIPLIER,
   SILENCE_FLUSH_MS,
   VAD_SAMPLE_MS,
   WAVEFORM_BUCKETS,
@@ -22,9 +28,12 @@ let recorderStream: MediaStream | null = null;
 let mediaRecorder: MediaRecorder | null = null;
 let audioContext: AudioContext | null = null;
 let analyserNode: AnalyserNode | null = null;
+let noiseGateGainNode: GainNode | null = null;
 let vadTimer: ReturnType<typeof setInterval> | null = null;
 let waveformTimer: ReturnType<typeof setInterval> | null = null;
 let audioSources: MediaStreamAudioSourceNode[] = [];
+
+let noiseGate: AdaptiveNoiseGate | null = null;
 
 let pendingChunks: Blob[] = [];
 let isStopping = false;
@@ -311,6 +320,7 @@ async function cleanupResources() {
 
   mediaRecorder = null;
   analyserNode = null;
+  noiseGateGainNode = null;
   analysisBuffer = null;
   audioSources = [];
   pendingChunks = [];
@@ -320,6 +330,9 @@ async function cleanupResources() {
   speechActive = false;
   vadTickCounter = 0;
   bufferStartTime = 0;
+
+  noiseGate?.reset();
+  noiseGate = null;
 
   voiceActivity = new VoiceActivityTracker({
     rmsThreshold: rmsThreshold,
@@ -529,6 +542,7 @@ async function startCapture(
   const destination = audioGraph.recorderDestination;
 
   analyserNode = audioGraph.analyser;
+  noiseGateGainNode = audioGraph.noiseGateGain;
   audioSources.push(audioGraph.tabSource);
 
   if (includeMicrophone) {
@@ -569,6 +583,15 @@ async function startCapture(
     rmsThreshold: rmsThreshold,
   });
 
+  noiseGate = new AdaptiveNoiseGate({
+    initialThreshold: rmsThreshold,
+    adaptationRate: NOISE_GATE_ADAPTATION_RATE,
+    thresholdMultiplier: NOISE_GATE_THRESHOLD_MULTIPLIER,
+    minThreshold: NOISE_GATE_MIN_THRESHOLD,
+    maxThreshold: NOISE_GATE_MAX_THRESHOLD,
+    holdFrames: NOISE_GATE_HOLD_FRAMES,
+  });
+
   silenceTicks = 0;
   speechActive = false;
   vadTickCounter = 0;
@@ -594,13 +617,34 @@ async function startCapture(
       if (runAnalysis) {
         rms = getCurrentRms();
         voiceActivity.observe(rms);
-        speechActive = rms >= rmsThreshold;
+
+        // Use adaptive threshold when noise gate is available
+        const adaptiveThreshold = noiseGate?.process(rms) ?? rmsThreshold;
+        speechActive = Number.isFinite(rms) && rms >= adaptiveThreshold;
+
         if (speechActive) {
           silenceTicks = 0;
         } else {
           silenceTicks++;
         }
         naturalPause = silenceTicks >= SILENCE_FLUSH_TICKS;
+      }
+
+      // Tick the noise gate hold counter on every VAD cycle so the gate
+      // decays correctly even during analysis-throttled ticks.
+      const gateHolding = noiseGate?.tick() ?? false;
+      const gainOpen = speechActive || gateHolding;
+
+      // Smoothly ramp the noise gain node to avoid audible clicks.
+      if (noiseGateGainNode && audioContext) {
+        const targetGain = gainOpen ? 1 : 0;
+        if (Math.abs(noiseGateGainNode.gain.value - targetGain) > 0.01) {
+          noiseGateGainNode.gain.setTargetAtTime(
+            targetGain,
+            audioContext.currentTime,
+            NOISE_GATE_RAMP_TIME,
+          );
+        }
       }
 
       if (naturalPause || overflowReached) {

--- a/src/offscreenAudioGraph.ts
+++ b/src/offscreenAudioGraph.ts
@@ -10,25 +10,33 @@ export interface OffscreenAudioGraph {
   recorderDestination: MediaStreamAudioDestinationNode;
   analyser: AnalyserNode;
   tabSource: MediaStreamAudioSourceNode;
+  noiseGateGain: GainNode;
 }
 
 /**
  * Connects a media stream to the shared recorder and analyser nodes.
  *
- * Only the tab stream receives a playback destination. The microphone must
- * never be routed to AudioContext.destination because that would create local
- * monitoring and potentially audible feedback.
+ * The recorder path is routed through the noise gate gain node so the
+ * adaptive noise gate can attenuate silent passages before they reach
+ * the MediaRecorder.  The analyser and playback destinations always
+ * receive the raw (ungated) signal so VAD and waveform rendering are
+ * unaffected by the gate state.
  */
 function connectCaptureSource(
   context: AudioContext,
   stream: MediaStream,
   recorderDestination: MediaStreamAudioDestinationNode,
   analyser: AnalyserNode,
+  noiseGateGain: GainNode,
   playbackDestination?: AudioDestinationNode,
 ): MediaStreamAudioSourceNode {
   const source = context.createMediaStreamSource(stream);
 
-  source.connect(recorderDestination);
+  // Gated path → recorder (noise gate can mute silent passages)
+  source.connect(noiseGateGain);
+  noiseGateGain.connect(recorderDestination);
+
+  // Ungated path → analyser (VAD & waveform need raw signal)
   source.connect(analyser);
 
   if (playbackDestination) {
@@ -47,14 +55,17 @@ export function createOffscreenAudioGraph(
 ): OffscreenAudioGraph {
   const recorderDestination = context.createMediaStreamDestination();
   const analyser = context.createAnalyser();
+  const noiseGateGain = context.createGain();
 
   analyser.fftSize = OFFSCREEN_ANALYSER_FFT_SIZE;
+  noiseGateGain.gain.value = 1; // start with gate fully open
 
   const tabSource = connectCaptureSource(
     context,
     tabStream,
     recorderDestination,
     analyser,
+    noiseGateGain,
     context.destination,
   );
 
@@ -62,6 +73,7 @@ export function createOffscreenAudioGraph(
     recorderDestination,
     analyser,
     tabSource,
+    noiseGateGain,
   };
 }
 
@@ -74,7 +86,13 @@ export function createOffscreenAudioGraph(
 export function connectMicrophoneToOffscreenAudioGraph(
   context: AudioContext,
   microphoneStream: MediaStream,
-  graph: Pick<OffscreenAudioGraph, "recorderDestination" | "analyser">,
+  graph: Pick<OffscreenAudioGraph, "recorderDestination" | "analyser" | "noiseGateGain">,
 ): MediaStreamAudioSourceNode {
-  return connectCaptureSource(context, microphoneStream, graph.recorderDestination, graph.analyser);
+  return connectCaptureSource(
+    context,
+    microphoneStream,
+    graph.recorderDestination,
+    graph.analyser,
+    graph.noiseGateGain,
+  );
 }

--- a/tests/offscreenAudioGraph.test.ts
+++ b/tests/offscreenAudioGraph.test.ts
@@ -27,6 +27,10 @@ class MockAnalyserNode extends MockAudioNode {
   fftSize = 2048;
 }
 
+class MockGainNode extends MockAudioNode {
+  gain = { value: 1 };
+}
+
 class MockMediaStreamDestinationNode extends MockAudioNode {
   readonly stream = createMockStream("recorder-output");
 }
@@ -36,6 +40,7 @@ class MockAudioContext {
   readonly analysers: MockAnalyserNode[] = [];
   readonly recorderDestinations: MockMediaStreamDestinationNode[] = [];
   readonly sources: MockSourceNode[] = [];
+  readonly gainNodes: MockGainNode[] = [];
 
   createMediaStreamDestination(): MediaStreamAudioDestinationNode {
     const destination = new MockMediaStreamDestinationNode();
@@ -49,6 +54,12 @@ class MockAudioContext {
     this.analysers.push(analyser);
 
     return analyser as unknown as AnalyserNode;
+  }
+
+  createGain(): GainNode {
+    const gain = new MockGainNode();
+    this.gainNodes.push(gain);
+    return gain as unknown as GainNode;
   }
 
   createMediaStreamSource(stream: MediaStream): MediaStreamAudioSourceNode {
@@ -93,19 +104,23 @@ test("configures the analyser with the offscreen FFT size", () => {
   assert.equal(context.analysers[0].fftSize, 1024);
 });
 
-test("routes tab audio to recorder, analyser, and playback output", () => {
+test("routes tab audio to noise gate gain, analyser, and playback output", () => {
   const context = new MockAudioContext();
 
   createOffscreenAudioGraph(asAudioContext(context), createMockStream("tab"));
 
-  assert.deepEqual(context.sources[0].connections, [
-    context.recorderDestinations[0],
-    context.analysers[0],
-    context.destination,
-  ]);
+  // Tab source → gainNode (gated recorder path), analyser (raw VAD), and destination (playback)
+  assert.equal(context.sources[0].connections.length, 3);
+  assert.equal(context.sources[0].connections[0], context.gainNodes[0]);
+  assert.equal(context.sources[0].connections[1], context.analysers[0]);
+  assert.equal(context.sources[0].connections[2], context.destination);
+
+  // Gain node → recorder destination
+  assert.equal(context.gainNodes[0].connections.length, 1);
+  assert.equal(context.gainNodes[0].connections[0], context.recorderDestinations[0]);
 });
 
-test("routes microphone audio to recorder and analyser", () => {
+test("routes microphone audio through noise gate gain and to analyser", () => {
   const context = new MockAudioContext();
 
   const graph = createOffscreenAudioGraph(asAudioContext(context), createMockStream("tab"));
@@ -118,10 +133,10 @@ test("routes microphone audio to recorder and analyser", () => {
 
   assert.equal(microphoneSource, context.sources[1]);
 
-  assert.deepEqual(context.sources[1].connections, [
-    context.recorderDestinations[0],
-    context.analysers[0],
-  ]);
+  // Mic source → gainNode (gated recorder path) and analyser (raw VAD)
+  assert.equal(context.sources[1].connections.length, 2);
+  assert.equal(context.sources[1].connections[0], context.gainNodes[0]);
+  assert.equal(context.sources[1].connections[1], context.analysers[0]);
 });
 
 test("does not route microphone audio to local playback", () => {


### PR DESCRIPTION
## Description

Implements an adaptive noise gate that dynamically estimates the background noise floor from incoming audio and adjusts the gating threshold in real time. Low-amplitude ambient noise (fans, keystrokes, background chatter) is physically attenuated before it reaches the MediaRecorder, reducing Whisper STT API costs.

Fixes #623

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Implementation

### AdaptiveNoiseGate class (src/audioProcessing.ts)
- Tracks a running noise floor estimate from incoming RMS samples
- Computes adaptive threshold = noiseFloor × multiplier (clamped to [0.003, 0.05])
- Noise floor adapts upward during silence, decays slowly during speech
- Hold counter prevents gate chatter during inter-word pauses

### Integration
- Replaces fixed rmsThreshold in the VAD loop with the adaptive threshold
- Adds a GainNode to the audio graph (offscreenAudioGraph.ts) that physically gates the signal before reaching the MediaRecorder
- Smooth gain ramps via setTargetAtTime (10ms time constant) to avoid audible clicks
- Analyser and playback always receive the raw ungated signal (VAD/waveform unaffected)

### Tests
- 14 unit tests for AdaptiveNoiseGate (threshold, hold counter, noise floor adaptation, clamping, reset, non-finite RMS)
- 2 offscreen graph tests updated for new gain node topology