### PR TITLE
fix(ux): show inline validation feedback for empty api key

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -64,8 +64,11 @@
             </button>
           </div>
 
-          <span id="api-key-error" style="color: #ef4444; font-size: 12px; display: none; margin-top: 4px;">API key cannot be
-            empty</span>
+          <span
+            id="api-key-error"
+            style="color: #ef4444; font-size: 12px; display: none; margin-top: 4px"
+            >API key cannot be empty</span
+          >
 
           <button id="save-keys" class="setup-btn">
             <span>Save Configuration</span>

--- a/src/popup.html
+++ b/src/popup.html
@@ -64,6 +64,9 @@
             </button>
           </div>
 
+          <span id="api-key-error" style="color: #ef4444; font-size: 12px; display: none; margin-top: 4px;">API key cannot be
+            empty</span>
+
           <button id="save-keys" class="setup-btn">
             <span>Save Configuration</span>
             <span class="btn-icon">→</span>

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -105,6 +105,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     if (!apiKey) {
       shakeElement(apiKeyInput);
+      const errorMsg = document.getElementById('api-key-error');
+      if (errorMsg) errorMsg.style.display = 'block';
       return;
     }
     //Validation.
@@ -753,3 +755,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
   });
 });
+
+// Clear error message when user starts typing
+const apiInputBox = document.getElementById('api-key-input');
+if (apiInputBox) {
+    apiInputBox.addEventListener('input', () => {
+        const errorMsg = document.getElementById('api-key-error');
+        if (errorMsg && errorMsg.style.display === 'block') {
+            errorMsg.style.display = 'none';
+        }
+    });
+}

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -105,8 +105,8 @@ document.addEventListener("DOMContentLoaded", async () => {
 
     if (!apiKey) {
       shakeElement(apiKeyInput);
-      const errorMsg = document.getElementById('api-key-error');
-      if (errorMsg) errorMsg.style.display = 'block';
+      const errorMsg = document.getElementById("api-key-error");
+      if (errorMsg) errorMsg.style.display = "block";
       return;
     }
     //Validation.
@@ -757,12 +757,12 @@ document.addEventListener("DOMContentLoaded", async () => {
 });
 
 // Clear error message when user starts typing
-const apiInputBox = document.getElementById('api-key-input');
+const apiInputBox = document.getElementById("api-key-input");
 if (apiInputBox) {
-    apiInputBox.addEventListener('input', () => {
-        const errorMsg = document.getElementById('api-key-error');
-        if (errorMsg && errorMsg.style.display === 'block') {
-            errorMsg.style.display = 'none';
-        }
-    });
+  apiInputBox.addEventListener("input", () => {
+    const errorMsg = document.getElementById("api-key-error");
+    if (errorMsg && errorMsg.style.display === "block") {
+      errorMsg.style.display = "none";
+    }
+  });
 }


### PR DESCRIPTION
## Description

Added an inline validation error message to the popup UI. Previously, submitting an empty API key only triggered a shake animation without any text feedback. Now, an explicit "API key cannot be empty" message appears below the input to improve UX. Added an event listener to clear the error state as soon as the user starts typing.

Fixes #858

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a visible inline error message when the API key is missing during setup.
  * The error message now appears on save failure and clears automatically as soon as the user starts typing again.
  * The existing input shake behavior remains, but users now get clearer feedback about what needs to be fixed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->