### PR TITLE
fix: add vault sentinel to prevent passphrase bypass on empty credential vault

### DIFF
--- a/src/utils/credentials.test.ts
+++ b/src/utils/credentials.test.ts
@@ -198,19 +198,19 @@ test("encrypted credentials survive simulated restart with same passphrase", asy
   assert.equal(creds.openai_api_key, "survive-key");
 });
 
-test(\"wrong passphrase after restart returns no credentials\", async () => {
+test("wrong passphrase after restart returns no credentials", async () => {
   const session1: StorageArea = {};
   const local1: StorageArea = {};
   setupChromeStorage(session1, local1);
 
-  await unlockCredentials(\"correct-passphrase\");
-  await saveApiCredentials({ openai_api_key: \"my-secret-key\" });
+  await unlockCredentials("correct-passphrase");
+  await saveApiCredentials({ openai_api_key: "my-secret-key" });
 
   lockCredentials();
   const session2: StorageArea = {};
   setupChromeStorage(session2, local1);
 
-  const result = await unlockCredentials(\"wrong-passphrase\");
+  const result = await unlockCredentials("wrong-passphrase");
   assert.equal(result, false);
 
   const creds = await getApiCredentials();
@@ -223,63 +223,63 @@ test(\"wrong passphrase after restart returns no credentials\", async () => {
 // Vault sentinel fix — see credentials.ts unlockCredentials() for details.
 // ---------------------------------------------------------------------------
 
-test(\"wrong passphrase rejected on empty vault (sentinel fix)\", async () => {
+test("wrong passphrase rejected on empty vault (sentinel fix)", async () => {
   const { local } = setupChromeStorage();
 
   // First-time setup with correct passphrase — no API keys saved.
-  await unlockCredentials(\"correct-passphrase\");
+  await unlockCredentials("correct-passphrase");
   assert.equal(isUnlocked(), true);
-  assert.ok(local[\"vault_sentinel\"], \"sentinel must be written on first-time setup\");
+  assert.ok(local["vault_sentinel"], "sentinel must be written on first-time setup");
   lockCredentials();
 
   // Attempt to unlock with a wrong passphrase — must be rejected.
-  const result = await unlockCredentials(\"WRONG-passphrase\");
-  assert.equal(result, false, \"wrong passphrase must return false even when no API keys are saved\");
+  const result = await unlockCredentials("WRONG-passphrase");
+  assert.equal(result, false, "wrong passphrase must return false even when no API keys are saved");
   assert.equal(isUnlocked(), false);
 });
 
-test(\"correct passphrase accepted on empty vault after sentinel written\", async () => {
+test("correct passphrase accepted on empty vault after sentinel written", async () => {
   setupChromeStorage();
 
-  await unlockCredentials(\"my-passphrase\");
+  await unlockCredentials("my-passphrase");
   lockCredentials();
 
   // Should accept the correct passphrase even with no API credentials saved.
-  const result = await unlockCredentials(\"my-passphrase\");
+  const result = await unlockCredentials("my-passphrase");
   assert.equal(result, true);
   assert.equal(isUnlocked(), true);
 });
 
-test(\"credentials saved after empty-vault unlock are recoverable with correct passphrase\", async () => {
+test("credentials saved after empty-vault unlock are recoverable with correct passphrase", async () => {
   const { local } = setupChromeStorage();
 
   // Setup vault, save no credentials, lock.
-  await unlockCredentials(\"secure-pass\");
+  await unlockCredentials("secure-pass");
   lockCredentials();
 
   // Unlock again (sentinel path), save credentials, lock.
-  await unlockCredentials(\"secure-pass\");
-  await saveApiCredentials({ openai_api_key: \"sk-sentinel-test\" });
+  await unlockCredentials("secure-pass");
+  await saveApiCredentials({ openai_api_key: "sk-sentinel-test" });
   lockCredentials();
 
   // Fresh session — credentials must be recoverable with correct passphrase.
   setupChromeStorage({}, local);
-  const result = await unlockCredentials(\"secure-pass\");
+  const result = await unlockCredentials("secure-pass");
   assert.equal(result, true);
 
   const creds = await getApiCredentials();
-  assert.equal(creds.openai_api_key, \"sk-sentinel-test\");
+  assert.equal(creds.openai_api_key, "sk-sentinel-test");
 });
 
-test(\"unlock on first run writes vault_sentinel to local storage\", async () => {
+test("unlock on first run writes vault_sentinel to local storage", async () => {
   const { local } = setupChromeStorage();
 
-  await unlockCredentials(\"test-passphrase\");
+  await unlockCredentials("test-passphrase");
 
-  assert.ok(typeof local[\"vault_sentinel\"] === \"string\", \"vault_sentinel must exist after first unlock\");
+  assert.ok(typeof local["vault_sentinel"] === "string", "vault_sentinel must exist after first unlock");
   assert.ok(
-    (local[\"vault_sentinel\"] as string).startsWith(\"enc:\"),
-    \"vault_sentinel must be encrypted (enc: prefix)\",
+    (local["vault_sentinel"] as string).startsWith("enc:"),
+    "vault_sentinel must be encrypted (enc: prefix)",
   );
 });
 

--- a/src/utils/credentials.test.ts
+++ b/src/utils/credentials.test.ts
@@ -198,23 +198,89 @@ test("encrypted credentials survive simulated restart with same passphrase", asy
   assert.equal(creds.openai_api_key, "survive-key");
 });
 
-test("wrong passphrase after restart returns no credentials", async () => {
+test(\"wrong passphrase after restart returns no credentials\", async () => {
   const session1: StorageArea = {};
   const local1: StorageArea = {};
   setupChromeStorage(session1, local1);
 
-  await unlockCredentials("correct-passphrase");
-  await saveApiCredentials({ openai_api_key: "my-secret-key" });
+  await unlockCredentials(\"correct-passphrase\");
+  await saveApiCredentials({ openai_api_key: \"my-secret-key\" });
 
   lockCredentials();
   const session2: StorageArea = {};
   setupChromeStorage(session2, local1);
 
-  const result = await unlockCredentials("wrong-passphrase");
+  const result = await unlockCredentials(\"wrong-passphrase\");
   assert.equal(result, false);
 
   const creds = await getApiCredentials();
   assert.equal(creds.openai_api_key, undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Regression tests for: unlockCredentials accepts any passphrase when vault
+// is initialized but no API credentials have been saved yet.
+// Vault sentinel fix — see credentials.ts unlockCredentials() for details.
+// ---------------------------------------------------------------------------
+
+test(\"wrong passphrase rejected on empty vault (sentinel fix)\", async () => {
+  const { local } = setupChromeStorage();
+
+  // First-time setup with correct passphrase — no API keys saved.
+  await unlockCredentials(\"correct-passphrase\");
+  assert.equal(isUnlocked(), true);
+  assert.ok(local[\"vault_sentinel\"], \"sentinel must be written on first-time setup\");
+  lockCredentials();
+
+  // Attempt to unlock with a wrong passphrase — must be rejected.
+  const result = await unlockCredentials(\"WRONG-passphrase\");
+  assert.equal(result, false, \"wrong passphrase must return false even when no API keys are saved\");
+  assert.equal(isUnlocked(), false);
+});
+
+test(\"correct passphrase accepted on empty vault after sentinel written\", async () => {
+  setupChromeStorage();
+
+  await unlockCredentials(\"my-passphrase\");
+  lockCredentials();
+
+  // Should accept the correct passphrase even with no API credentials saved.
+  const result = await unlockCredentials(\"my-passphrase\");
+  assert.equal(result, true);
+  assert.equal(isUnlocked(), true);
+});
+
+test(\"credentials saved after empty-vault unlock are recoverable with correct passphrase\", async () => {
+  const { local } = setupChromeStorage();
+
+  // Setup vault, save no credentials, lock.
+  await unlockCredentials(\"secure-pass\");
+  lockCredentials();
+
+  // Unlock again (sentinel path), save credentials, lock.
+  await unlockCredentials(\"secure-pass\");
+  await saveApiCredentials({ openai_api_key: \"sk-sentinel-test\" });
+  lockCredentials();
+
+  // Fresh session — credentials must be recoverable with correct passphrase.
+  setupChromeStorage({}, local);
+  const result = await unlockCredentials(\"secure-pass\");
+  assert.equal(result, true);
+
+  const creds = await getApiCredentials();
+  assert.equal(creds.openai_api_key, \"sk-sentinel-test\");
+});
+
+test(\"unlock on first run writes vault_sentinel to local storage\", async () => {
+  const { local } = setupChromeStorage();
+
+  await unlockCredentials(\"test-passphrase\");
+
+  assert.ok(typeof local[\"vault_sentinel\"] === \"string\", \"vault_sentinel must exist after first unlock\");
+  assert.ok(
+    (local[\"vault_sentinel\"] as string).startsWith(\"enc:\"),
+    \"vault_sentinel must be encrypted (enc: prefix)\",
+  );
 });
 
 test("encryption operations are blocked without derived key", async () => {

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -39,6 +39,8 @@ const IV_LENGTH = 12;
 const PBKDF2_ITERATIONS = 100_000;
 const SALT_LENGTH = 16;
 const SALT_STORAGE_KEY = "credential_encryption_salt";
+const VAULT_SENTINEL_KEY = "vault_sentinel";
+const VAULT_SENTINEL_PLAINTEXT = "late-meet-vault-v1";
 
 let derivedKey: CryptoKey | null = null;
 
@@ -136,29 +138,76 @@ export async function unlockCredentials(passphrase: string): Promise<boolean> {
 
   if (typeof storedSalt === "string") {
     const key = await deriveKeyFromPassphrase(passphrase, base64ToArrayBuffer(storedSalt));
-    const encryptedLocal = await chrome.storage.local.get(CREDENTIAL_KEYS);
-    const encryptedCreds = unmarkEncrypted(encryptedLocal);
-    if (Object.keys(encryptedCreds).length > 0) {
+
+    // -------------------------------------------------------------------------
+    // Passphrase verification strategy (in priority order):
+    //
+    // 1. Vault sentinel  — preferred. Written by unlockCredentials() on every
+    //    first-time setup (new code path). A small known-plaintext encrypted
+    //    with the derived key; decryption succeeds iff the passphrase is correct.
+    //    This works even when no API credentials have been saved yet, closing the
+    //    "empty vault accepts any passphrase" vulnerability.
+    //
+    // 2. Legacy fallback — for vaults created before the sentinel was introduced.
+    //    If no sentinel exists but encrypted credentials do, decrypt a sample
+    //    credential to verify. Also writes the sentinel for future unlocks.
+    //
+    // 3. Unverifiable empty vault — sentinel absent AND no credentials (old vault,
+    //    no keys ever saved). Cannot verify the passphrase; accept and write a
+    //    sentinel immediately so the very next unlock is always verifiable.
+    // -------------------------------------------------------------------------
+
+    const localData = await chrome.storage.local.get([VAULT_SENTINEL_KEY, ...CREDENTIAL_KEYS]);
+    const rawSentinel = localData[VAULT_SENTINEL_KEY];
+
+    if (typeof rawSentinel === "string" && rawSentinel.startsWith(ENCRYPTED_MARKER)) {
+      // Path 1 — sentinel present: verify passphrase via sentinel decryption.
       try {
-        const sampleKey = CREDENTIAL_KEYS.find((k) => encryptedCreds[k]);
-        if (sampleKey && encryptedCreds[sampleKey]) {
-          const combined = base64ToArrayBuffer(encryptedCreds[sampleKey]);
-          const iv = new Uint8Array(combined.slice(0, IV_LENGTH));
-          const ciphertext = combined.slice(IV_LENGTH);
-          await crypto.subtle.decrypt({ name: AES_ALGORITHM, iv }, key, ciphertext);
-        }
+        const combined = base64ToArrayBuffer(rawSentinel.slice(ENCRYPTED_MARKER.length));
+        const iv = new Uint8Array(combined.slice(0, IV_LENGTH));
+        const ciphertext = combined.slice(IV_LENGTH);
+        const decrypted = await crypto.subtle.decrypt({ name: AES_ALGORITHM, iv }, key, ciphertext);
+        const plaintext = new TextDecoder().decode(decrypted);
+        if (plaintext !== VAULT_SENTINEL_PLAINTEXT) return false;
       } catch {
-        return false;
+        return false; // Wrong passphrase — decryption failed.
       }
+    } else {
+      // Path 2 or 3 — legacy vault without sentinel.
+      const encryptedCreds = unmarkEncrypted(localData);
+
+      if (Object.keys(encryptedCreds).length > 0) {
+        // Path 2: encrypted credentials exist — verify via credential decryption.
+        try {
+          const sampleKey = CREDENTIAL_KEYS.find((k) => encryptedCreds[k]);
+          if (sampleKey && encryptedCreds[sampleKey]) {
+            const combined = base64ToArrayBuffer(encryptedCreds[sampleKey]!);
+            const iv = new Uint8Array(combined.slice(0, IV_LENGTH));
+            const ciphertext = combined.slice(IV_LENGTH);
+            await crypto.subtle.decrypt({ name: AES_ALGORITHM, iv }, key, ciphertext);
+          }
+        } catch {
+          return false; // Wrong passphrase.
+        }
+      }
+      // Path 2 fall-through OR Path 3: write sentinel now so all future unlocks
+      // use it. For Path 3 (unverifiable empty vault) we trust the passphrase
+      // once and then lock it in — any subsequent mistyped passphrase will be
+      // caught by the sentinel on the very next unlock attempt.
+      derivedKey = key;
+      const sentinelCiphertext = ENCRYPTED_MARKER + (await encrypt(VAULT_SENTINEL_PLAINTEXT));
+      await chrome.storage.local.set({ [VAULT_SENTINEL_KEY]: sentinelCiphertext });
+      resetAutoLockTimer();
+      return true;
     }
+
     derivedKey = key;
     resetAutoLockTimer();
     return true;
   }
 
-  // First-time setup: enforce the minimum passphrase strength at the boundary so
+  // First-time setup: enforce minimum passphrase strength at the boundary so
   // every caller (options, popup, onboarding) is covered, not just the UI (#655).
-  // Only applies to setup — unlocking an existing vault above is never gated.
   if (!evaluatePassphraseStrength(passphrase).meetsMinimum) {
     return false;
   }
@@ -166,6 +215,12 @@ export async function unlockCredentials(passphrase: string): Promise<boolean> {
   const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
   await chrome.storage.local.set({ [SALT_STORAGE_KEY]: arrayBufferToBase64(salt.buffer) });
   derivedKey = await deriveKeyFromPassphrase(passphrase, salt.buffer);
+
+  // Write vault sentinel immediately on first-time setup so all future unlocks
+  // can verify the passphrase even before any API credentials are saved.
+  const sentinelCiphertext = ENCRYPTED_MARKER + (await encrypt(VAULT_SENTINEL_PLAINTEXT));
+  await chrome.storage.local.set({ [VAULT_SENTINEL_KEY]: sentinelCiphertext });
+
   resetAutoLockTimer();
   return true;
 }

--- a/src/utils/credentials.ts
+++ b/src/utils/credentials.ts
@@ -178,16 +178,27 @@ export async function unlockCredentials(passphrase: string): Promise<boolean> {
 
       if (Object.keys(encryptedCreds).length > 0) {
         // Path 2: encrypted credentials exist — verify via credential decryption.
+        // Require a key whose ciphertext is non-empty. If every stored ciphertext
+        // is empty/malformed ("enc:" with no payload), we cannot verify the
+        // passphrase and must reject — accepting here would let an attacker write
+        // a sentinel encrypted with a wrong passphrase, silently locking the user out.
+        const sampleKey = CREDENTIAL_KEYS.find(
+          (k) => encryptedCreds[k] && encryptedCreds[k]!.length > 0
+        );
+
+        if (!sampleKey) {
+          // Storage has credential keys but all ciphertexts are empty/malformed.
+          // Fail closed — do not write sentinel with an unverified passphrase.
+          return false;
+        }
+
         try {
-          const sampleKey = CREDENTIAL_KEYS.find((k) => encryptedCreds[k]);
-          if (sampleKey && encryptedCreds[sampleKey]) {
-            const combined = base64ToArrayBuffer(encryptedCreds[sampleKey]!);
-            const iv = new Uint8Array(combined.slice(0, IV_LENGTH));
-            const ciphertext = combined.slice(IV_LENGTH);
-            await crypto.subtle.decrypt({ name: AES_ALGORITHM, iv }, key, ciphertext);
-          }
+          const combined = base64ToArrayBuffer(encryptedCreds[sampleKey]!);
+          const iv = new Uint8Array(combined.slice(0, IV_LENGTH));
+          const ciphertext = combined.slice(IV_LENGTH);
+          await crypto.subtle.decrypt({ name: AES_ALGORITHM, iv }, key, ciphertext);
         } catch {
-          return false; // Wrong passphrase.
+          return false; // Wrong passphrase — decryption failed.
         }
       }
       // Path 2 fall-through OR Path 3: write sentinel now so all future unlocks


### PR DESCRIPTION
## Problem
`unlockCredentials()` verified the passphrase by decrypting a sample
API credential. When the vault had been initialized (salt stored) but
no credentials saved yet, the verification block was skipped and any
passphrase was accepted as valid.

A user who mistyped their passphrase on this "empty window" would
silently encrypt their subsequent API keys with the wrong-passphrase-
derived key, making them unrecoverable with the correct passphrase.

## Fix
Writes an encrypted vault sentinel (`late-meet-vault-v1`) to
`chrome.storage.local` on every first-time vault setup. All subsequent
`unlockCredentials()` calls verify the passphrase by decrypting the
sentinel — no API credentials needed for verification.

Backward compatible: existing vaults without a sentinel fall back to
credential-based verification and write the sentinel for migration.

## Files changed
- `src/utils/credentials.ts` — sentinel constants + revised `unlockCredentials()`
- `src/utils/credentials.test.ts` — 4 regression tests

Closes #837 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential unlocking for accounts with no saved API keys yet.
  * Passphrase checks are now more reliable after restart, including first-time setup.
  * Saved credentials can now be unlocked and recovered consistently after a restart with the correct passphrase.
  * Wrong passphrases are correctly rejected in empty-vault and populated-vault scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->