### PR TITLE
fix: replace async setInterval with recursive setTimeout in VAD loop and participant polling

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -432,32 +432,36 @@ void initTheme().catch((err) => console.error(err));
     return { participants: collectParticipantNames(candidates), selfName };
   }
 
-  let participantPollTimer: number | NodeJS.Timeout | null = null;
+  let participantPollTimer: ReturnType<typeof setTimeout> | null = null;
   let activeSpeakerObserver: MutationObserver | null = null;
   let activeSpeakerCheckTimer: number | NodeJS.Timeout | null = null;
   let lastActiveSpeakerName: string | null = null;
 
+  async function pollParticipants() {
+    try {
+      const { participants, selfName } = await collectParticipants();
+
+      await chrome.runtime.sendMessage({
+        type: "PARTICIPANTS_UPDATED",
+        participants,
+        selfName,
+      });
+    } catch (err) {
+      console.debug("[LateMeet] Participant polling failed:", err);
+    } finally {
+      participantPollTimer = setTimeout(pollParticipants, 5000);
+    }
+  }
+
   function startParticipantPolling() {
     if (participantPollTimer) return;
 
-    participantPollTimer = setInterval(async () => {
-      const { participants, selfName } = await collectParticipants();
-
-      try {
-        await chrome.runtime.sendMessage({
-          type: "PARTICIPANTS_UPDATED",
-          participants,
-          selfName,
-        });
-      } catch {
-        // Service worker idle
-      }
-    }, 5000);
+    pollParticipants();
   }
 
   function stopParticipantPolling() {
     if (participantPollTimer) {
-      clearInterval(participantPollTimer);
+      clearTimeout(participantPollTimer);
       participantPollTimer = null;
     }
   }
@@ -643,7 +647,7 @@ void initTheme().catch((err) => console.error(err));
     console.log(`${COPILOT_PREFIX} Disconnecting observers and clearing active timers.`);
 
     if (participantPollTimer) {
-      clearInterval(participantPollTimer);
+      clearTimeout(participantPollTimer);
       participantPollTimer = null;
     }
 

--- a/src/offscreen.ts
+++ b/src/offscreen.ts
@@ -22,7 +22,7 @@ let recorderStream: MediaStream | null = null;
 let mediaRecorder: MediaRecorder | null = null;
 let audioContext: AudioContext | null = null;
 let analyserNode: AnalyserNode | null = null;
-let vadTimer: ReturnType<typeof setInterval> | null = null;
+let vadTimer: ReturnType<typeof setTimeout> | null = null;
 let waveformTimer: ReturnType<typeof setInterval> | null = null;
 let audioSources: MediaStreamAudioSourceNode[] = [];
 
@@ -34,7 +34,7 @@ const SILENCE_FLUSH_TICKS = Math.ceil(SILENCE_FLUSH_MS / VAD_SAMPLE_MS);
 let rmsThreshold = 0.012;
 
 let isFlushInProgress = false;
-let isVadBusy = false;
+
 let silenceTicks = 0;
 let bufferStartTime = 0;
 let recorderMimeType = "";
@@ -315,7 +315,6 @@ async function cleanupResources() {
   audioSources = [];
   pendingChunks = [];
   isStopping = false;
-  isVadBusy = false;
   silenceTicks = 0;
   speechActive = false;
   vadTickCounter = 0;
@@ -459,6 +458,55 @@ function createRecorder(): MediaRecorder {
   return recorder;
 }
 
+async function vadLoop() {
+  if (isStopping || isDrainingQueue) {
+    vadTimer = null;
+    return;
+  }
+
+  vadTickCounter += 1;
+  const overflowReached = Date.now() - bufferStartTime >= MAX_BUFFER_MS;
+  const runAnalysis = shouldRunVadAnalysis(speechActive, vadTickCounter);
+
+  if (!runAnalysis && !overflowReached) {
+    vadTimer = setTimeout(vadLoop, VAD_SAMPLE_MS);
+    return;
+  }
+
+  try {
+    let naturalPause = false;
+    let rms = -1;
+
+    if (runAnalysis) {
+      rms = getCurrentRms();
+      voiceActivity.observe(rms);
+      speechActive = rms >= rmsThreshold;
+      if (speechActive) {
+        silenceTicks = 0;
+      } else {
+        silenceTicks++;
+      }
+      naturalPause = silenceTicks >= SILENCE_FLUSH_TICKS;
+    }
+
+    if (naturalPause || overflowReached) {
+      const reason = naturalPause ? "silence-pause" : "overflow-cap";
+      relay(
+        `flush triggered — reason=${reason} rms=${rms >= 0 ? rms.toFixed(4) : "n/a"} silenceTicks=${silenceTicks}`,
+      );
+      silenceTicks = 0;
+      bufferStartTime = Date.now();
+      await flushAudioChunk(overflowReached && !naturalPause);
+    }
+  } catch (err) {
+    console.error("[LateMeet][offscreen] VAD loop error:", err);
+  } finally {
+    if (!isStopping) {
+      vadTimer = setTimeout(vadLoop, VAD_SAMPLE_MS);
+    }
+  }
+}
+
 async function startCapture(
   streamId: string,
   _tabId: number,
@@ -492,7 +540,7 @@ async function startCapture(
 
       try {
         if (vadTimer) {
-          clearInterval(vadTimer);
+          clearTimeout(vadTimer);
           vadTimer = null;
         }
 
@@ -574,51 +622,7 @@ async function startCapture(
   vadTickCounter = 0;
   bufferStartTime = Date.now();
 
-  vadTimer = setInterval(async () => {
-    if (isStopping || isVadBusy || isDrainingQueue) return;
-
-    vadTickCounter += 1;
-    const overflowReached = Date.now() - bufferStartTime >= MAX_BUFFER_MS;
-    const runAnalysis = shouldRunVadAnalysis(speechActive, vadTickCounter);
-
-    // While speech is sustained, skip the analyser read on alternate ticks to
-    // cut CPU (#632). The overflow flush is time-based, so it still runs.
-    if (!runAnalysis && !overflowReached) return;
-
-    isVadBusy = true;
-
-    try {
-      let naturalPause = false;
-      let rms = -1;
-
-      if (runAnalysis) {
-        rms = getCurrentRms();
-        voiceActivity.observe(rms);
-        speechActive = rms >= rmsThreshold;
-        if (speechActive) {
-          silenceTicks = 0;
-        } else {
-          silenceTicks++;
-        }
-        naturalPause = silenceTicks >= SILENCE_FLUSH_TICKS;
-      }
-
-      if (naturalPause || overflowReached) {
-        const reason = naturalPause ? "silence-pause" : "overflow-cap";
-        relay(
-          `flush triggered — reason=${reason} rms=${rms >= 0 ? rms.toFixed(4) : "n/a"} silenceTicks=${silenceTicks}`,
-        );
-        silenceTicks = 0;
-        bufferStartTime = Date.now();
-        // Force-flush on overflow so silent audio doesn't block the buffer cap.
-        await flushAudioChunk(overflowReached && !naturalPause);
-      }
-    } catch (err) {
-      console.error("[LateMeet][offscreen] VAD loop error:", err);
-    } finally {
-      isVadBusy = false;
-    }
-  }, VAD_SAMPLE_MS);
+  vadTimer = setTimeout(vadLoop, VAD_SAMPLE_MS);
 
   relay(`capture started — mic=${Boolean(microphoneStream)} rmsThreshold=${rmsThreshold}`);
 
@@ -637,7 +641,7 @@ async function stopCapture() {
 
   try {
     if (vadTimer) {
-      clearInterval(vadTimer);
+      clearTimeout(vadTimer);
       vadTimer = null;
     }
 


### PR DESCRIPTION
﻿Reliability fix: Replace async setInterval with recursive setTimeout in VAD loop and participant polling (#876)

Problem:
setInterval with async callbacks was used in two critical paths:
1. VAD analysis loop in src/offscreen.ts
2. Participant polling loop in src/content.ts

This caused:
- Unhandled promise rejections when async callbacks threw errors
- Overlapping async executions when callback duration exceeded the interval
- Timer drift accumulation over long meetings
- Silent failure mode in participant polling

Changes:

offscreen.ts:
- Extracted VAD loop logic into dedicated async vadLoop() function
- Replaced setInterval with recursive setTimeout via vadTimer
- Removed unused isVadBusy flag (no longer needed - recursive setTimeout naturally serializes)
- Added proper stop check before scheduling next tick
- Removed early-return pattern on isVadBusy (no longer applicable)

content.ts:
- Extracted participant polling into async pollParticipants() function
- Replaced setInterval with recursive setTimeout via participantPollTimer
- Added proper error logging with console.debug instead of empty catch
- Added finally block to ensure next poll is always scheduled
- Changed clearInterval to clearTimeout in all cleanup paths

Benefits:
- Async work completes before next tick starts (no overlap)
- Errors are properly caught and logged
- Timer drift is eliminated
- Cleanup is straightforward (just clearTimeout)
- Production debuggability improved
