### PR TITLE
fix: add missing @keyframes shake animation

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -822,3 +822,16 @@ body::-webkit-scrollbar-thumb {
   cursor: wait;
   pointer-events: none;
 }
+
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  25% {
+    transform: translateX(-5px);
+  }
+  75% {
+    transform: translateX(5px);
+  }
+}


### PR DESCRIPTION
Fixes #529 - adds the @keyframes shake CSS rule referenced by shakeElement() in popup.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added a subtle shake animation that can be used by popup interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->