### PR TITLE
feat: improve error handling and lifecycle management for tabCapture

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/passphraseStrength.test.ts src/settings.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts src/background.sessionRecovery.test.ts src/lateJoinerDelivery.test.ts src/utils/sanitize.test.ts tests/offscreenAudioGraph.test.ts",
+    "test": "tsx --test src/activeMeetingMessages.test.ts src/audioCaptureLifecycle.test.ts src/audioProcessing.test.ts src/audioChunkQueue.test.ts src/audioChunkQueue.fuzz.test.ts src/participantDetection.test.ts src/meetingTabs.test.ts src/sessionStorage.test.ts src/dashboardCapture.test.ts src/popupCapture.test.ts src/speakerAttribution.test.ts src/passphraseStrength.test.ts src/settings.test.ts src/utils/credentials.test.ts src/utils/storageUtils.test.ts src/background.urlParsing.test.ts src/background.sessionRecovery.test.ts src/lateJoinerDelivery.test.ts src/utils/sanitize.test.ts tests/offscreenAudioGraph.test.ts src/audioCaptureRetry.test.ts",
     "lint": "eslint . --ext .ts,.js",
     "type-check": "tsc --noEmit",
     "size-check": "tsx scripts/checkBundleSize.ts",

--- a/src/audioCaptureRetry.test.ts
+++ b/src/audioCaptureRetry.test.ts
@@ -1,0 +1,178 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+type AnyRecord = Record<string, unknown>;
+type MessageListener = (
+  message: AnyRecord,
+  sender: AnyRecord,
+  sendResponse: (response?: unknown) => void,
+) => boolean | undefined;
+
+let messageListener: MessageListener | undefined;
+let getMediaStreamIdCalls = 0;
+let getMediaStreamIdCallbackValue: string | null = null;
+let lastErrorMock: { message: string } | null = null;
+let sentMessages: AnyRecord[] = [];
+let tabUpdatedListener: Function | null = null;
+
+// Speed up setTimeout for backoff testing
+const originalSetTimeout = globalThis.setTimeout;
+(globalThis as any).setTimeout = (cb: Function, ms?: number) => {
+  return originalSetTimeout(cb, 0);
+};
+
+function installChromeMock() {
+  if (typeof (globalThis as any).addEventListener !== "function") {
+    (globalThis as any).addEventListener = () => {};
+  }
+  (globalThis as any).self = globalThis;
+
+  (globalThis as any).chrome = {
+    runtime: {
+      getURL: (path: string) => `chrome-extension://fakeextid/${path}`,
+      sendMessage: async (msg: AnyRecord) => {
+        sentMessages.push(msg);
+        if (msg.type === "OFFSCREEN_START_CAPTURE") {
+          return { success: false, error: "Mock offscreen start failure" };
+        }
+        return { success: true };
+      },
+      getContexts: async () => [],
+      onMessage: {
+        addListener: (cb: MessageListener) => {
+          messageListener = cb;
+        },
+      },
+      onInstalled: { addListener: () => {} },
+      onStartup: { addListener: () => {} },
+      onSuspend: { addListener: () => {} },
+      get lastError() {
+        return lastErrorMock;
+      },
+    },
+    offscreen: {
+      createDocument: async () => {},
+      closeDocument: async () => {},
+      hasDocument: async () => false,
+    },
+    alarms: {
+      onAlarm: { addListener: () => {} },
+      create: () => {},
+    },
+    tabs: {
+      onUpdated: {
+        addListener: (cb: Function) => {
+          tabUpdatedListener = cb;
+        },
+      },
+      onActivated: { addListener: () => {} },
+      onRemoved: { addListener: () => {} },
+      get: async () => ({}),
+      query: async () => [],
+      sendMessage: async () => {},
+    },
+    tabCapture: {
+      getMediaStreamId: (options: any, callback: (streamId: string | null) => void) => {
+        getMediaStreamIdCalls++;
+        callback(getMediaStreamIdCallbackValue);
+      },
+    },
+    commands: { onCommand: { addListener: () => {} } },
+    contextMenus: {
+      onClicked: { addListener: () => {} },
+      removeAll: (cb?: () => void) => cb?.(),
+      create: () => {},
+    },
+    sidePanel: { open: async () => {} },
+    storage: {
+      local: {
+        get: async () => ({}),
+        set: async () => {},
+        remove: async () => {},
+      },
+      session: {
+        get: async () => ({}),
+        set: async () => {},
+        remove: async () => {},
+      },
+    },
+  };
+}
+
+installChromeMock();
+await import("./background.ts");
+
+function sendMessage(message: AnyRecord): Promise<AnyRecord> {
+  return new Promise((resolve) => {
+    if (!messageListener) {
+      throw new Error("background did not register an onMessage listener");
+    }
+    const kept = messageListener(message, {}, (response) => resolve((response ?? {}) as AnyRecord));
+    if (kept !== true) resolve({});
+  });
+}
+
+test("audio capture retries 3 times and reports error on failure", async () => {
+  getMediaStreamIdCalls = 0;
+  getMediaStreamIdCallbackValue = null;
+  lastErrorMock = { message: "Mocked capture stream permission denied" };
+  sentMessages = [];
+
+  const response = await sendMessage({
+    type: "MANUAL_START_AUDIO",
+    tabId: 42,
+    meetingId: "abc-defg-hij",
+  });
+
+  // Verify that getMediaStreamId was called 3 times (due to retry limit)
+  assert.equal(getMediaStreamIdCalls, 3);
+
+  // Retrieve final state to check error message is populated
+  const finalState = await sendMessage({ type: "GET_STATE" });
+  assert.equal(finalState.audioActive, false);
+  assert.equal(finalState.captureError, "Failed to get media stream ID for tab capture. Ensure you have given permission.");
+});
+
+test("audio capture stops when active tab navigates away from Google Meet", async () => {
+  // Reset states
+  const finalState1 = await sendMessage({ type: "GET_STATE" });
+  assert.equal(finalState1.audioActive, false);
+
+  // Simulate success on first try
+  getMediaStreamIdCalls = 0;
+  getMediaStreamIdCallbackValue = "mock-stream-id";
+  lastErrorMock = null;
+  
+  // Temporarily mock sendMessage for runtime to return success for offscreen document start
+  const originalSendMessage = chrome.runtime.sendMessage;
+  chrome.runtime.sendMessage = async (msg: any) => {
+    if (msg.type === "OFFSCREEN_START_CAPTURE") {
+      return { success: true };
+    }
+    return { success: true };
+  };
+
+  await sendMessage({
+    type: "MANUAL_START_AUDIO",
+    tabId: 42,
+    meetingId: "abc-defg-hij",
+  });
+
+  const activeState = await sendMessage({ type: "GET_STATE" });
+  assert.equal(activeState.audioActive, true);
+  assert.equal(activeState.targetTabId, 42);
+
+  // Restore original runtime sendMessage
+  chrome.runtime.sendMessage = originalSendMessage;
+
+  // Now trigger tab update listener to navigate away
+  assert.ok(tabUpdatedListener);
+  await tabUpdatedListener(
+    42,
+    { url: "https://example.com" },
+    { id: 42, url: "https://example.com" }
+  );
+
+  const stoppedState = await sendMessage({ type: "GET_STATE" });
+  assert.equal(stoppedState.audioActive, false);
+});

--- a/src/background.ts
+++ b/src/background.ts
@@ -274,6 +274,7 @@ const state: State = {
   participantCount: 0,
   tokensUsed: 0,
   estimatedCost: 0,
+  captureError: null,
 };
 
 async function trackUsage(delta: UsageDelta) {
@@ -533,6 +534,7 @@ function resetState() {
   selfParticipantName = null;
   state.tokensUsed = 0;
   state.estimatedCost = 0;
+  state.captureError = null;
 }
 
 function addTimeline(event: string) {
@@ -578,6 +580,7 @@ function snapshot() {
     pendingJoiners: [...(state.pendingJoiners ?? [])],
     tokensUsed: state.tokensUsed ?? 0,
     estimatedCost: state.estimatedCost ?? 0,
+    captureError: state.captureError,
   };
 }
 
@@ -1657,76 +1660,101 @@ async function startAudioCapture(
 
   const createdSession = !state.isActive || !state.meetingId;
 
-  try {
-    await ensureOffscreenDocument();
+  if (createdSession) {
+    resetState();
+    await chrome.storage.local.remove("activeMeetingState");
+    state.isActive = true;
+    state.startTime = Date.now();
+    state.meetingId = meetingId || "unknown";
+    state.meetingUrl = meetingUrl || null;
+    state.targetTabId = tabId;
+    addTimeline(`Meeting started (${state.meetingId})`);
+  }
 
-    if (createdSession) {
-      resetState();
-      await chrome.storage.local.remove("activeMeetingState");
-      state.isActive = true;
-      state.startTime = Date.now();
-      state.meetingId = meetingId || "unknown";
-      state.meetingUrl = meetingUrl || null;
-      state.targetTabId = tabId;
-      addTimeline(`Meeting started (${state.meetingId})`);
-    }
+  let attempts = 0;
+  const maxAttempts = 3;
+  const baseDelay = 1000;
+  let success = false;
+  let lastErr: any = null;
 
-    let streamId = providedStreamId;
+  while (attempts < maxAttempts) {
+    try {
+      await ensureOffscreenDocument();
 
-    if (!streamId) {
-      streamId = await new Promise<string | null>((resolve) => {
-        chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, (id) => {
-          if (chrome.runtime.lastError) {
-            console.error(
-              "[LateMeet] getMediaStreamId error (background):",
-              chrome.runtime.lastError.message || chrome.runtime.lastError,
-            );
-            resolve(null);
-          } else {
-            resolve(id);
-          }
+      let streamId = providedStreamId;
+
+      if (!streamId) {
+        streamId = await new Promise<string | null>((resolve) => {
+          chrome.tabCapture.getMediaStreamId({ targetTabId: tabId }, (id) => {
+            if (chrome.runtime.lastError) {
+              console.error(
+                `[LateMeet] getMediaStreamId error (attempt ${attempts + 1}):`,
+                chrome.runtime.lastError.message || chrome.runtime.lastError,
+              );
+              resolve(null);
+            } else {
+              resolve(id);
+            }
+          });
         });
+      }
+
+      if (!streamId) {
+        throw new Error(
+          "Failed to get media stream ID for tab capture. Ensure you have given permission.",
+        );
+      }
+
+      const settings = await getSettings();
+      const raw = settings.vadThreshold;
+      const vadThreshold =
+        typeof raw === "number" && Number.isFinite(raw) && raw >= 0.001 && raw <= 1.0 ? raw : 0.012;
+      const response = await chrome.runtime.sendMessage({
+        type: "OFFSCREEN_START_CAPTURE",
+        streamId,
+        tabId,
+        includeMicrophone,
+        vadThreshold,
       });
-    }
 
-    if (!streamId) {
-      throw new Error(
-        "Failed to get media stream ID for tab capture. Ensure you have given permission.",
-      );
-    }
+      if (!response?.success) {
+        throw new Error(response?.error || "Failed to start offscreen capture");
+      }
 
-    const settings = await getSettings();
-    const raw = settings.vadThreshold;
-    const vadThreshold =
-      typeof raw === "number" && Number.isFinite(raw) && raw >= 0.001 && raw <= 1.0 ? raw : 0.012;
-    const response = await chrome.runtime.sendMessage({
-      type: "OFFSCREEN_START_CAPTURE",
-      streamId,
-      tabId,
-      includeMicrophone,
-      vadThreshold,
-    });
-
-    if (!response?.success) {
-      throw new Error(response?.error || "Failed to start offscreen capture");
+      state.audioActive = true;
+      addTimeline("Audio capture started");
+      if (response.microphoneActive === false) {
+        addTimeline("Microphone capture unavailable; recording tab audio only");
+      }
+      state.captureError = null;
+      await broadcastStateUpdate(true);
+      success = true;
+      break;
+    } catch (err: any) {
+      attempts++;
+      lastErr = err;
+      console.warn(`[LateMeet] Audio capture start attempt ${attempts} failed:`, err.message || err);
+      if (attempts < maxAttempts) {
+        const delay = baseDelay * Math.pow(2, attempts - 1) + Math.random() * 200;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
     }
+  }
 
-    state.audioActive = true;
-    addTimeline("Audio capture started");
-    if (response.microphoneActive === false) {
-      addTimeline("Microphone capture unavailable; recording tab audio only");
-    }
-    await broadcastStateUpdate(true);
-  } catch (err) {
+  if (!success) {
+    state.captureError = lastErr?.message || "Audio capture failed";
     state.audioActive = false;
     if (createdSession) {
       resetState();
-      await broadcastStateUpdate(true);
+      // Keep captureError preserved even after resetState()
+      state.captureError = lastErr?.message || "Audio capture failed";
     }
-    throw err;
-  } finally {
+    await broadcastStateUpdate(true);
     isStartingAudio = false;
+    throw lastErr || new Error("Audio capture failed after retries");
   }
+
+  isStartingAudio = false;
 }
 
 async function scanForMeetTabs() {
@@ -1782,7 +1810,7 @@ async function pollRemainingChunks(): Promise<void> {
   while (Date.now() - pollStart < POLL_TIMEOUT) {
     try {
       const pollResponse = await chrome.runtime.sendMessage({
-        type: "GET_REMAINING_CHUNKS",
+        type: "OFFSCREEN_GET_REMAINING_CHUNKS",
       });
       if (pollResponse && typeof pollResponse === "object") {
         const pending = pollResponse.pending ?? 0;
@@ -1846,6 +1874,26 @@ async function stopAudioCapture(reason = "Stopped") {
 }
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  // If the target tab being captured updates its URL or completes loading:
+  if (tabId === state.targetTabId) {
+    const newUrl = changeInfo.url || (changeInfo.status === "complete" ? tab.url : undefined);
+    if (newUrl) {
+      await hydrateState();
+      if (state.isActive) {
+        const newMeetingId = getMeetingIdFromUrl(newUrl);
+        if (!newMeetingId || newMeetingId !== state.meetingId) {
+          let reason = "Left meeting";
+          if (newMeetingId && newMeetingId !== state.meetingId) {
+            reason = "Meeting code changed";
+          } else if (!newUrl.includes("meet.google.com")) {
+            reason = "Navigated away from Google Meet";
+          }
+          await stopAudioCapture(reason);
+        }
+      }
+    }
+  }
+
   if (changeInfo.status !== "complete" || !tab.url) return;
   await hydrateState();
   try {

--- a/src/dashboard.css
+++ b/src/dashboard.css
@@ -1125,6 +1125,52 @@ body::-webkit-scrollbar-thumb,
   color: #fca5a5;
 }
 
+/* --- ERROR BANNER --- */
+.dash-error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid #ef4444;
+  border-radius: 8px;
+  padding: 10px 16px;
+  margin: 12px 16px;
+  font-size: 13px;
+  color: #ef4444;
+  gap: 12px;
+}
+
+.dash-error-banner .dash-error-message {
+  flex-grow: 1;
+}
+
+.dash-error-banner .dash-error-retry-btn {
+  background: #ef4444;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+  transition: background-color 0.2s ease;
+}
+
+.dash-error-banner .dash-error-retry-btn:hover {
+  background: #dc2626;
+}
+
+.dash-error-banner .dash-error-close-btn {
+  background: transparent;
+  color: #ef4444;
+  border: none;
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+}
+
 /* =====================================================
    RESPONSIVE BREAKPOINTS — Issue #648
    Fix: text overlap, button clipping, header overflow,

--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -150,6 +150,13 @@
       </div>
     </header>
 
+    <!-- Error Banner -->
+    <div id="dash-error-banner" class="dash-error-banner" style="display: none;">
+      <span id="dash-error-message" class="dash-error-message">Audio capture failed — please retry.</span>
+      <button id="dash-error-retry-btn" class="dash-error-retry-btn">Retry</button>
+      <button id="dash-error-close-btn" class="dash-error-close-btn">×</button>
+    </div>
+
     <!-- Tabs -->
     <nav class="dash-tabs" role="tablist" aria-label="Dashboard Navigation">
       <button

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -353,6 +353,34 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ——— Start Audio Capture (User Gesture via tabCapture) ———
   const audioBtn = document.getElementById("dash-start-audio-btn") as HTMLButtonElement | null;
+  const errorBanner = document.getElementById("dash-error-banner") as HTMLDivElement | null;
+  const errorMessage = document.getElementById("dash-error-message") as HTMLSpanElement | null;
+  const errorRetryBtn = document.getElementById("dash-error-retry-btn") as HTMLButtonElement | null;
+  const errorCloseBtn = document.getElementById("dash-error-close-btn") as HTMLButtonElement | null;
+
+  errorRetryBtn?.addEventListener("click", () => {
+    if (errorBanner) errorBanner.style.display = "none";
+    if (audioBtn) {
+      audioBtn.click();
+    }
+  });
+
+  errorCloseBtn?.addEventListener("click", async () => {
+    if (errorBanner) errorBanner.style.display = "none";
+    try {
+      await chrome.storage.local.get("activeMeetingState", async (data) => {
+        if (data && data.activeMeetingState) {
+          data.activeMeetingState.captureError = null;
+          await chrome.storage.local.set({ activeMeetingState: data.activeMeetingState });
+        }
+      });
+      if (lastState) {
+        lastState.captureError = null;
+      }
+    } catch (err) {
+      console.error("[LateMeet] Failed to clear captureError:", err);
+    }
+  });
 
   function getDashboardMediaStreamId(tabId: number): Promise<string> {
     return new Promise((resolve, reject) => {
@@ -445,7 +473,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       audioBtn.classList.add("active");
       audioBtn.disabled = false;
       audioBtn.innerHTML =
-        '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right: 6px;"><rect width="18" height="18" x="3" y="3" rx="2"></rect><path d="M9 12h6"></path></svg> Stop Audio';
+        '<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon" style="margin-right: 6px;"><rect width="18" height="18" x="3" y="3" rx="2"></rect><path d="M9 12h6"></path></svg> Stop Recording';
     } else {
       audioBtn.classList.remove("active");
       audioBtn.disabled = false;
@@ -469,6 +497,16 @@ document.addEventListener("DOMContentLoaded", async () => {
   // ——— Update Dashboard ———
   function updateDashboard(state: State) {
     currentMeetingId = state.meetingId || "unknown";
+
+    // Error banner
+    if (errorBanner && errorMessage) {
+      if (state.captureError) {
+        errorMessage.textContent = state.captureError;
+        errorBanner.style.display = "flex";
+      } else {
+        errorBanner.style.display = "none";
+      }
+    }
     // Status
     const statusDot = document.querySelector(".dash-status-dot");
     const statusText = document.getElementById("dash-status-text");

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -223,6 +223,12 @@ async function postChunk(blob: Blob) {
       mimeType,
     });
 
+    if (response?.ignored) {
+      relay("chunk ignored by background because session is inactive — stopping capture");
+      await stopCapture();
+      return;
+    }
+
     if (!response?.success) {
       relay(`chunk rejected by background — ${response?.error || "unknown error"}`);
     }
@@ -710,6 +716,14 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
       sendResponse({ success: true });
 
+      return;
+    }
+
+    if (message.type === "OFFSCREEN_GET_REMAINING_CHUNKS") {
+      sendResponse({
+        pending: pendingChunks.length,
+        isDrainingQueue: isDrainingQueue || isFlushInProgress,
+      });
       return;
     }
 

--- a/src/popup.css
+++ b/src/popup.css
@@ -909,3 +909,49 @@ body::-webkit-scrollbar-thumb {
   cursor: wait;
   pointer-events: none;
 }
+
+/* --- ERROR BANNER --- */
+.error-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(239, 68, 68, 0.1);
+  border: 1px solid #ef4444;
+  border-radius: 8px;
+  padding: 8px 12px;
+  margin: 10px 12px;
+  font-size: 12px;
+  color: #ef4444;
+  gap: 8px;
+}
+
+.error-banner .error-message {
+  flex-grow: 1;
+}
+
+.error-banner .error-retry-btn {
+  background: #ef4444;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.error-banner .error-retry-btn:hover {
+  background: #dc2626;
+}
+
+.error-banner .error-close-btn {
+  background: transparent;
+  color: #ef4444;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+}
+

--- a/src/popup.html
+++ b/src/popup.html
@@ -106,6 +106,13 @@
         <button id="settings-btn" class="icon-btn" aria-label="Settings">⚙️</button>
       </header>
 
+      <!-- Error Banner -->
+      <div id="error-banner" class="error-banner" style="display: none;">
+        <span id="error-message" class="error-message">Audio capture failed — please retry.</span>
+        <button id="error-retry-btn" class="error-retry-btn">Retry</button>
+        <button id="error-close-btn" class="error-close-btn">×</button>
+      </div>
+
       <!-- Content Sections -->
       <div id="meeting-section" style="display: none">
         <!-- Duration & ID -->

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -25,6 +25,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     "session-modal-error",
   ) as HTMLParagraphElement | null;
 
+  const errorBanner = document.getElementById("error-banner") as HTMLDivElement | null;
+  const errorMessage = document.getElementById("error-message") as HTMLSpanElement | null;
+  const errorRetryBtn = document.getElementById("error-retry-btn") as HTMLButtonElement | null;
+  const errorCloseBtn = document.getElementById("error-close-btn") as HTMLButtonElement | null;
+
   let lastState: State | null = null;
 
   // ——— Passphrase management ———
@@ -385,6 +390,33 @@ document.addEventListener("DOMContentLoaded", async () => {
     handleStartAudio(btn);
   });
 
+  errorRetryBtn?.addEventListener("click", () => {
+    if (errorBanner) errorBanner.style.display = "none";
+    const startBtn = (meetingSection && meetingSection.style.display === "block")
+      ? (document.getElementById("meeting-start-audio-btn") as HTMLButtonElement | null)
+      : copilotBtn;
+    if (startBtn) {
+      handleStartAudio(startBtn);
+    }
+  });
+
+  errorCloseBtn?.addEventListener("click", async () => {
+    if (errorBanner) errorBanner.style.display = "none";
+    try {
+      await chrome.storage.local.get("activeMeetingState", async (data) => {
+        if (data && data.activeMeetingState) {
+          data.activeMeetingState.captureError = null;
+          await chrome.storage.local.set({ activeMeetingState: data.activeMeetingState });
+        }
+      });
+      if (lastState) {
+        lastState.captureError = null;
+      }
+    } catch (err) {
+      console.error("[LateMeet] Failed to clear captureError:", err);
+    }
+  });
+
   function setCopilotActive(active: boolean) {
     if (!copilotBtn) return;
     const miniBtn = document.getElementById("meeting-start-audio-btn");
@@ -413,7 +445,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         miniBtn.classList.add("active");
         miniBtn.title = "Stop audio capture";
         const labelNode = getMiniBtnLabelNode();
-        if (labelNode) labelNode.textContent = " Stop Audio";
+        if (labelNode) labelNode.textContent = " Stop Recording";
       }
     } else {
       copilotBtn.classList.remove("active");
@@ -627,6 +659,15 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   // ——— Update UI ———
   function updateUI(state: State) {
+    if (errorBanner && errorMessage) {
+      if (state.captureError) {
+        errorMessage.textContent = state.captureError;
+        errorBanner.style.display = "flex";
+      } else {
+        errorBanner.style.display = "none";
+      }
+    }
+
     if (state.isActive) {
       if (meetingSection) meetingSection.style.display = "block";
       if (noMeetingSection) noMeetingSection.style.display = "none";

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,7 @@ export interface State {
   truncatedCounts?: Record<string, number>;
   tokensUsed?: number;
   estimatedCost?: number;
+  captureError?: string | null;
 }
 
 /** Storage metadata summary for a single saved meeting, used in storage usage reports. */


### PR DESCRIPTION
## Description

Introduces robust error handling, transient retry logic with exponential backoff, and strict lifecycle management for `tabCapture` audio recording in Late-Meet. 

- **Error Handling & State**: Added `captureError` to the session `State` interface. Captures initialization/connection failures and broadcasts them to active UI components.
- **Transient Retry Logic**: Implemented an exponential backoff retry mechanism (up to 3 attempts with random jitter) when initializing tab capture or establishing the offscreen document.
- **URL Tracking & Lifecycle Teardown**: Automatically stops capture and cleans up resources if the target Google Meet tab navigates away from `meet.google.com` or if the meeting code changes.
- **Ignored Chunk Teardown**: Ensures the offscreen document stops recording immediately if the background service worker rejects or ignores audio chunks due to session inactivity.
- **Error UI Banners**: Integrated responsive, theme-consistent error banners in both the Popup and Full Dashboard views, complete with "Retry" and "Dismiss/Close" buttons.
- **Button Labels**: Renamed the active state button labels from `"Stop Audio"` to `"Stop Recording"`.

Fixes #871

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear audio capture error messages with Retry and dismiss controls in the dashboard and popup.
  * Audio capture now retries automatically up to three times and reports failures when unsuccessful.
  * Audio recording stops when navigating away from the active meeting.

* **Bug Fixes**
  * Improved handling of inactive recording sessions and pending audio data.
  * Updated controls to consistently display “Stop Recording.”

* **Tests**
  * Added coverage for capture retries, failure reporting, and navigation-based stopping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->