### PR TITLE
fix: resolved signal re-use on retry and storage null-set leak

### DIFF
--- a/src/popup.ts
+++ b/src/popup.ts
@@ -78,11 +78,11 @@ document.addEventListener("DOMContentLoaded", async () => {
   const config = await getApiCredentials();
 
   if (!config.openai_api_key && !config.elevenlabs_api_key) {
-    setupView.style.display = "block";
-    mainView.style.display = "none";
+    if (setupView) setupView.style.display = "block";
+    if (mainView) mainView.style.display = "none";
   } else {
-    setupView.style.display = "none";
-    mainView.style.display = "block";
+    if (setupView) setupView.style.display = "none";
+    if (mainView) mainView.style.display = "block";
   }
 
   void maybeStartPopupTour();
@@ -141,15 +141,15 @@ document.addEventListener("DOMContentLoaded", async () => {
     // Users can configure ElevenLabs in the options page.
 
     await saveApiCredentials({ openai_api_key: apiKey });
-    setupView.style.display = "none";
-    mainView.style.display = "block";
+    if (setupView) setupView.style.display = "none";
+    if (mainView) mainView.style.display = "block";
     void maybeStartPopupTour();
   });
 
   // ——— Toggle API Key Visibility ———
   document.getElementById("toggle-key")?.addEventListener("click", () => {
-    const input = document.getElementById("api-key-input") as HTMLInputElement;
-    input.type = input.type === "password" ? "text" : "password";
+    const input = document.getElementById("api-key-input") as HTMLInputElement | null;
+    if (input) input.type = input.type === "password" ? "text" : "password";
   });
 
   // ——— Settings ———

--- a/src/sessionStorage.ts
+++ b/src/sessionStorage.ts
@@ -236,7 +236,7 @@ export async function persistPendingMeetingSession(storage: StorageArea): Promis
   }
 
   const session = await persistMeetingSession(storage, pendingSession);
-  await storage.set({ [PENDING_SESSION_KEY]: null });
+  await storage.remove(PENDING_SESSION_KEY);
 
   return session;
 }
@@ -294,7 +294,7 @@ export async function persistMeetingSession(
  * @param storage - The storage area to modify.
  */
 export async function discardPendingMeetingSession(storage: StorageArea): Promise<void> {
-  await storage.set({ [PENDING_SESSION_KEY]: null });
+  await storage.remove(PENDING_SESSION_KEY);
 }
 
 /**

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -46,7 +46,8 @@ export async function fetchWithRetry(
     if (retries <= 0) throw error;
     console.warn(`Retrying request to ${url}... (${retries} attempts left)`);
     await new Promise((resolve) => setTimeout(resolve, backoff));
-    return fetchWithRetry(url, options, retries - 1, backoff * 2);
+    const { signal: _signal, ...restOptions } = options;
+    return fetchWithRetry(url, restOptions, retries - 1, backoff * 2);
   }
 }
 


### PR DESCRIPTION
## Bug Fixes

### 1. fetchWithRetry reuses aborted AbortController signal on retries (`src/utils/api.ts`)
When a request is aborted (e.g. timeout via AbortController), `fetchWithRetry` passes the same `options` object — including the already-aborted `signal` — to each retry attempt. This causes all subsequent fetch calls to immediately reject with an `AbortError`, rendering the retry mechanism completely ineffective.
**Fix:** Destructure and omit `signal` from options on retry so each attempt gets a fresh signal-less request.

### 2. `discardPendingMeetingSession` and `persistPendingMeetingSession` leak storage (`src/sessionStorage.ts`)
Both functions use `storage.set({ [PENDING_SESSION_KEY]: null })` which stores a `null` value in Chrome storage instead of removing the key. This leaves phantom null entries that waste storage quota and can interfere with state checks.
**Fix:** Use `storage.remove(PENDING_SESSION_KEY)` to properly clean up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup stability when expected interface elements are unavailable.
  * Fixed API key visibility toggling when the input field is missing.
  * Pending meeting sessions are now properly removed after completion or dismissal.
  * Improved retry handling for interrupted network requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->