### PR TITLE
fix: add aria-live region to popup status badge

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -97,7 +97,7 @@
           </span>
           <div>
             <div class="header-title">Meeting Copilot</div>
-            <div id="status-badge" class="status-badge inactive">
+            <div id="status-badge" class="status-badge inactive" role="status" aria-live="polite">
               <span class="status-dot"></span>
               <span class="status-text">No active meeting</span>
             </div>


### PR DESCRIPTION
Real fix for #741.

The popup recording status badge updated via `innerHTML`/`textContent` but had no `role`/`aria-live`, so screen readers never announced state changes (violates WCAG 2.1 SC 4.1.3). Added `role="status"` and `aria-live="polite"` to `#status-badge`.

Closes #741