### PR TITLE
fix: fire AudioChunkQueue.onDrain when queue fills mid-drain

### DIFF
--- a/src/audioChunkQueue.test.ts
+++ b/src/audioChunkQueue.test.ts
@@ -172,3 +172,39 @@ test("audio chunk queue handles large backlog without rejection when capacity al
 
   assert.equal(processed.length, 1000);
 });
+
+test("audio chunk queue fires onDrain when the queue fills mid-drain", async () => {
+  const gate = deferred<void>();
+  const processed: string[] = [];
+  let drainCalls = 0;
+  const queue = new AudioChunkQueue<string>({
+    maxPending: 2,
+    process: async ({ item }) => {
+      await gate.promise;
+      processed.push(item);
+    },
+    onDrain: () => {
+      drainCalls += 1;
+    },
+  });
+
+  // Drain starts with the queue NOT full (a single item), then fills to
+  // capacity during processing. Capturing `wasFull` only before the loop
+  // (see issue #778) would miss this and never fire onDrain.
+  queue.enqueue("first");
+  queue.enqueue("second");
+  queue.enqueue("third");
+  await Promise.resolve();
+
+  assert.equal(drainCalls, 0);
+
+  gate.resolve();
+
+  while (queue.isProcessing) {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  assert.deepEqual(processed, ["first", "second", "third"]);
+  assert.equal(queue.pending, 0);
+  assert.equal(drainCalls, 1);
+});

--- a/src/audioChunkQueue.ts
+++ b/src/audioChunkQueue.ts
@@ -74,10 +74,18 @@ export class AudioChunkQueue<T> {
     if (this.processing) return;
 
     this.processing = true;
-    const wasFull = this.pendingItems.length >= this.maxPending;
+    // Capture whether the queue started full so we know to fire onDrain once it
+    // drains back below the cap. enqueue() may push more items (and the queue
+    // may briefly become full again) while we await processing, so re-check the
+    // fullness at the end rather than relying solely on the initial snapshot.
+    let becameFull = this.pendingItems.length >= this.maxPending;
 
     try {
       while (this.pendingItems.length > 0) {
+        if (this.pendingItems.length >= this.maxPending) {
+          becameFull = true;
+        }
+
         const entry = this.pendingItems.shift();
         if (!entry) continue;
 
@@ -93,7 +101,7 @@ export class AudioChunkQueue<T> {
       }
     } finally {
       this.processing = false;
-      if (wasFull && this.pendingItems.length < this.maxPending) {
+      if (becameFull && this.pendingItems.length < this.maxPending) {
         this.onDrain?.();
       }
     }


### PR DESCRIPTION
Real fix for #778.

`drain()` captured `wasFull` once before the processing loop, so if the queue became full during draining (concurrent `enqueue`) the `onDrain` callback was never invoked — consumers waiting for OFFSCREEN_RESUME_RECORDING never got notified. Now tracks fullness across the loop and fires `onDrain` correctly. Adds a regression test.

Closes #778