### PR TITLE
fix: add missing @keyframes shake animation referenced in popup.ts

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -822,3 +822,24 @@ body::-webkit-scrollbar-thumb {
   cursor: wait;
   pointer-events: none;
 }
+
+.border-danger {
+  border-color: #ef4444 !important;
+}
+
+.shake {
+  animation: shake 0.4s ease;
+}
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-5px);
+  }
+  75% {
+    transform: translateX(5px);
+  }
+}

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -536,11 +536,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   function shakeElement(el: HTMLElement | null) {
     if (!el) return;
-    el.style.borderColor = "#EF4444";
-    el.style.animation = "shake 0.4s ease";
+    el.classList.add("shake", "border-danger");
     setTimeout(() => {
-      el.style.borderColor = "";
-      el.style.animation = "";
+      el.classList.remove("shake", "border-danger");
     }, 400);
   }
 });


### PR DESCRIPTION
fixes #529

Adds the missing @keyframes shake rule in popup.css and refactors shakeElement() to use CSS classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error feedback with a clearer red border and shake animation when an input or element needs attention.
  * Switched visual alerts to use reusable styles, making the effect more consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->