### PR TITLE
fix: guard participantNameFromCandidate against nullish candidate

### DIFF
--- a/src/participantDetection.test.ts
+++ b/src/participantDetection.test.ts
@@ -101,3 +101,8 @@ test("case-insensitive control labels are rejected", () => {
   assert.equal(participantNameFromCandidate({ selfName: "mute" }), null);
   assert.equal(participantNameFromCandidate({ selfName: "Camera Off" }), null);
 });
+
+test("nullish candidate does not throw", () => {
+  assert.equal(participantNameFromCandidate(null), null);
+  assert.equal(participantNameFromCandidate(undefined), null);
+});

--- a/src/participantDetection.ts
+++ b/src/participantDetection.ts
@@ -47,7 +47,11 @@ const LOWERCASE_EXCLUDED_LABELS = new Set(
   Array.from(EXCLUDED_PARTICIPANT_LABELS).map((label) => label.toLowerCase()),
 );
 
-export function participantNameFromCandidate(candidate: ParticipantNameCandidate): string | null {
+export function participantNameFromCandidate(
+  candidate: ParticipantNameCandidate | null | undefined,
+): string | null {
+  if (!candidate) return null;
+
   const selfName = cleanText(candidate.selfName || "");
   const text = stripExcludedLabels(candidate.text || "");
   const ariaLabel = cleanText(candidate.ariaLabel || "");


### PR DESCRIPTION
Real fix for #803.

Make `participantNameFromCandidate` null-safe so a nullish candidate no longer throws a TypeError on property access; adds a regression test.

Closes #803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant name handling when candidate information is missing.
  * Prevented errors caused by null or undefined participant data.

* **Tests**
  * Added coverage verifying safe handling of missing participant information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->