### PR TITLE
fix: add aria-labels to icon-only buttons for accessibility

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -161,7 +161,11 @@
           <p class="form-hint">Required for AI summarization</p>
           <div class="input-row">
             <input type="password" id="openai-key" class="form-input" placeholder="sk-..." />
-            <button class="toggle-vis" data-target="openai-key">
+            <button
+              class="toggle-vis"
+              data-target="openai-key"
+              aria-label="Toggle API key visibility"
+            >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
@@ -188,7 +192,11 @@
           <p class="form-hint">Required for Speech-to-Text transcription</p>
           <div class="input-row">
             <input type="password" id="elevenlabs-key" class="form-input" placeholder="sk_..." />
-            <button class="toggle-vis" data-target="elevenlabs-key">
+            <button
+              class="toggle-vis"
+              data-target="elevenlabs-key"
+              aria-label="Toggle API key visibility"
+            >
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"

--- a/src/popup.html
+++ b/src/popup.html
@@ -40,7 +40,9 @@
           <label class="setup-label">OpenAI API Key</label>
           <div class="input-group">
             <input type="password" id="api-key-input" class="setup-input" placeholder="sk-..." />
-            <button id="toggle-key" class="toggle-btn">👁</button>
+            <button id="toggle-key" class="toggle-btn" aria-label="Toggle API key visibility">
+              👁
+            </button>
           </div>
 
           <button id="save-keys" class="setup-btn">
@@ -81,7 +83,9 @@
             </div>
           </div>
         </div>
-        <button id="settings-btn" class="icon-btn" title="Settings">⚙️</button>
+        <button id="settings-btn" class="icon-btn" title="Settings" aria-label="Settings">
+          ⚙️
+        </button>
       </header>
 
       <!-- Content Sections -->


### PR DESCRIPTION
Fixes #865 - adds descriptive aria-label attributes to icon-only buttons (toggle visibility, settings) for screen reader accessibility