### PR TITLE
feat(history): add search, filter, sort, and bulk export (JSON/CSV)

### DIFF
--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -1480,15 +1480,21 @@ body::-webkit-scrollbar-thumb,
   font-family: inherit;
   font-size: 12px;
   outline: none;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
   box-sizing: border-box;
 }
 
-.history-search-input::placeholder { color: var(--text-muted); }
-.history-search-input::-webkit-search-cancel-button { display: none; }
+.history-search-input::placeholder {
+  color: var(--text-muted);
+}
+.history-search-input::-webkit-search-cancel-button {
+  display: none;
+}
 .history-search-input:focus {
   border-color: var(--accent-blue, #60a5fa);
-  box-shadow: 0 0 0 2px rgba(96,165,250,0.15);
+  box-shadow: 0 0 0 2px rgba(96, 165, 250, 0.15);
 }
 
 .history-search-clear {
@@ -1504,7 +1510,9 @@ body::-webkit-scrollbar-thumb,
   border-radius: 3px;
   transition: color 0.15s ease;
 }
-.history-search-clear:hover { color: var(--text-main); }
+.history-search-clear:hover {
+  color: var(--text-main);
+}
 
 .history-filter-row {
   display: flex;
@@ -1519,7 +1527,9 @@ body::-webkit-scrollbar-thumb,
   gap: 5px;
 }
 
-.history-filter-group--right { margin-left: auto; }
+.history-filter-group--right {
+  margin-left: auto;
+}
 
 .history-filter-label {
   font-size: 11px;
@@ -1544,7 +1554,9 @@ body::-webkit-scrollbar-thumb,
   background-position: right 6px center;
   transition: border-color 0.15s ease;
 }
-.history-filter-select:focus { border-color: var(--accent-blue, #60a5fa); }
+.history-filter-select:focus {
+  border-color: var(--accent-blue, #60a5fa);
+}
 
 .history-results-count {
   font-size: 11px;
@@ -1580,7 +1592,10 @@ body::-webkit-scrollbar-thumb,
   font-size: 11px;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 .history-export-chip:hover {
   background: var(--bg-base);
@@ -1589,7 +1604,7 @@ body::-webkit-scrollbar-thumb,
 }
 
 .history-highlight {
-  background: rgba(250,204,21,0.28);
+  background: rgba(250, 204, 21, 0.28);
   color: var(--text-main);
   border-radius: 2px;
   padding: 0 1px;

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -1435,3 +1435,176 @@ body::-webkit-scrollbar-thumb,
     scroll-behavior: auto !important;
   }
 }
+/* ============================================================
+   Session History Enhancement — Search, Filter, Sort, Export
+   ============================================================ */
+
+.history-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px 14px 12px;
+  border-bottom: 1px solid var(--border-main);
+  background: var(--bg-surface);
+  border-radius: 8px 8px 0 0;
+  margin-bottom: 8px;
+}
+
+.history-search-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.history-search-wrap {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.history-search-icon {
+  position: absolute;
+  left: 9px;
+  color: var(--text-muted);
+  pointer-events: none;
+}
+
+.history-search-input {
+  width: 100%;
+  padding: 7px 30px 7px 28px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-sub);
+  border-radius: 7px;
+  color: var(--text-main);
+  font-family: inherit;
+  font-size: 12px;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  box-sizing: border-box;
+}
+
+.history-search-input::placeholder { color: var(--text-muted); }
+.history-search-input::-webkit-search-cancel-button { display: none; }
+.history-search-input:focus {
+  border-color: var(--accent-blue, #60a5fa);
+  box-shadow: 0 0 0 2px rgba(96,165,250,0.15);
+}
+
+.history-search-clear {
+  position: absolute;
+  right: 7px;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  border-radius: 3px;
+  transition: color 0.15s ease;
+}
+.history-search-clear:hover { color: var(--text-main); }
+
+.history-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.history-filter-group {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.history-filter-group--right { margin-left: auto; }
+
+.history-filter-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.history-filter-select {
+  padding: 5px 22px 5px 8px;
+  background: var(--bg-base);
+  border: 1px solid var(--border-sub);
+  border-radius: 6px;
+  color: var(--text-sub);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  outline: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%236b7280' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 6px center;
+  transition: border-color 0.15s ease;
+}
+.history-filter-select:focus { border-color: var(--accent-blue, #60a5fa); }
+
+.history-results-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.history-export-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 4px;
+  border-top: 1px solid var(--border-main);
+  margin-top: 2px;
+}
+
+.history-export-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.history-export-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: transparent;
+  border: 1px solid var(--border-sub);
+  border-radius: 5px;
+  color: var(--text-sub);
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+.history-export-chip:hover {
+  background: var(--bg-base);
+  border-color: var(--accent-blue, #60a5fa);
+  color: var(--accent-blue, #60a5fa);
+}
+
+.history-highlight {
+  background: rgba(250,204,21,0.28);
+  color: var(--text-main);
+  border-radius: 2px;
+  padding: 0 1px;
+}
+
+.history-no-results {
+  padding: 28px 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.history-no-results strong {
+  display: block;
+  font-size: 14px;
+  color: var(--text-sub);
+  margin-bottom: 6px;
+}

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -1020,6 +1020,52 @@
             </span>
             <span class="dash-card-title">Meeting History</span>
           </div>
+            <!-- Search & Filter Controls -->
+          <div class="history-controls" id="history-controls">
+            <div class="history-search-row">
+              <div class="history-search-wrap">
+                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="history-search-icon" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+                <input id="history-search-input" type="search" class="history-search-input" placeholder="Search meetings, topics, decisions…" aria-label="Search meeting history" autocomplete="off" />
+                <button id="history-search-clear" class="history-search-clear" aria-label="Clear search" hidden>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                </button>
+              </div>
+            </div>
+            <div class="history-filter-row">
+              <div class="history-filter-group">
+                <label class="history-filter-label" for="history-sort-select">Sort</label>
+                <select id="history-sort-select" class="history-filter-select">
+                  <option value="newest">Newest first</option>
+                  <option value="oldest">Oldest first</option>
+                  <option value="longest">Longest first</option>
+                  <option value="most-actions">Most actions</option>
+                </select>
+              </div>
+              <div class="history-filter-group">
+                <label class="history-filter-label" for="history-date-filter">Date</label>
+                <select id="history-date-filter" class="history-filter-select">
+                  <option value="all">All time</option>
+                  <option value="today">Today</option>
+                  <option value="week">This week</option>
+                  <option value="month">This month</option>
+                </select>
+              </div>
+              <div class="history-filter-group history-filter-group--right">
+                <span id="history-results-count" class="history-results-count" aria-live="polite"></span>
+              </div>
+            </div>
+            <div class="history-export-row">
+              <span class="history-export-label">Export all</span>
+              <button id="history-export-json-btn" class="history-export-chip" title="Download all sessions as JSON">
+                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                JSON
+              </button>
+              <button id="history-export-csv-btn" class="history-export-chip" title="Download all sessions as CSV">
+                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+                CSV
+              </button>
+            </div>
+          </div>
           <div id="dash-history-list" class="sessions-list">
             <div class="empty-msg">No history exists yet.</div>
           </div>

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -1020,14 +1020,54 @@
             </span>
             <span class="dash-card-title">Meeting History</span>
           </div>
-            <!-- Search & Filter Controls -->
+          <!-- Search & Filter Controls -->
           <div class="history-controls" id="history-controls">
             <div class="history-search-row">
               <div class="history-search-wrap">
-                <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="history-search-icon" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-                <input id="history-search-input" type="search" class="history-search-input" placeholder="Search meetings, topics, decisions…" aria-label="Search meeting history" autocomplete="off" />
-                <button id="history-search-clear" class="history-search-clear" aria-label="Clear search" hidden>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="13"
+                  height="13"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  class="history-search-icon"
+                  aria-hidden="true"
+                >
+                  <circle cx="11" cy="11" r="8" />
+                  <path d="m21 21-4.3-4.3" />
+                </svg>
+                <input
+                  id="history-search-input"
+                  type="search"
+                  class="history-search-input"
+                  placeholder="Search meetings, topics, decisions…"
+                  aria-label="Search meeting history"
+                  autocomplete="off"
+                />
+                <button
+                  id="history-search-clear"
+                  class="history-search-clear"
+                  aria-label="Clear search"
+                  hidden
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M18 6 6 18" />
+                    <path d="m6 6 12 12" />
+                  </svg>
                 </button>
               </div>
             </div>
@@ -1051,17 +1091,57 @@
                 </select>
               </div>
               <div class="history-filter-group history-filter-group--right">
-                <span id="history-results-count" class="history-results-count" aria-live="polite"></span>
+                <span
+                  id="history-results-count"
+                  class="history-results-count"
+                  aria-live="polite"
+                ></span>
               </div>
             </div>
             <div class="history-export-row">
               <span class="history-export-label">Export all</span>
-              <button id="history-export-json-btn" class="history-export-chip" title="Download all sessions as JSON">
-                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+              <button
+                id="history-export-json-btn"
+                class="history-export-chip"
+                title="Download all sessions as JSON"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="11"
+                  height="11"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" x2="12" y1="15" y2="3" />
+                </svg>
                 JSON
               </button>
-              <button id="history-export-csv-btn" class="history-export-chip" title="Download all sessions as CSV">
-                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+              <button
+                id="history-export-csv-btn"
+                class="history-export-chip"
+                title="Download all sessions as CSV"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="11"
+                  height="11"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                  <polyline points="7 10 12 15 17 10" />
+                  <line x1="12" x2="12" y1="15" y2="3" />
+                </svg>
                 CSV
               </button>
             </div>

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1598,109 +1598,199 @@ document.addEventListener("DOMContentLoaded", async () => {
   // ——— Meeting History Tab ———
   let sessionToDelete: string | null = null;
 
+  let allHistorySessions: State[] = [];
+
+  function highlightText(text: string, query: string): string {
+    if (!query.trim()) return escapeHtml(text);
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`(${escaped})`, "gi");
+    return escapeHtml(text).replace(re, '<mark class="history-highlight">$1</mark>');
+  }
+
+  function buildSessionCardHTML(s: State, query = ""): string {
+    const date = new Date(s.savedAt || s.startTime || Date.now()).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    const time = new Date(s.savedAt || s.startTime || Date.now()).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
+    const topicCount = s.topics?.length || 0;
+    const decisionCount = s.decisions?.length || 0;
+    const actionCount = s.actionItems?.length || 0;
+    const meetingLabel = s.meetingUrl || s.meetingId || "Unknown Meeting";
+    const summaryText = s.summary || "No summary available";
+    return `
+      <div class="session-item" data-session-id="${sanitizeDataAttr(s.id)}">
+        <div class="session-item-header">
+          <div>
+            <div class="session-item-date">${highlightText(date + " at " + time, query)}</div>
+            <div class="session-item-id" title="${escapeHtml(s.meetingUrl || "")}">${highlightText(meetingLabel, query)}</div>
+          </div>
+          <div class="session-item-meta">
+            <span>${formatDuration((s as State & { duration?: number }).duration || 0)}</span>
+          </div>
+        </div>
+        <div class="session-item-summary" style="cursor:pointer;" title="Click to expand/collapse summary">${highlightText(summaryText, query)}</div>
+        <div class="session-item-stats">
+          <span>${topicCount} topics</span>
+          <span>${decisionCount} decisions</span>
+          <span>${actionCount} actions</span>
+        </div>
+        <div class="session-item-actions">
+          <button class="session-export-btn" data-session-id="${sanitizeDataAttr(s.id)}" title="Copy as Markdown">
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" x2="12" y1="15" y2="3"></line></svg>
+            Copy MD
+          </button>
+          <button class="session-export-btn session-download-btn" data-session-id="${sanitizeDataAttr(s.id)}" title="Download as Markdown">
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" x2="12" y1="15" y2="3"></line></svg>
+            Download
+          </button>
+          <button class="session-delete-btn" data-session-id="${sanitizeDataAttr(s.id)}" title="Delete session">
+            <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
+            Delete
+          </button>
+        </div>
+      </div>`;
+  }
+
+  function sessionMatchesQuery(s: State, query: string): boolean {
+    if (!query.trim()) return true;
+    const q = query.toLowerCase();
+    return [
+      s.meetingUrl || "", s.meetingId || "", s.summary || "", s.currentTopic || "",
+      ...(s.topics?.map((t) => t.name) || []),
+      ...(s.decisions?.map((d) => d.text) || []),
+      ...(s.actionItems?.map((a) => a.task) || []),
+      ...(s.participants || []),
+    ].some((f) => f.toLowerCase().includes(q));
+  }
+
+  function sessionMatchesDateFilter(s: State, range: string): boolean {
+    if (range === "all") return true;
+    const d = new Date(s.savedAt || s.startTime || 0);
+    const now = new Date();
+    if (range === "today") return d.toDateString() === now.toDateString();
+    if (range === "week") { const w = new Date(now); w.setDate(now.getDate() - 7); return d >= w; }
+    if (range === "month") { const m = new Date(now); m.setMonth(now.getMonth() - 1); return d >= m; }
+    return true;
+  }
+
+  function sortSessions(sessions: State[], sort: string): State[] {
+    const arr = [...sessions];
+    if (sort === "oldest") arr.sort((a, b) => (a.savedAt || a.startTime || 0) - (b.savedAt || b.startTime || 0));
+    else if (sort === "longest") arr.sort((a, b) => ((b as State & { duration?: number }).duration || 0) - ((a as State & { duration?: number }).duration || 0));
+    else if (sort === "most-actions") arr.sort((a, b) => (b.actionItems?.length || 0) - (a.actionItems?.length || 0));
+    else arr.sort((a, b) => (b.savedAt || b.startTime || 0) - (a.savedAt || a.startTime || 0));
+    return arr;
+  }
+
+  function renderHistoryList(sessions: State[], query: string): void {
+    const container = document.getElementById("dash-history-list");
+    const countEl = document.getElementById("history-results-count");
+    if (!container) return;
+    if (sessions.length === 0) {
+      container.innerHTML = query.trim()
+        ? `<div class="history-no-results"><strong>No results found</strong>Try a different search term or clear the filters.</div>`
+        : getEmptyStateHTML("No history exists yet. Sessions are saved when you end them.");
+      if (countEl) countEl.textContent = "";
+      return;
+    }
+    if (countEl) countEl.textContent = sessions.length === allHistorySessions.length
+      ? `${sessions.length} session${sessions.length !== 1 ? "s" : ""}`
+      : `${sessions.length} of ${allHistorySessions.length}`;
+    container.innerHTML = sessions.map((s) => buildSessionCardHTML(s, query)).join("");
+    container.querySelectorAll<HTMLButtonElement>(".session-export-btn:not(.session-download-btn)").forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const session = btn.dataset.sessionId ? await loadFullSavedSession(btn.dataset.sessionId) : null;
+        if (session) exportSessionMarkdown(session);
+      });
+    });
+    container.querySelectorAll<HTMLButtonElement>(".session-download-btn").forEach((btn) => {
+      btn.addEventListener("click", async () => {
+        const session = btn.dataset.sessionId ? await loadFullSavedSession(btn.dataset.sessionId) : null;
+        if (session) downloadSessionMarkdown(session);
+      });
+    });
+    container.querySelectorAll<HTMLButtonElement>(".session-delete-btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        sessionToDelete = btn.dataset.sessionId || null;
+        if (sessionToDelete) document.getElementById("delete-confirm-modal")?.classList.remove("hidden");
+      });
+    });
+    container.querySelectorAll<HTMLDivElement>(".session-item-summary").forEach((summary) => {
+      summary.addEventListener("click", () => summary.closest(".session-item")?.classList.toggle("expanded"));
+    });
+  }
+
+  function applyHistoryFilters(): void {
+    const query = (document.getElementById("history-search-input") as HTMLInputElement)?.value || "";
+    const dateRange = (document.getElementById("history-date-filter") as HTMLSelectElement)?.value || "all";
+    const sort = (document.getElementById("history-sort-select") as HTMLSelectElement)?.value || "newest";
+    const filtered = allHistorySessions
+      .filter((s) => sessionMatchesQuery(s, query))
+      .filter((s) => sessionMatchesDateFilter(s, dateRange));
+    renderHistoryList(sortSessions(filtered, sort), query);
+  }
+
+  function exportHistoryAsJSON(): void {
+    if (!allHistorySessions.length) { showToast("No sessions to export", "error"); return; }
+    const data = allHistorySessions.map((s) => ({
+      id: s.id, meetingUrl: s.meetingUrl, meetingId: s.meetingId,
+      savedAt: s.savedAt, startTime: s.startTime,
+      duration: (s as State & { duration?: number }).duration,
+      summary: s.summary, topics: s.topics, decisions: s.decisions,
+      actionItems: s.actionItems, participants: s.participants, keyInsights: s.keyInsights,
+    }));
+    downloadFile(JSON.stringify(data, null, 2), `late-meet-history-${new Date().toISOString().slice(0, 10)}.json`, "application/json");
+    showToast("History exported as JSON", "success");
+  }
+
+  function exportHistoryAsCSV(): void {
+    if (!allHistorySessions.length) { showToast("No sessions to export", "error"); return; }
+    const e = (v: unknown) => `"${String(v ?? "").replace(/"/g, '""')}"`;
+    const headers = ["ID","Date","Meeting URL","Duration (s)","Summary","Topics","Decisions","Action Items","Participants"];
+    const rows = allHistorySessions.map((s) => [
+      e(s.id),
+      e(s.savedAt || s.startTime ? new Date(s.savedAt || s.startTime || 0).toISOString() : ""),
+      e(s.meetingUrl || s.meetingId || ""),
+      e(Math.round(((s as State & { duration?: number }).duration || 0) / 1000)),
+      e(s.summary || ""),
+      e((s.topics || []).map((t) => t.name).join("; ")),
+      e((s.decisions || []).map((d) => d.text).join("; ")),
+      e((s.actionItems || []).map((a) => a.task).join("; ")),
+      e((s.participants || []).join("; ")),
+    ].join(","));
+    downloadFile([headers.join(","), ...rows].join("\r\n"), `late-meet-history-${new Date().toISOString().slice(0, 10)}.csv`, "text/csv");
+    showToast("History exported as CSV", "success");
+  }
+
   async function loadMeetingHistory() {
     try {
       const sessions: State[] = await chrome.runtime.sendMessage({ type: "GET_SAVED_SESSIONS" });
-      const container = document.getElementById("dash-history-list");
-      if (!container) return;
-      if (!sessions || sessions.length === 0) {
-        container.innerHTML = getEmptyStateHTML(
-          "No history exists yet. Sessions are saved when you end them.",
-        );
-        return;
-      }
-
-      container.innerHTML = sessions
-        .map((s: State) => {
-          const date = new Date(s.savedAt || s.startTime || Date.now()).toLocaleDateString(
-            "en-US",
-            { month: "short", day: "numeric", year: "numeric" },
-          );
-          const time = new Date(s.savedAt || s.startTime || Date.now()).toLocaleTimeString(
-            "en-US",
-            { hour: "2-digit", minute: "2-digit" },
-          );
-          const topicCount = s.topics?.length || 0;
-          const decisionCount = s.decisions?.length || 0;
-          const actionCount = s.actionItems?.length || 0;
-
-          return `
-          <div class="session-item" data-session-id="${sanitizeDataAttr(s.id)}">
-            <div class="session-item-header">
-              <div>
-                <div class="session-item-date">${escapeHtml(date)} at ${escapeHtml(time)}</div>
-                <div class="session-item-id" title="${escapeHtml(s.meetingUrl || "")}">${escapeHtml(s.meetingUrl || s.meetingId || "Unknown Meeting")}</div>
-              </div>
-              <div class="session-item-meta">
-                <span>${formatDuration((s as State & { duration?: number }).duration || 0)}</span>
-              </div>
-            </div>
-            <div class="session-item-summary" style="cursor: pointer;" title="Click to expand/collapse summary">${escapeHtml(s.summary || "No summary available")}</div>
-            <div class="session-item-stats">
-              <span>${topicCount} topics</span>
-              <span>${decisionCount} decisions</span>
-              <span>${actionCount} actions</span>
-            </div>
-            <div class="session-item-actions">
-              <button class="session-export-btn" data-session-id="${sanitizeDataAttr(s.id)}" title="Export as Markdown">
-                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" x2="12" y1="15" y2="3"></line></svg>
-                Export
-              </button>
-              <button class="session-export-btn session-download-btn" data-session-id="${sanitizeDataAttr(s.id)}" title="Download as Markdown File">
-                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" x2="12" y1="15" y2="3"></line></svg>
-                Download
-              </button>
-              <button class="session-delete-btn" data-session-id="${sanitizeDataAttr(s.id)}" title="Delete session">
-                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon"><path d="M3 6h18"></path><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path></svg>
-                Delete
-              </button>
-            </div>
-          </div>
-        `;
-        })
-        .join("");
-
-      // Wire up export buttons
-      container
-        .querySelectorAll<HTMLButtonElement>(".session-export-btn:not(.session-download-btn)")
-        .forEach((btn) => {
-          btn.addEventListener("click", async () => {
-            const sessionId = btn.dataset.sessionId;
-            const session = sessionId ? await loadFullSavedSession(sessionId) : null;
-            if (session) exportSessionMarkdown(session);
-          });
-        });
-
-      container.querySelectorAll<HTMLButtonElement>(".session-download-btn").forEach((btn) => {
-        btn.addEventListener("click", async () => {
-          const sessionId = btn.dataset.sessionId;
-          const session = sessionId ? await loadFullSavedSession(sessionId) : null;
-          if (session) downloadSessionMarkdown(session);
-        });
-      });
-
-      // Wire up delete buttons
-      container.querySelectorAll<HTMLButtonElement>(".session-delete-btn").forEach((btn) => {
-        btn.addEventListener("click", () => {
-          sessionToDelete = btn.dataset.sessionId || null;
-          if (sessionToDelete) {
-            document.getElementById("delete-confirm-modal")?.classList.remove("hidden");
-          }
-        });
-      });
-
-      // Wire up summary expand/collapse
-      container.querySelectorAll<HTMLDivElement>(".session-item-summary").forEach((summary) => {
-        summary.addEventListener("click", () => {
-          const item = summary.closest(".session-item");
-          if (item) item.classList.toggle("expanded");
-        });
-      });
+      allHistorySessions = sessions || [];
+      applyHistoryFilters();
+      const controls = document.getElementById("history-controls");
+      if (controls) controls.style.display = allHistorySessions.length === 0 ? "none" : "flex";
     } catch (err) {
       console.error("[Dashboard] Failed to load history:", err);
     }
   }
 
+  (() => {
+    const searchInput = document.getElementById("history-search-input") as HTMLInputElement | null;
+    const clearBtn = document.getElementById("history-search-clear") as HTMLButtonElement | null;
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    searchInput?.addEventListener("input", () => {
+      if (clearBtn) clearBtn.hidden = !searchInput.value.trim();
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(applyHistoryFilters, 200);
+    });
+    clearBtn?.addEventListener("click", () => {
+      if (searchInput) searchInput.value = "";
+      clearBtn.hidden = true;
+      applyHistoryFilters();
+    });
+    document.getElementById("history-sort-select")?.addEventListener("change", applyHistoryFilters);
+    document.getElementById("history-date-filter")?.addEventListener("change", applyHistoryFilters);
+    document.getElementById("history-export-json-btn")?.addEventListener("click", exportHistoryAsJSON);
+    document.getElementById("history-export-csv-btn")?.addEventListener("click", exportHistoryAsCSV);
+  })();
   // Modal logic
   document.getElementById("cancel-delete-btn")?.addEventListener("click", () => {
     sessionToDelete = null;

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1677,14 +1677,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     const d = new Date(s.savedAt || s.startTime || 0);
     const now = new Date();
     if (range === "today") return d.toDateString() === now.toDateString();
-    if (range === "week") {
+   if (range === "week") {
       const w = new Date(now);
-      w.setDate(now.getDate() - 7);
+      w.setDate(now.getDate() - now.getDay());
+      w.setHours(0, 0, 0, 0);
       return d >= w;
     }
     if (range === "month") {
-      const m = new Date(now);
-      m.setMonth(now.getMonth() - 1);
+      const m = new Date(now.getFullYear(), now.getMonth(), 1);
       return d >= m;
     }
     return true;
@@ -1719,7 +1719,9 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
     if (countEl)
       countEl.textContent =
-        sessions.length === allHistorySessions.length
+        sessions.length === 0
+          ? `No sessions found`
+          : sessions.length === allHistorySessions.length
           ? `${sessions.length} session${sessions.length !== 1 ? "s" : ""}`
           : `${sessions.length} of ${allHistorySessions.length}`;
     container.innerHTML = sessions.map((s) => buildSessionCardHTML(s, query)).join("");

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1600,17 +1600,24 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   let allHistorySessions: State[] = [];
 
- function highlightText(text: string, query: string): string {
-  if (!query.trim()) return escapeHtml(text);
-  const escapedText = escapeHtml(text);
-  const escapedQuery = escapeHtml(query).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const re = new RegExp(`(${escapedQuery})`, "gi");
-  return escapedText.replace(re, '<mark class="history-highlight">$1</mark>');
- }
+  function highlightText(text: string, query: string): string {
+    if (!query.trim()) return escapeHtml(text);
+    const escapedText = escapeHtml(text);
+    const escapedQuery = escapeHtml(query).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const re = new RegExp(`(${escapedQuery})`, "gi");
+    return escapedText.replace(re, '<mark class="history-highlight">$1</mark>');
+  }
 
   function buildSessionCardHTML(s: State, query = ""): string {
-    const date = new Date(s.savedAt || s.startTime || Date.now()).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
-    const time = new Date(s.savedAt || s.startTime || Date.now()).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
+    const date = new Date(s.savedAt || s.startTime || Date.now()).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+    const time = new Date(s.savedAt || s.startTime || Date.now()).toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
     const topicCount = s.topics?.length || 0;
     const decisionCount = s.decisions?.length || 0;
     const actionCount = s.actionItems?.length || 0;
@@ -1654,7 +1661,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (!query.trim()) return true;
     const q = query.toLowerCase();
     return [
-      s.meetingUrl || "", s.meetingId || "", s.summary || "", s.currentTopic || "",
+      s.meetingUrl || "",
+      s.meetingId || "",
+      s.summary || "",
+      s.currentTopic || "",
       ...(s.topics?.map((t) => t.name) || []),
       ...(s.decisions?.map((d) => d.text) || []),
       ...(s.actionItems?.map((a) => a.task) || []),
@@ -1667,16 +1677,31 @@ document.addEventListener("DOMContentLoaded", async () => {
     const d = new Date(s.savedAt || s.startTime || 0);
     const now = new Date();
     if (range === "today") return d.toDateString() === now.toDateString();
-    if (range === "week") { const w = new Date(now); w.setDate(now.getDate() - 7); return d >= w; }
-    if (range === "month") { const m = new Date(now); m.setMonth(now.getMonth() - 1); return d >= m; }
+    if (range === "week") {
+      const w = new Date(now);
+      w.setDate(now.getDate() - 7);
+      return d >= w;
+    }
+    if (range === "month") {
+      const m = new Date(now);
+      m.setMonth(now.getMonth() - 1);
+      return d >= m;
+    }
     return true;
   }
 
   function sortSessions(sessions: State[], sort: string): State[] {
     const arr = [...sessions];
-    if (sort === "oldest") arr.sort((a, b) => (a.savedAt || a.startTime || 0) - (b.savedAt || b.startTime || 0));
-    else if (sort === "longest") arr.sort((a, b) => ((b as State & { duration?: number }).duration || 0) - ((a as State & { duration?: number }).duration || 0));
-    else if (sort === "most-actions") arr.sort((a, b) => (b.actionItems?.length || 0) - (a.actionItems?.length || 0));
+    if (sort === "oldest")
+      arr.sort((a, b) => (a.savedAt || a.startTime || 0) - (b.savedAt || b.startTime || 0));
+    else if (sort === "longest")
+      arr.sort(
+        (a, b) =>
+          ((b as State & { duration?: number }).duration || 0) -
+          ((a as State & { duration?: number }).duration || 0),
+      );
+    else if (sort === "most-actions")
+      arr.sort((a, b) => (b.actionItems?.length || 0) - (a.actionItems?.length || 0));
     else arr.sort((a, b) => (b.savedAt || b.startTime || 0) - (a.savedAt || a.startTime || 0));
     return arr;
   }
@@ -1692,37 +1717,51 @@ document.addEventListener("DOMContentLoaded", async () => {
       if (countEl) countEl.textContent = "";
       return;
     }
-    if (countEl) countEl.textContent = sessions.length === allHistorySessions.length
-      ? `${sessions.length} session${sessions.length !== 1 ? "s" : ""}`
-      : `${sessions.length} of ${allHistorySessions.length}`;
+    if (countEl)
+      countEl.textContent =
+        sessions.length === allHistorySessions.length
+          ? `${sessions.length} session${sessions.length !== 1 ? "s" : ""}`
+          : `${sessions.length} of ${allHistorySessions.length}`;
     container.innerHTML = sessions.map((s) => buildSessionCardHTML(s, query)).join("");
-    container.querySelectorAll<HTMLButtonElement>(".session-export-btn:not(.session-download-btn)").forEach((btn) => {
-      btn.addEventListener("click", async () => {
-        const session = btn.dataset.sessionId ? await loadFullSavedSession(btn.dataset.sessionId) : null;
-        if (session) exportSessionMarkdown(session);
+    container
+      .querySelectorAll<HTMLButtonElement>(".session-export-btn:not(.session-download-btn)")
+      .forEach((btn) => {
+        btn.addEventListener("click", async () => {
+          const session = btn.dataset.sessionId
+            ? await loadFullSavedSession(btn.dataset.sessionId)
+            : null;
+          if (session) exportSessionMarkdown(session);
+        });
       });
-    });
     container.querySelectorAll<HTMLButtonElement>(".session-download-btn").forEach((btn) => {
       btn.addEventListener("click", async () => {
-        const session = btn.dataset.sessionId ? await loadFullSavedSession(btn.dataset.sessionId) : null;
+        const session = btn.dataset.sessionId
+          ? await loadFullSavedSession(btn.dataset.sessionId)
+          : null;
         if (session) downloadSessionMarkdown(session);
       });
     });
     container.querySelectorAll<HTMLButtonElement>(".session-delete-btn").forEach((btn) => {
       btn.addEventListener("click", () => {
         sessionToDelete = btn.dataset.sessionId || null;
-        if (sessionToDelete) document.getElementById("delete-confirm-modal")?.classList.remove("hidden");
+        if (sessionToDelete)
+          document.getElementById("delete-confirm-modal")?.classList.remove("hidden");
       });
     });
     container.querySelectorAll<HTMLDivElement>(".session-item-summary").forEach((summary) => {
-      summary.addEventListener("click", () => summary.closest(".session-item")?.classList.toggle("expanded"));
+      summary.addEventListener("click", () =>
+        summary.closest(".session-item")?.classList.toggle("expanded"),
+      );
     });
   }
 
   function applyHistoryFilters(): void {
-    const query = (document.getElementById("history-search-input") as HTMLInputElement)?.value || "";
-    const dateRange = (document.getElementById("history-date-filter") as HTMLSelectElement)?.value || "all";
-    const sort = (document.getElementById("history-sort-select") as HTMLSelectElement)?.value || "newest";
+    const query =
+      (document.getElementById("history-search-input") as HTMLInputElement)?.value || "";
+    const dateRange =
+      (document.getElementById("history-date-filter") as HTMLSelectElement)?.value || "all";
+    const sort =
+      (document.getElementById("history-sort-select") as HTMLSelectElement)?.value || "newest";
     const filtered = allHistorySessions
       .filter((s) => sessionMatchesQuery(s, query))
       .filter((s) => sessionMatchesDateFilter(s, dateRange));
@@ -1730,34 +1769,67 @@ document.addEventListener("DOMContentLoaded", async () => {
   }
 
   function exportHistoryAsJSON(): void {
-    if (!allHistorySessions.length) { showToast("No sessions to export", "error"); return; }
+    if (!allHistorySessions.length) {
+      showToast("No sessions to export", "error");
+      return;
+    }
     const data = allHistorySessions.map((s) => ({
-      id: s.id, meetingUrl: s.meetingUrl, meetingId: s.meetingId,
-      savedAt: s.savedAt, startTime: s.startTime,
+      id: s.id,
+      meetingUrl: s.meetingUrl,
+      meetingId: s.meetingId,
+      savedAt: s.savedAt,
+      startTime: s.startTime,
       duration: (s as State & { duration?: number }).duration,
-      summary: s.summary, topics: s.topics, decisions: s.decisions,
-      actionItems: s.actionItems, participants: s.participants, keyInsights: s.keyInsights,
+      summary: s.summary,
+      topics: s.topics,
+      decisions: s.decisions,
+      actionItems: s.actionItems,
+      participants: s.participants,
+      keyInsights: s.keyInsights,
     }));
-    downloadFile(JSON.stringify(data, null, 2), `late-meet-history-${new Date().toISOString().slice(0, 10)}.json`, "application/json");
+    downloadFile(
+      JSON.stringify(data, null, 2),
+      `late-meet-history-${new Date().toISOString().slice(0, 10)}.json`,
+      "application/json",
+    );
     showToast("History exported as JSON", "success");
   }
 
   function exportHistoryAsCSV(): void {
-    if (!allHistorySessions.length) { showToast("No sessions to export", "error"); return; }
+    if (!allHistorySessions.length) {
+      showToast("No sessions to export", "error");
+      return;
+    }
     const e = (v: unknown) => `"${String(v ?? "").replace(/"/g, '""')}"`;
-    const headers = ["ID","Date","Meeting URL","Duration (s)","Summary","Topics","Decisions","Action Items","Participants"];
-    const rows = allHistorySessions.map((s) => [
-      e(s.id),
-      e(s.savedAt || s.startTime ? new Date(s.savedAt || s.startTime || 0).toISOString() : ""),
-      e(s.meetingUrl || s.meetingId || ""),
-      e(Math.round(((s as State & { duration?: number }).duration || 0) / 1000)),
-      e(s.summary || ""),
-      e((s.topics || []).map((t) => t.name).join("; ")),
-      e((s.decisions || []).map((d) => d.text).join("; ")),
-      e((s.actionItems || []).map((a) => a.task).join("; ")),
-      e((s.participants || []).join("; ")),
-    ].join(","));
-    downloadFile([headers.join(","), ...rows].join("\r\n"), `late-meet-history-${new Date().toISOString().slice(0, 10)}.csv`, "text/csv");
+    const headers = [
+      "ID",
+      "Date",
+      "Meeting URL",
+      "Duration (s)",
+      "Summary",
+      "Topics",
+      "Decisions",
+      "Action Items",
+      "Participants",
+    ];
+    const rows = allHistorySessions.map((s) =>
+      [
+        e(s.id),
+        e(s.savedAt || s.startTime ? new Date(s.savedAt || s.startTime || 0).toISOString() : ""),
+        e(s.meetingUrl || s.meetingId || ""),
+        e(Math.round(((s as State & { duration?: number }).duration || 0) / 1000)),
+        e(s.summary || ""),
+        e((s.topics || []).map((t) => t.name).join("; ")),
+        e((s.decisions || []).map((d) => d.text).join("; ")),
+        e((s.actionItems || []).map((a) => a.task).join("; ")),
+        e((s.participants || []).join("; ")),
+      ].join(","),
+    );
+    downloadFile(
+      [headers.join(","), ...rows].join("\r\n"),
+      `late-meet-history-${new Date().toISOString().slice(0, 10)}.csv`,
+      "text/csv",
+    );
     showToast("History exported as CSV", "success");
   }
 
@@ -1789,8 +1861,12 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
     document.getElementById("history-sort-select")?.addEventListener("change", applyHistoryFilters);
     document.getElementById("history-date-filter")?.addEventListener("change", applyHistoryFilters);
-    document.getElementById("history-export-json-btn")?.addEventListener("click", exportHistoryAsJSON);
-    document.getElementById("history-export-csv-btn")?.addEventListener("click", exportHistoryAsCSV);
+    document
+      .getElementById("history-export-json-btn")
+      ?.addEventListener("click", exportHistoryAsJSON);
+    document
+      .getElementById("history-export-csv-btn")
+      ?.addEventListener("click", exportHistoryAsCSV);
   })();
   // Modal logic
   document.getElementById("cancel-delete-btn")?.addEventListener("click", () => {

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1600,12 +1600,13 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   let allHistorySessions: State[] = [];
 
-  function highlightText(text: string, query: string): string {
-    if (!query.trim()) return escapeHtml(text);
-    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const re = new RegExp(`(${escaped})`, "gi");
-    return escapeHtml(text).replace(re, '<mark class="history-highlight">$1</mark>');
-  }
+ function highlightText(text: string, query: string): string {
+  if (!query.trim()) return escapeHtml(text);
+  const escapedText = escapeHtml(text);
+  const escapedQuery = escapeHtml(query).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`(${escapedQuery})`, "gi");
+  return escapedText.replace(re, '<mark class="history-highlight">$1</mark>');
+ }
 
   function buildSessionCardHTML(s: State, query = ""): string {
     const date = new Date(s.savedAt || s.startTime || Date.now()).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -1677,7 +1677,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const d = new Date(s.savedAt || s.startTime || 0);
     const now = new Date();
     if (range === "today") return d.toDateString() === now.toDateString();
-   if (range === "week") {
+    if (range === "week") {
       const w = new Date(now);
       w.setDate(now.getDate() - now.getDay());
       w.setHours(0, 0, 0, 0);
@@ -1722,8 +1722,8 @@ document.addEventListener("DOMContentLoaded", async () => {
         sessions.length === 0
           ? `No sessions found`
           : sessions.length === allHistorySessions.length
-          ? `${sessions.length} session${sessions.length !== 1 ? "s" : ""}`
-          : `${sessions.length} of ${allHistorySessions.length}`;
+            ? `${sessions.length} session${sessions.length !== 1 ? "s" : ""}`
+            : `${sessions.length} of ${allHistorySessions.length}`;
     container.innerHTML = sessions.map((s) => buildSessionCardHTML(s, query)).join("");
     container
       .querySelectorAll<HTMLButtonElement>(".session-export-btn:not(.session-download-btn)")


### PR DESCRIPTION
## Description

This PR significantly improves the usability of the History tab in the Late Meet dashboard by adding advanced session management features. As the number of saved meeting sessions grows, it becomes difficult for users to quickly find, analyze, or export specific sessions. This update solves that problem by introducing search, filtering, sorting, and bulk export capabilities.

The enhancement focuses on improving discoverability, productivity, and data portability without changing any backend logic or existing APIs.

Fixes #832

---

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---

## Checklist:

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced **Meeting History** with full **Search & Filter** controls, including date range, sort options, and a live results counter.
  * Improved **search experience** with highlighted matches and a one-click **clear search** button, plus clearer **no-results/empty** states.
  * Added **export entire history** actions to download all sessions as **JSON** or **CSV**.
  * Expanded per-session actions: **copy/export Markdown**, **download Markdown**, **delete with confirmation**, and **expand/collapse** summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->