### PR TITLE
test(security): cover credential auto-lock session purge

### DIFF
--- a/src/utils/credentials.test.ts
+++ b/src/utils/credentials.test.ts
@@ -249,6 +249,103 @@ test("saving partial credentials does not wipe out omitted keys", async () => {
   assert.ok((local.openai_api_key as string).startsWith("enc:"));
 });
 
+test("lockCredentials purges plaintext credentials from session storage", async () => {
+  const { session } = setupChromeStorage();
+
+  await unlockCredentials("test-passphrase");
+  await saveApiCredentials({
+    openai_api_key: "sk-session-secret",
+    elevenlabs_api_key: "el-session-secret",
+  });
+
+  assert.equal(session.openai_api_key, "sk-session-secret");
+  assert.equal(session.elevenlabs_api_key, "el-session-secret");
+
+  lockCredentials();
+  await Promise.resolve();
+
+  assert.equal(isUnlocked(), false);
+  assert.equal(session.openai_api_key, undefined);
+  assert.equal(session.elevenlabs_api_key, undefined);
+});
+
+test("auto-lock timeout purges plaintext credentials from session storage", async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+
+  let scheduledCallback: (() => void) | undefined;
+
+  (globalThis as any).setTimeout = (callback: () => void) => {
+    scheduledCallback = callback;
+    return 1;
+  };
+
+  (globalThis as any).clearTimeout = () => undefined;
+
+  try {
+    const { session } = setupChromeStorage();
+
+    await unlockCredentials("test-passphrase");
+    await saveApiCredentials({
+      openai_api_key: "sk-auto-lock-secret",
+      elevenlabs_api_key: "el-auto-lock-secret",
+    });
+
+    assert.equal(isUnlocked(), true);
+    assert.equal(session.openai_api_key, "sk-auto-lock-secret");
+    assert.equal(session.elevenlabs_api_key, "el-auto-lock-secret");
+
+    assert.ok(scheduledCallback);
+    scheduledCallback();
+
+    await Promise.resolve();
+
+    assert.equal(isUnlocked(), false);
+    assert.equal(session.openai_api_key, undefined);
+    assert.equal(session.elevenlabs_api_key, undefined);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+test("credential access refreshes the inactivity lock timer", async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+
+  const autoLockDelayMs = 30 * 60 * 1000;
+  let setTimeoutCalls = 0;
+  let clearTimeoutCalls = 0;
+  const delays: number[] = [];
+
+  (globalThis as any).setTimeout = (_callback: () => void, delay?: number) => {
+    setTimeoutCalls += 1;
+    delays.push(delay ?? 0);
+    return setTimeoutCalls;
+  };
+
+  (globalThis as any).clearTimeout = () => {
+    clearTimeoutCalls += 1;
+  };
+
+  try {
+    setupChromeStorage();
+
+    await unlockCredentials("test-passphrase");
+    assert.equal(setTimeoutCalls, 1);
+    assert.deepEqual(delays, [autoLockDelayMs]);
+
+    await getApiCredentials();
+
+    assert.equal(setTimeoutCalls, 2);
+    assert.equal(clearTimeoutCalls >= 1, true);
+    assert.deepEqual(delays, [autoLockDelayMs, autoLockDelayMs]);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
 after(() => {
   lockCredentials();
 });


### PR DESCRIPTION
## Description

Fixes #654

This PR adds regression coverage for credential auto-lock security behavior.

The tests verify that plaintext API credentials stored in `chrome.storage.session` are purged when the credential vault is locked, including both manual lock and inactivity auto-lock flows. It also verifies that credential access refreshes the inactivity timer, so the auto-lock behavior is based on actual inactivity.

This strengthens the security guarantee that decrypted API keys do not remain available in session storage after the vault is locked.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Security impact

- Covers plaintext credential cleanup from `chrome.storage.session`
- Ensures auto-lock timeout follows the same lock path as manual locking
- Prevents stale decrypted OpenAI/ElevenLabs API keys from remaining accessible after lock

## Validation

- `git diff --check` → passed
- `npm test -- src/utils/credentials.test.ts` → passed
- `npx tsx --test src/utils/credentials.test.ts` → passed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for credential locking behavior, including clearing stored plaintext API keys when credentials are locked.
  * Added coverage for automatic lock timing, confirming plaintext values are removed and the unlocked state is updated after inactivity.
  * Added a test to verify that accessing credentials refreshes the inactivity timer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->