### PR TITLE
docs: fix Table of Contents order to match actual section order

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,12 @@
 - [Documentation Hub](#documentation-hub)
 - [Known Issues](#known-issues)
 - [Extension Shortcuts](#extension-shortcuts)
-- [Global Shortcuts](#global-shortcuts)
 - [Security & Privacy](#security--privacy)
 - [FAQ](#faq)
 - [Community](#community)
 - [License](#license)
 - [Troubleshooting](#troubleshooting)
+- [Global Shortcuts](#global-shortcuts)
 
 ## 🌟 The Problem
 


### PR DESCRIPTION
## Description
Fixed the Table of Contents order in README.md to match the actual document structure — "Global Shortcuts" was listed early in the TOC (before "Security & Privacy"), but it's actually the very last section in the file, appearing after "Troubleshooting."

Fixes #None (just a documentation quick fix)

## Type of Change
- [x] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reordered the README table of contents for improved navigation.
  * Updated the placement of the Global Shortcuts entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->